### PR TITLE
[codex] Add core and infrastructure project skeletons

### DIFF
--- a/Conductor.slnx
+++ b/Conductor.slnx
@@ -1,0 +1,15 @@
+<Solution>
+  <Folder Name="/src/">
+    <Project Path="src/Conductor.Core/Conductor.Core.csproj" />
+    <Project Path="src/Conductor.Infrastructure.GitHub/Conductor.Infrastructure.GitHub.csproj" />
+    <Project Path="src/Conductor.Infrastructure.Notifications/Conductor.Infrastructure.Notifications.csproj" />
+    <Project Path="src/Conductor.Infrastructure.Reporting/Conductor.Infrastructure.Reporting.csproj" />
+    <Project Path="src/Conductor.Infrastructure.Runners.Docker/Conductor.Infrastructure.Runners.Docker.csproj" />
+    <Project Path="src/Conductor.Infrastructure.Runners.Local/Conductor.Infrastructure.Runners.Local.csproj" />
+    <Project Path="src/Conductor.Infrastructure.Secrets/Conductor.Infrastructure.Secrets.csproj" />
+    <Project Path="src/Conductor.Infrastructure.Symphony/Conductor.Infrastructure.Symphony.csproj" />
+  </Folder>
+  <Folder Name="/tests/">
+    <Project Path="tests/Conductor.Core.Tests/Conductor.Core.Tests.csproj" />
+  </Folder>
+</Solution>

--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
-# AgenticAITemplate
-Template for Agentic AI Development
+# Conductor
+
+Conductor is the fleet control layer above Symphony. It is being built as a .NET 10 modular monolith with a thin host, a core domain/application layer, and infrastructure adapters for external systems.
+
+## Solution Layout
+
+- `Conductor.slnx` is the .NET solution entry point.
+- `src/Conductor.Core` contains domain types, value objects, and infrastructure-facing contracts.
+- `src/Conductor.Infrastructure.*` projects contain adapter boundaries for GitHub, Symphony HTTP, runners, secrets, reporting, and notifications.
+- `tests/Conductor.Core.Tests` contains focused validation for the initial core and infrastructure skeleton.
+
+The SQLite persistence project and Blazor host are tracked separately in Sprint 0 issues.
+
+## Build And Test
+
+```powershell
+dotnet restore Conductor.slnx
+dotnet build Conductor.slnx --no-restore --warnaserror
+dotnet test Conductor.slnx --no-build
+```

--- a/src/Conductor.Core/Abstractions/GitHub/IGitHubRepositoryClient.cs
+++ b/src/Conductor.Core/Abstractions/GitHub/IGitHubRepositoryClient.cs
@@ -1,0 +1,16 @@
+namespace Conductor.Core.Abstractions.GitHub;
+
+public interface IGitHubRepositoryClient
+{
+    Task<IReadOnlyList<GitHubRepositorySummary>> SearchRepositoriesAsync(
+        string query,
+        CancellationToken cancellationToken);
+}
+
+public sealed record GitHubRepositorySummary(
+    string Owner,
+    string Name,
+    string DefaultBranch,
+    Uri CloneUrl,
+    Uri WebUrl,
+    bool IsArchived);

--- a/src/Conductor.Core/Abstractions/Notifications/INotificationSender.cs
+++ b/src/Conductor.Core/Abstractions/Notifications/INotificationSender.cs
@@ -1,0 +1,14 @@
+namespace Conductor.Core.Abstractions.Notifications;
+
+public interface INotificationSender
+{
+    string Channel { get; }
+
+    Task SendAsync(NotificationMessage message, CancellationToken cancellationToken);
+}
+
+public sealed record NotificationMessage(
+    string Subject,
+    string Body,
+    string Severity,
+    DateTimeOffset CreatedAtUtc);

--- a/src/Conductor.Core/Abstractions/Reporting/IReportRenderer.cs
+++ b/src/Conductor.Core/Abstractions/Reporting/IReportRenderer.cs
@@ -1,0 +1,22 @@
+using Conductor.Core.Domain.Ids;
+
+namespace Conductor.Core.Abstractions.Reporting;
+
+public interface IReportRenderer
+{
+    string Format { get; }
+
+    Task<RenderedReport> RenderAsync(ReportRequest request, CancellationToken cancellationToken);
+}
+
+public sealed record ReportRequest(
+    ReportId ReportId,
+    string Title,
+    string MarkdownContent,
+    DateTimeOffset GeneratedAtUtc);
+
+public sealed record RenderedReport(
+    ReportId ReportId,
+    string Format,
+    string Content,
+    string ContentType);

