### PR TITLE
Configure solution-wide build settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,40 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{cs,csx}]
+indent_size = 4
+
+[*.{json,md,yml,yaml,props,targets,xml}]
+indent_size = 2
+
+[*.md]
+max_line_length = off
+
+[*.cs]
+dotnet_sort_system_directives_first = true
+dotnet_separate_import_directive_groups = false
+
+dotnet_style_qualification_for_event = false:suggestion
+dotnet_style_qualification_for_field = false:suggestion
+dotnet_style_qualification_for_method = false:suggestion
+dotnet_style_qualification_for_property = false:suggestion
+
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+dotnet_style_predefined_type_for_member_access = true:suggestion
+
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+
+csharp_style_namespace_declarations = file_scoped:suggestion
+csharp_style_var_elsewhere = false:suggestion
+csharp_style_var_for_built_in_types = false:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
+csharp_prefer_braces = true:suggestion

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+* text=auto eol=lf
+
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.pdf binary

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,20 @@
+<Project>
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <AnalysisLevel>latest</AnalysisLevel>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <Deterministic>true</Deterministic>
+    <ContinuousIntegrationBuild Condition="'$(CI)' == 'true'">true</ContinuousIntegrationBuild>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <Company>ReleasedGroup</Company>
+    <Product>Conductor</Product>
+    <Authors>ReleasedGroup</Authors>
+    <RepositoryUrl>https://github.com/ReleasedGroup/TheConductor</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+  </PropertyGroup>
+</Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,25 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+  </PropertyGroup>
+
+  <ItemGroup Label="Application">
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.7" />
+  </ItemGroup>
+
+  <ItemGroup Label="Testing">
+    <PackageVersion Include="bunit" Version="2.7.2" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.0" />
+    <PackageVersion Include="FluentAssertions" Version="8.9.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageVersion Include="RichardSzalay.MockHttp" Version="7.0.0" />
+    <PackageVersion Include="Testcontainers" Version="4.11.0" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+  </ItemGroup>
+</Project>

--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
-# AgenticAITemplate
-Template for Agentic AI Development
+# The Conductor
+
+Conductor is the fleet control layer above Symphony. It supervises many Symphony instances, collects operational state, and presents portfolio-level delivery visibility.
+
+## Development Baseline
+
+This repository targets .NET 10 and uses solution-wide MSBuild defaults from `Directory.Build.props`.
+
+Package versions are managed centrally in `Directory.Packages.props`. Project files should reference packages without inline `Version` attributes unless a local exception is deliberately required.
+
+The planned host configuration starts in `src/Conductor.Host/appsettings.json`. It defines local SQLite, instance, and Symphony release cache paths without storing credentials.

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "10.0.100",
+    "rollForward": "latestFeature",
+    "allowPrerelease": false
+  }
+}

--- a/src/Conductor.Host/appsettings.json
+++ b/src/Conductor.Host/appsettings.json
@@ -1,0 +1,22 @@
+{
+  "ConnectionStrings": {
+    "Conductor": "Data Source=./data/conductor.db;Cache=Shared"
+  },
+  "Conductor": {
+    "InstanceRoot": "./data/instances",
+    "ReleaseCacheRoot": "./data/cache/symphony-releases",
+    "DefaultHealthPollSeconds": 10,
+    "DefaultStatePollSeconds": 30,
+    "DefaultRuntimePollSeconds": 120,
+    "AllowLocalProcessRunner": true,
+    "AllowDockerRunner": true
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning",
+      "Microsoft.EntityFrameworkCore.Database.Command": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
## Summary
- Add repository-wide editor and Git line-ending rules.
- Add .NET 10 solution-wide MSBuild defaults, SDK pinning, and central package versions for the planned Conductor app and tests.
- Add baseline host appsettings and README notes for the development configuration.

Closes #7

## Validation
- XML parse for `Directory.Build.props` and `Directory.Packages.props`: passed.
- JSON parse for `global.json` and `src/Conductor.Host/appsettings.json`: passed.
- `git diff --check`: passed.
- Disposable .NET 10 class library using copied repo props and central package management with `Microsoft.Data.Sqlite`: `dotnet restore` and `dotnet build --no-restore --warnaserror` passed with 0 warnings and 0 errors.
- Disposable .NET 10 xUnit project using copied repo props and central test package versions: `dotnet restore` and `dotnet test --no-restore --warnaserror` passed, 1/1 tests.

## Notes
- The repository does not yet contain a solution or project skeleton, so there is no meaningful in-repo `dotnet build` or `dotnet test` target until the neighboring Sprint 0 scaffold issues land.