### PR TITLE
Tighten pull request CI validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,17 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build-test:
     runs-on: windows-latest
+    timeout-minutes: 15
+
+    env:
+      DOTNET_CLI_TELEMETRY_OPTOUT: 1
+      DOTNET_NOLOGO: true
 
     steps:
       - name: Checkout
@@ -32,4 +40,4 @@ jobs:
         run: dotnet test Conductor.slnx --no-build --collect:"XPlat Code Coverage"
 
       - name: Format check
-        run: dotnet format Conductor.slnx --verify-no-changes
+        run: dotnet format Conductor.slnx --no-restore --verify-no-changes

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Conductor is the fleet control layer above Symphony. It is being built as a .NET
 dotnet restore Conductor.slnx
 dotnet build Conductor.slnx --no-restore --warnaserror
 dotnet test Conductor.slnx --no-build
+dotnet format Conductor.slnx --no-restore --verify-no-changes
 ```
 
 ## Run Locally


### PR DESCRIPTION
## Summary
- Harden the PR CI workflow with read-only repository permissions, a job timeout, and quiet .NET CLI defaults.
- Keep restore as an explicit single step by running `dotnet format` with `--no-restore`.
- Document the local format verification command alongside restore/build/test.

Closes #8

## Validation
- `dotnet restore Conductor.slnx`: passed with no errors or warnings
- `dotnet build Conductor.slnx --no-restore --warnaserror`: passed with 0 warnings and 0 errors
- `dotnet test Conductor.slnx --no-build`: passed, 12 tests
- `dotnet format Conductor.slnx --no-restore --verify-no-changes`: passed with no changes