--- a/src/Conductor.Core/Abstractions/Runners/ISymphonyRunner.cs
+++ b/src/Conductor.Core/Abstractions/Runners/ISymphonyRunner.cs
@@ -1,0 +1,61 @@
+using Conductor.Core.Abstractions.Releases;
+using Conductor.Core.Domain;
+using Conductor.Core.Domain.Ids;
+
+namespace Conductor.Core.Abstractions.Runners;
+
+public interface ISymphonyRunner
+{
+    ExecutionMode Mode { get; }
+
+    Task<ProvisionedInstance> ProvisionAsync(
+        SymphonyInstanceSpec spec,
+        CancellationToken cancellationToken);
+
+    Task StartAsync(SymphonyInstanceId instanceId, CancellationToken cancellationToken);
+
+    Task StopAsync(SymphonyInstanceId instanceId, CancellationToken cancellationToken);
+
+    Task RestartAsync(SymphonyInstanceId instanceId, CancellationToken cancellationToken);
+
+    Task<InstanceHealthProbe> GetHealthAsync(
+        SymphonyInstanceId instanceId,
+        CancellationToken cancellationToken);
+
+    Task<InstanceLogs> GetLogsAsync(
+        SymphonyInstanceId instanceId,
+        LogQuery query,
+        CancellationToken cancellationToken);
+
+    Task DestroyAsync(
+        SymphonyInstanceId instanceId,
+        DestroyInstanceOptions options,
+        CancellationToken cancellationToken);
+}
+
+public sealed record SymphonyInstanceSpec(
+    SymphonyInstanceId InstanceId,
+    RepositoryId RepositoryId,
+    string DisplayName,
+    Uri BaseUrl,
+    ReleaseSelector ReleaseSelector,
+    int Port);
+
+public sealed record ProvisionedInstance(
+    SymphonyInstanceId InstanceId,
+    Uri BaseUrl,
+    InstanceLifecycleStatus LifecycleStatus);
+
+public sealed record InstanceHealthProbe(
+    InstanceHealthStatus Status,
+    DateTimeOffset ObservedAtUtc,
+    string? Message);
+
+public sealed record InstanceLogs(
+    string StandardOutput,
+    string StandardError,
+    DateTimeOffset CapturedAtUtc);
+
+public sealed record LogQuery(DateTimeOffset? SinceUtc = null, int? TailLines = null);
+
+public sealed record DestroyInstanceOptions(bool DeleteData);

--- a/src/Conductor.Core/Abstractions/Secrets/ISecretStore.cs
+++ b/src/Conductor.Core/Abstractions/Secrets/ISecretStore.cs
@@ -1,0 +1,66 @@
+using Conductor.Core.Domain;
+using Conductor.Core.Domain.Ids;
+
+namespace Conductor.Core.Abstractions.Secrets;
+
+public interface ISecretStore
+{
+    Task<SecretDescriptor> CreateAsync(CreateSecretRequest request, CancellationToken cancellationToken);
+
+    Task RotateAsync(
+        SecretId secretId,
+        RotateSecretRequest request,
+        CancellationToken cancellationToken);
+
+    Task<ResolvedSecret> ResolveAsync(
+        SecretReference reference,
+        CancellationToken cancellationToken);
+
+    Task<IReadOnlyList<SecretDescriptor>> ListAsync(
+        SecretQuery query,
+        CancellationToken cancellationToken);
+
+    Task DeleteAsync(SecretId secretId, CancellationToken cancellationToken);
+}
+
+public enum SecretScopeType
+{
+    Global,
+    Project,
+    Repository,
+    SymphonyInstance,
+}
+
+public enum SecretType
+{
+    GitHubToken,
+    OpenAiApiKey,
+    CodexHome,
+    Other,
+}
+
+public sealed record CreateSecretRequest(
+    string Name,
+    SecretType SecretType,
+    SecretScopeType ScopeType,
+    string? ScopeId,
+    string Value);
+
+public sealed record RotateSecretRequest(string Value);
+
+public sealed record SecretReference(
+    SecretId SecretId,
+    CredentialInheritanceMode InheritanceMode);
+
+public sealed record ResolvedSecret(SecretId SecretId, string Value);
+
+public sealed record SecretQuery(SecretType? SecretType = null, SecretScopeType? ScopeType = null);
+
+public sealed record SecretDescriptor(
+    SecretId Id,
+    string Name,
+    SecretType SecretType,
+    SecretScopeType ScopeType,
+    string? ScopeId,
+    DateTimeOffset CreatedAtUtc,
+    DateTimeOffset? RotatedAtUtc);

--- a/src/Conductor.Core/Abstractions/Symphony/ISymphonyApiClient.cs
+++ b/src/Conductor.Core/Abstractions/Symphony/ISymphonyApiClient.cs
@@ -1,0 +1,42 @@
+using Conductor.Core.Domain;
+
+namespace Conductor.Core.Abstractions.Symphony;
+
+public interface ISymphonyApiClient
+{
+    Task<SymphonyHealthResponse> GetHealthAsync(Uri baseUri, CancellationToken cancellationToken);
+
+    Task<SymphonyRuntimeResponse> GetRuntimeAsync(Uri baseUri, CancellationToken cancellationToken);
+
+    Task<SymphonyWorkflowDocument> GetWorkflowAsync(Uri baseUri, CancellationToken cancellationToken);
+
+    Task<SymphonyWorkflowDocument> SaveWorkflowAsync(
+        Uri baseUri,
+        SymphonyWorkflowDocument document,
+        CancellationToken cancellationToken);
+
+    Task<SymphonyStateResponse> GetStateAsync(Uri baseUri, CancellationToken cancellationToken);
+
+    Task<SymphonyIssueResponse?> GetIssueAsync(
+        Uri baseUri,
+        string issueIdentifier,
+        CancellationToken cancellationToken);
+
+    Task<SymphonyRefreshResponse> RequestRefreshAsync(Uri baseUri, CancellationToken cancellationToken);
+}
+
+public sealed record SymphonyHealthResponse(
+    InstanceHealthStatus Status,
+    int? HttpStatusCode,
+    TimeSpan Latency,
+    string RawJson);
+
+public sealed record SymphonyRuntimeResponse(string RawJson);
+
+public sealed record SymphonyWorkflowDocument(string Source, string? ETag);
+
+public sealed record SymphonyStateResponse(string RawJson);
+
+public sealed record SymphonyIssueResponse(string IssueIdentifier, string RawJson);
+
+public sealed record SymphonyRefreshResponse(bool Accepted, string RawJson);

--- a/src/Conductor.Core/Application/InfrastructureModule.cs
+++ b/src/Conductor.Core/Application/InfrastructureModule.cs
@@ -1,0 +1,3 @@
+namespace Conductor.Core.Application;
+
+public sealed record InfrastructureModule(string Name, string Responsibility);

--- a/src/Conductor.Core/Common/Guard.cs
+++ b/src/Conductor.Core/Common/Guard.cs
@@ -1,0 +1,26 @@
+namespace Conductor.Core.Common;
+
+internal static class Guard
+{
+    public static string NotWhiteSpace(string value, string parameterName)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new ArgumentException("A value is required.", parameterName);
+        }
+
+        return value.Trim();
+    }
+
+    public static Uri AbsoluteUri(Uri value, string parameterName)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+
+        if (!value.IsAbsoluteUri)
+        {
+            throw new ArgumentException("An absolute URI is required.", parameterName);
+        }
+
+        return value;
+    }
+}

--- a/src/Conductor.Core/Conductor.Core.csproj
+++ b/src/Conductor.Core/Conductor.Core.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/Conductor.Core/Domain/ConductorEnums.cs
+++ b/src/Conductor.Core/Domain/ConductorEnums.cs
@@ -1,0 +1,47 @@
+namespace Conductor.Core.Domain;
+
+public enum CredentialInheritanceMode
+{
+    InheritDefault,
+    SpecificSecret,
+    None,
+}
+
+public enum ExecutionMode
+{
+    LocalProcess,
+    Docker,
+    AzureContainer,
+}
+
+public enum InstanceHealthStatus
+{
+    Unknown,
+    Healthy,
+    Warning,
+    Critical,
+    Offline,
+}
+
+public enum InstanceLifecycleStatus
+{
+    NotProvisioned,
+    Provisioned,
+    Starting,
+    Running,
+    Stopping,
+    Stopped,
+    Failed,
+    Destroyed,
+}
+
+public enum ProjectStatus
+{
+    Active,
+    Archived,
+}
+
+public enum RepositoryProvider
+{
+    GitHub,
+}

--- a/src/Conductor.Core/Domain/Ids/EntityIds.cs
+++ b/src/Conductor.Core/Domain/Ids/EntityIds.cs
@@ -1,0 +1,57 @@
+namespace Conductor.Core.Domain.Ids;
+
+public readonly record struct BackgroundOperationId(Guid Value)
+{
+    public static BackgroundOperationId New() => new(Guid.NewGuid());
+
+    public override string ToString() => Value.ToString("D");
+}
+
+public readonly record struct ProjectId(Guid Value)
+{
+    public static ProjectId New() => new(Guid.NewGuid());
+
+    public override string ToString() => Value.ToString("D");
+}
+
+public readonly record struct ReportId(Guid Value)
+{
+    public static ReportId New() => new(Guid.NewGuid());
+
+    public override string ToString() => Value.ToString("D");
+}
+
+public readonly record struct RepositoryId(Guid Value)
+{
+    public static RepositoryId New() => new(Guid.NewGuid());
+
+    public override string ToString() => Value.ToString("D");
+}
+
+public readonly record struct RunId(Guid Value)
+{
+    public static RunId New() => new(Guid.NewGuid());
+
+    public override string ToString() => Value.ToString("D");
+}
+
+public readonly record struct SecretId(Guid Value)
+{
+    public static SecretId New() => new(Guid.NewGuid());
+
+    public override string ToString() => Value.ToString("D");
+}
+
+public readonly record struct SymphonyInstanceId(Guid Value)
+{
+    public static SymphonyInstanceId New() => new(Guid.NewGuid());
+
+    public override string ToString() => Value.ToString("D");
+}
+
+public readonly record struct WorkflowProfileId(Guid Value)
+{
+    public static WorkflowProfileId New() => new(Guid.NewGuid());
+
+    public override string ToString() => Value.ToString("D");
+}

--- a/src/Conductor.Core/Domain/Projects/Project.cs
+++ b/src/Conductor.Core/Domain/Projects/Project.cs
@@ -1,0 +1,41 @@
+using Conductor.Core.Common;
+using Conductor.Core.Domain.Ids;
+
+namespace Conductor.Core.Domain.Projects;
+
+public sealed class Project
+{
+    public Project(
+        ProjectId id,
+        string name,
+        string ownerName,
+        ProjectStatus status,
+        DateTimeOffset createdAtUtc,
+        DateTimeOffset updatedAtUtc)
+    {
+        Id = id;
+        Name = Guard.NotWhiteSpace(name, nameof(name));
+        OwnerName = Guard.NotWhiteSpace(ownerName, nameof(ownerName));
+        Status = status;
+        CreatedAtUtc = createdAtUtc;
+        UpdatedAtUtc = updatedAtUtc;
+    }
+
+    public ProjectId Id { get; }
+
+    public string Name { get; }
+
+    public string OwnerName { get; }
+
+    public ProjectStatus Status { get; private set; }
+
+    public DateTimeOffset CreatedAtUtc { get; }
+
+    public DateTimeOffset UpdatedAtUtc { get; private set; }
+
+    public void Archive(DateTimeOffset archivedAtUtc)
+    {
+        Status = ProjectStatus.Archived;
+        UpdatedAtUtc = archivedAtUtc;
+    }
+}

--- a/src/Conductor.Core/Domain/Repositories/Repository.cs
+++ b/src/Conductor.Core/Domain/Repositories/Repository.cs
@@ -1,0 +1,49 @@
+using Conductor.Core.Common;
+using Conductor.Core.Domain.Ids;
+
+namespace Conductor.Core.Domain.Repositories;
+
+public sealed class Repository
+{
+    public Repository(
+        RepositoryId id,
+        RepositoryProvider provider,
+        string owner,
+        string name,
+        string defaultBranch,
+        Uri cloneUrl,
+        Uri webUrl,
+        bool isArchived,
+        ProjectId? projectId)
+    {
+        Id = id;
+        Provider = provider;
+        Owner = Guard.NotWhiteSpace(owner, nameof(owner));
+        Name = Guard.NotWhiteSpace(name, nameof(name));
+        DefaultBranch = Guard.NotWhiteSpace(defaultBranch, nameof(defaultBranch));
+        CloneUrl = Guard.AbsoluteUri(cloneUrl, nameof(cloneUrl));
+        WebUrl = Guard.AbsoluteUri(webUrl, nameof(webUrl));
+        IsArchived = isArchived;
+        ProjectId = projectId;
+    }
+
+    public RepositoryId Id { get; }
+
+    public RepositoryProvider Provider { get; }
+
+    public string Owner { get; }
+
+    public string Name { get; }
+
+    public string FullName => $"{Owner}/{Name}";
+
+    public string DefaultBranch { get; }
+
+    public Uri CloneUrl { get; }
+
+    public Uri WebUrl { get; }
+
+    public bool IsArchived { get; }
+
+    public ProjectId? ProjectId { get; }
+}

--- a/src/Conductor.Core/Domain/Snapshots/InstanceSnapshot.cs
+++ b/src/Conductor.Core/Domain/Snapshots/InstanceSnapshot.cs
@@ -1,0 +1,11 @@
+using Conductor.Core.Domain.Ids;
+
+namespace Conductor.Core.Domain.Snapshots;
+
+public sealed record InstanceSnapshot(
+    SymphonyInstanceId SymphonyInstanceId,
+    DateTimeOffset CapturedAtUtc,
+    InstanceHealthStatus HealthStatus,
+    string? HealthJson,
+    string? RuntimeJson,
+    string? StateJson);

--- a/src/Conductor.Core/Domain/Symphony/SymphonyInstance.cs
+++ b/src/Conductor.Core/Domain/Symphony/SymphonyInstance.cs
@@ -1,0 +1,59 @@
+using Conductor.Core.Common;
+using Conductor.Core.Domain.Ids;
+
+namespace Conductor.Core.Domain.Symphony;
+
+public sealed class SymphonyInstance
+{
+    public SymphonyInstance(
+        SymphonyInstanceId id,
+        RepositoryId repositoryId,
+        string displayName,
+        ExecutionMode executionMode,
+        Uri baseUrl,
+        InstanceLifecycleStatus lifecycleStatus = InstanceLifecycleStatus.NotProvisioned,
+        InstanceHealthStatus healthStatus = InstanceHealthStatus.Unknown)
+    {
+        Id = id;
+        RepositoryId = repositoryId;
+        DisplayName = Guard.NotWhiteSpace(displayName, nameof(displayName));
+        ExecutionMode = executionMode;
+        BaseUrl = Guard.AbsoluteUri(baseUrl, nameof(baseUrl));
+        LifecycleStatus = lifecycleStatus;
+        HealthStatus = healthStatus;
+    }
+
+    public SymphonyInstanceId Id { get; }
+
+    public RepositoryId RepositoryId { get; }
+
+    public string DisplayName { get; }
+
+    public ExecutionMode ExecutionMode { get; }
+
+    public Uri BaseUrl { get; }
+
+    public InstanceLifecycleStatus LifecycleStatus { get; private set; }
+
+    public InstanceHealthStatus HealthStatus { get; private set; }
+
+    public DateTimeOffset? LastHealthCheckAtUtc { get; private set; }
+
+    public DateTimeOffset? LastSeenAtUtc { get; private set; }
+
+    public void MarkLifecycle(InstanceLifecycleStatus lifecycleStatus)
+    {
+        LifecycleStatus = lifecycleStatus;
+    }
+
+    public void RecordHealth(InstanceHealthStatus healthStatus, DateTimeOffset observedAtUtc)
+    {
+        HealthStatus = healthStatus;
+        LastHealthCheckAtUtc = observedAtUtc;
+
+        if (healthStatus is not InstanceHealthStatus.Offline and not InstanceHealthStatus.Unknown)
+        {
+            LastSeenAtUtc = observedAtUtc;
+        }
+    }
+}

--- a/src/Conductor.Core/Domain/SymphonyReleases/SymphonyReleaseArtifact.cs
+++ b/src/Conductor.Core/Domain/SymphonyReleases/SymphonyReleaseArtifact.cs
@@ -1,0 +1,30 @@
+using Conductor.Core.Common;
+
+namespace Conductor.Core.Domain.SymphonyReleases;
+
+public sealed class SymphonyReleaseArtifact
+{
+    public SymphonyReleaseArtifact(
+        string releaseTag,
+        string assetName,
+        Uri sourceUrl,
+        DateTimeOffset downloadedAtUtc,
+        string? checksum)
+    {
+        ReleaseTag = Guard.NotWhiteSpace(releaseTag, nameof(releaseTag));
+        AssetName = Guard.NotWhiteSpace(assetName, nameof(assetName));
+        SourceUrl = Guard.AbsoluteUri(sourceUrl, nameof(sourceUrl));
+        DownloadedAtUtc = downloadedAtUtc;
+        Checksum = string.IsNullOrWhiteSpace(checksum) ? null : checksum.Trim();
+    }
+
+    public string ReleaseTag { get; }
+
+    public string AssetName { get; }
+
+    public Uri SourceUrl { get; }
+
+    public DateTimeOffset DownloadedAtUtc { get; }
+
+    public string? Checksum { get; }
+}

--- a/src/Conductor.Core/Domain/Workflows/WorkflowProfile.cs
+++ b/src/Conductor.Core/Domain/Workflows/WorkflowProfile.cs
@@ -1,0 +1,27 @@
+using Conductor.Core.Common;
+using Conductor.Core.Domain.Ids;
+
+namespace Conductor.Core.Domain.Workflows;
+
+public sealed class WorkflowProfile
+{
+    public WorkflowProfile(
+        WorkflowProfileId id,
+        string name,
+        string workflowSource,
+        DateTimeOffset createdAtUtc)
+    {
+        Id = id;
+        Name = Guard.NotWhiteSpace(name, nameof(name));
+        WorkflowSource = Guard.NotWhiteSpace(workflowSource, nameof(workflowSource));
+        CreatedAtUtc = createdAtUtc;
+    }
+
+    public WorkflowProfileId Id { get; }
+
+    public string Name { get; }
+
+    public string WorkflowSource { get; }
+
+    public DateTimeOffset CreatedAtUtc { get; }
+}

--- a/src/Conductor.Infrastructure.GitHub/Conductor.Infrastructure.GitHub.csproj
+++ b/src/Conductor.Infrastructure.GitHub/Conductor.Infrastructure.GitHub.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\Conductor.Core\Conductor.Core.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/Conductor.Infrastructure.GitHub/GitHubInfrastructureModule.cs
+++ b/src/Conductor.Infrastructure.GitHub/GitHubInfrastructureModule.cs
@@ -1,0 +1,10 @@
+using Conductor.Core.Application;
+
+namespace Conductor.Infrastructure.GitHub;
+
+public static class GitHubInfrastructureModule
+{
+    public static InfrastructureModule Descriptor { get; } = new(
+        "Conductor.Infrastructure.GitHub",
+        "GitHub repository discovery, metadata, and Symphony release resolution adapters.");
+}

--- a/src/Conductor.Infrastructure.Notifications/Conductor.Infrastructure.Notifications.csproj
+++ b/src/Conductor.Infrastructure.Notifications/Conductor.Infrastructure.Notifications.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\Conductor.Core\Conductor.Core.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/Conductor.Infrastructure.Notifications/NotificationsInfrastructureModule.cs
+++ b/src/Conductor.Infrastructure.Notifications/NotificationsInfrastructureModule.cs
@@ -1,0 +1,10 @@
+using Conductor.Core.Application;
+
+namespace Conductor.Infrastructure.Notifications;
+
+public static class NotificationsInfrastructureModule
+{
+    public static InfrastructureModule Descriptor { get; } = new(
+        "Conductor.Infrastructure.Notifications",
+        "Email, Teams, Slack, and GitHub comment notification adapters.");
+}

--- a/src/Conductor.Infrastructure.Reporting/Conductor.Infrastructure.Reporting.csproj
+++ b/src/Conductor.Infrastructure.Reporting/Conductor.Infrastructure.Reporting.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\Conductor.Core\Conductor.Core.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/Conductor.Infrastructure.Reporting/ReportingInfrastructureModule.cs
+++ b/src/Conductor.Infrastructure.Reporting/ReportingInfrastructureModule.cs
@@ -1,0 +1,10 @@
+using Conductor.Core.Application;
+
+namespace Conductor.Infrastructure.Reporting;
+
+public static class ReportingInfrastructureModule
+{
+    public static InfrastructureModule Descriptor { get; } = new(
+        "Conductor.Infrastructure.Reporting",
+        "Markdown, HTML, and future PDF report rendering adapters.");
+}

--- a/src/Conductor.Infrastructure.Runners.Docker/Conductor.Infrastructure.Runners.Docker.csproj
+++ b/src/Conductor.Infrastructure.Runners.Docker/Conductor.Infrastructure.Runners.Docker.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\Conductor.Core\Conductor.Core.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/Conductor.Infrastructure.Runners.Docker/DockerRunnerInfrastructureModule.cs
+++ b/src/Conductor.Infrastructure.Runners.Docker/DockerRunnerInfrastructureModule.cs
@@ -1,0 +1,10 @@
+using Conductor.Core.Application;
+
+namespace Conductor.Infrastructure.Runners.Docker;
+
+public static class DockerRunnerInfrastructureModule
+{
+    public static InfrastructureModule Descriptor { get; } = new(
+        "Conductor.Infrastructure.Runners.Docker",
+        "Docker-backed Symphony lifecycle, log, and volume management adapters.");
+}

--- a/src/Conductor.Infrastructure.Runners.Local/Conductor.Infrastructure.Runners.Local.csproj
+++ b/src/Conductor.Infrastructure.Runners.Local/Conductor.Infrastructure.Runners.Local.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\Conductor.Core\Conductor.Core.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/Conductor.Infrastructure.Runners.Local/LocalRunnerInfrastructureModule.cs
+++ b/src/Conductor.Infrastructure.Runners.Local/LocalRunnerInfrastructureModule.cs
@@ -1,0 +1,10 @@
+using Conductor.Core.Application;
+
+namespace Conductor.Infrastructure.Runners.Local;
+
+public static class LocalRunnerInfrastructureModule
+{
+    public static InfrastructureModule Descriptor { get; } = new(
+        "Conductor.Infrastructure.Runners.Local",
+        "Local-process Symphony lifecycle, process, and log management adapters.");
+}

--- a/src/Conductor.Infrastructure.Secrets/Conductor.Infrastructure.Secrets.csproj
+++ b/src/Conductor.Infrastructure.Secrets/Conductor.Infrastructure.Secrets.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\Conductor.Core\Conductor.Core.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/Conductor.Infrastructure.Secrets/SecretsInfrastructureModule.cs
+++ b/src/Conductor.Infrastructure.Secrets/SecretsInfrastructureModule.cs
@@ -1,0 +1,10 @@
+using Conductor.Core.Application;
+
+namespace Conductor.Infrastructure.Secrets;
+
+public static class SecretsInfrastructureModule
+{
+    public static InfrastructureModule Descriptor { get; } = new(
+        "Conductor.Infrastructure.Secrets",
+        "Secret protection, descriptor storage, and credential resolution adapters.");
+}

--- a/src/Conductor.Infrastructure.Symphony/Conductor.Infrastructure.Symphony.csproj
+++ b/src/Conductor.Infrastructure.Symphony/Conductor.Infrastructure.Symphony.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\Conductor.Core\Conductor.Core.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/Conductor.Infrastructure.Symphony/SymphonyInfrastructureModule.cs
+++ b/src/Conductor.Infrastructure.Symphony/SymphonyInfrastructureModule.cs
@@ -1,0 +1,10 @@
+using Conductor.Core.Application;
+
+namespace Conductor.Infrastructure.Symphony;
+
+public static class SymphonyInfrastructureModule
+{
+    public static InfrastructureModule Descriptor { get; } = new(
+        "Conductor.Infrastructure.Symphony",
+        "Typed HTTP clients and contracts for Symphony runtime APIs.");
+}

--- a/tests/Conductor.Core.Tests/Conductor.Core.Tests.csproj
+++ b/tests/Conductor.Core.Tests/Conductor.Core.Tests.csproj
@@ -1,0 +1,32 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Conductor.Core\Conductor.Core.csproj" />
+    <ProjectReference Include="..\..\src\Conductor.Infrastructure.GitHub\Conductor.Infrastructure.GitHub.csproj" />
+    <ProjectReference Include="..\..\src\Conductor.Infrastructure.Symphony\Conductor.Infrastructure.Symphony.csproj" />
+    <ProjectReference Include="..\..\src\Conductor.Infrastructure.Runners.Local\Conductor.Infrastructure.Runners.Local.csproj" />
+    <ProjectReference Include="..\..\src\Conductor.Infrastructure.Runners.Docker\Conductor.Infrastructure.Runners.Docker.csproj" />
+    <ProjectReference Include="..\..\src\Conductor.Infrastructure.Secrets\Conductor.Infrastructure.Secrets.csproj" />
+    <ProjectReference Include="..\..\src\Conductor.Infrastructure.Reporting\Conductor.Infrastructure.Reporting.csproj" />
+    <ProjectReference Include="..\..\src\Conductor.Infrastructure.Notifications\Conductor.Infrastructure.Notifications.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Conductor.Core.Tests/DomainSkeletonTests.cs
+++ b/tests/Conductor.Core.Tests/DomainSkeletonTests.cs
@@ -1,0 +1,103 @@
+using Conductor.Core.Abstractions.Releases;
+using Conductor.Core.Application;
+using Conductor.Core.Domain;
+using Conductor.Core.Domain.Ids;
+using Conductor.Core.Domain.Projects;
+using Conductor.Core.Domain.Repositories;
+using Conductor.Core.Domain.Symphony;
+using Conductor.Infrastructure.GitHub;
+using Conductor.Infrastructure.Notifications;
+using Conductor.Infrastructure.Reporting;
+using Conductor.Infrastructure.Runners.Docker;
+using Conductor.Infrastructure.Runners.Local;
+using Conductor.Infrastructure.Secrets;
+using Conductor.Infrastructure.Symphony;
+
+namespace Conductor.Core.Tests;
+
+public sealed class DomainSkeletonTests
+{
+    [Fact]
+    public void Project_Trims_Names_And_Can_Be_Archived()
+    {
+        var createdAt = DateTimeOffset.Parse("2026-04-29T00:00:00Z");
+        var archivedAt = createdAt.AddHours(1);
+        var project = new Project(ProjectId.New(), "  Conductor  ", "  Platform  ", ProjectStatus.Active, createdAt, createdAt);
+
+        project.Archive(archivedAt);
+
+        Assert.Equal("Conductor", project.Name);
+        Assert.Equal("Platform", project.OwnerName);
+        Assert.Equal(ProjectStatus.Archived, project.Status);
+        Assert.Equal(archivedAt, project.UpdatedAtUtc);
+    }
+
+    [Fact]
+    public void Repository_Exposes_GitHub_FullName()
+    {
+        var repository = new Repository(
+            RepositoryId.New(),
+            RepositoryProvider.GitHub,
+            "ReleasedGroup",
+            "TheConductor",
+            "main",
+            new Uri("https://github.com/ReleasedGroup/TheConductor.git"),
+            new Uri("https://github.com/ReleasedGroup/TheConductor"),
+            isArchived: false,
+            projectId: ProjectId.New());
+
+        Assert.Equal("ReleasedGroup/TheConductor", repository.FullName);
+        Assert.False(repository.IsArchived);
+    }
+
+    [Fact]
+    public void SymphonyInstance_Tracks_Last_Health_Check_Separately_From_Last_Seen()
+    {
+        var instance = new SymphonyInstance(
+            SymphonyInstanceId.New(),
+            RepositoryId.New(),
+            "Conductor main",
+            ExecutionMode.Docker,
+            new Uri("http://localhost:8080"));
+
+        var healthyAt = DateTimeOffset.Parse("2026-04-29T00:00:00Z");
+        var offlineAt = healthyAt.AddMinutes(5);
+
+        instance.RecordHealth(InstanceHealthStatus.Healthy, healthyAt);
+        instance.RecordHealth(InstanceHealthStatus.Offline, offlineAt);
+
+        Assert.Equal(InstanceHealthStatus.Offline, instance.HealthStatus);
+        Assert.Equal(offlineAt, instance.LastHealthCheckAtUtc);
+        Assert.Equal(healthyAt, instance.LastSeenAtUtc);
+    }
+
+    [Fact]
+    public void ReleaseSelector_Latest_Has_No_Pinned_Tag()
+    {
+        var selector = ReleaseSelector.Latest;
+
+        Assert.True(selector.IsLatest);
+        Assert.Null(selector.Tag);
+    }
+
+    [Fact]
+    public void Infrastructure_Modules_Declare_Project_Boundaries()
+    {
+        InfrastructureModule[] modules =
+        [
+            GitHubInfrastructureModule.Descriptor,
+            SymphonyInfrastructureModule.Descriptor,
+            LocalRunnerInfrastructureModule.Descriptor,
+            DockerRunnerInfrastructureModule.Descriptor,
+            SecretsInfrastructureModule.Descriptor,
+            ReportingInfrastructureModule.Descriptor,
+            NotificationsInfrastructureModule.Descriptor,
+        ];
+
+        Assert.All(modules, module =>
+        {
+            Assert.StartsWith("Conductor.Infrastructure.", module.Name, StringComparison.Ordinal);
+            Assert.False(string.IsNullOrWhiteSpace(module.Responsibility));
+        });
+    }
+}


### PR DESCRIPTION
## Summary

- Creates `Conductor.slnx` with the core domain/application project and non-persistence infrastructure adapter projects.
- Adds core domain IDs, initial aggregate shapes, and infrastructure-facing interfaces for GitHub, Symphony, runners, secrets, reporting, notifications, and release resolution.
- Adds module descriptors, focused skeleton tests, and README build/test guidance.

Fixes #5

## Validation

- `dotnet restore Conductor.slnx`
- `dotnet build Conductor.slnx --no-restore --warnaserror`
- `dotnet test Conductor.slnx --no-build`
- `dotnet format Conductor.slnx --verify-no-changes`