### PR TITLE
Add workflow release and secret entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Conductor is the fleet control layer above Symphony. It is being built as a .NET
 
 - `Conductor.slnx` is the .NET solution entry point.
 - `src/Conductor.Host` contains the Blazor Web App host, health endpoints, worker registration, and the placeholder dashboard.
-- `src/Conductor.Core` contains domain types, value objects, and infrastructure-facing contracts.
+- `src/Conductor.Core` contains domain types, value objects, and infrastructure-facing contracts, including the workflow profile, release artifact, and secret descriptor entities.
 - `src/Conductor.Infrastructure.Persistence.Sqlite` contains the EF Core SQLite persistence shell.
 - `src/Conductor.Infrastructure.*` projects contain adapter boundaries for GitHub, Symphony HTTP, runners, secrets, reporting, and notifications.
 - `tests/Conductor.*.Tests` projects contain the initial unit, persistence, API, Blazor, host, and integration test suites.

--- a/src/Conductor.Core/Abstractions/Secrets/ISecretStore.cs
+++ b/src/Conductor.Core/Abstractions/Secrets/ISecretStore.cs
@@ -1,5 +1,6 @@
 using Conductor.Core.Domain;
 using Conductor.Core.Domain.Ids;
+using Conductor.Core.Domain.Secrets;
 
 namespace Conductor.Core.Abstractions.Secrets;
 
@@ -23,22 +24,6 @@ public interface ISecretStore
     Task DeleteAsync(SecretId secretId, CancellationToken cancellationToken);
 }
 
-public enum SecretScopeType
-{
-    Global,
-    Project,
-    Repository,
-    SymphonyInstance,
-}
-
-public enum SecretType
-{
-    GitHubToken,
-    OpenAiApiKey,
-    CodexHome,
-    Other,
-}
-
 public sealed record CreateSecretRequest(
     string Name,
     SecretType SecretType,
@@ -55,12 +40,3 @@ public sealed record SecretReference(
 public sealed record ResolvedSecret(SecretId SecretId, string Value);
 
 public sealed record SecretQuery(SecretType? SecretType = null, SecretScopeType? ScopeType = null);
-
-public sealed record SecretDescriptor(
-    SecretId Id,
-    string Name,
-    SecretType SecretType,
-    SecretScopeType ScopeType,
-    string? ScopeId,
-    DateTimeOffset CreatedAtUtc,
-    DateTimeOffset? RotatedAtUtc);

--- a/src/Conductor.Core/Domain/Secrets/SecretDescriptor.cs
+++ b/src/Conductor.Core/Domain/Secrets/SecretDescriptor.cs
@@ -1,0 +1,75 @@
+using Conductor.Core.Common;
+using Conductor.Core.Domain.Ids;
+
+namespace Conductor.Core.Domain.Secrets;
+
+public enum SecretScopeType
+{
+    Global,
+    Project,
+    Repository,
+    SymphonyInstance,
+}
+
+public enum SecretType
+{
+    GitHubToken,
+    OpenAiApiKey,
+    CodexHome,
+    Other,
+}
+
+public sealed class SecretDescriptor
+{
+    public SecretDescriptor(
+        SecretId id,
+        string name,
+        SecretType secretType,
+        SecretScopeType scopeType,
+        string? scopeId,
+        DateTimeOffset createdAtUtc,
+        DateTimeOffset? rotatedAtUtc = null)
+    {
+        Id = id;
+        Name = Guard.NotWhiteSpace(name, nameof(name));
+        SecretType = secretType;
+        ScopeType = scopeType;
+        ScopeId = NormalizeScopeId(scopeType, scopeId);
+        CreatedAtUtc = createdAtUtc;
+        RotatedAtUtc = rotatedAtUtc;
+    }
+
+    public SecretId Id { get; }
+
+    public string Name { get; }
+
+    public SecretType SecretType { get; }
+
+    public SecretScopeType ScopeType { get; }
+
+    public string? ScopeId { get; }
+
+    public DateTimeOffset CreatedAtUtc { get; }
+
+    public DateTimeOffset? RotatedAtUtc { get; private set; }
+
+    public void MarkRotated(DateTimeOffset rotatedAtUtc)
+    {
+        RotatedAtUtc = rotatedAtUtc;
+    }
+
+    private static string? NormalizeScopeId(SecretScopeType scopeType, string? scopeId)
+    {
+        if (scopeType is SecretScopeType.Global)
+        {
+            if (!string.IsNullOrWhiteSpace(scopeId))
+            {
+                throw new ArgumentException("Global secrets cannot have a scope identifier.", nameof(scopeId));
+            }
+
+            return null;
+        }
+
+        return Guard.NotWhiteSpace(scopeId ?? string.Empty, nameof(scopeId));
+    }
+}

--- a/tests/Conductor.Core.Tests/Issue13DomainEntityTests.cs
+++ b/tests/Conductor.Core.Tests/Issue13DomainEntityTests.cs
@@ -1,0 +1,100 @@
+using Conductor.Core.Domain.Ids;
+using Conductor.Core.Domain.Secrets;
+using Conductor.Core.Domain.SymphonyReleases;
+using Conductor.Core.Domain.Workflows;
+
+namespace Conductor.Core.Tests;
+
+public sealed class Issue13DomainEntityTests
+{
+    [Fact]
+    public void WorkflowProfile_Trims_Name_And_Source_Template()
+    {
+        var createdAt = DateTimeOffset.Parse("2026-04-29T00:00:00Z");
+        var profile = new WorkflowProfile(
+            WorkflowProfileId.New(),
+            "  Default Docker  ",
+            "  # WORKFLOW\nrun: symphony  ",
+            createdAt);
+
+        Assert.Equal("Default Docker", profile.Name);
+        Assert.Equal("# WORKFLOW\nrun: symphony", profile.WorkflowSource);
+        Assert.Equal(createdAt, profile.CreatedAtUtc);
+    }
+
+    [Fact]
+    public void SymphonyReleaseArtifact_Stores_Release_Asset_Provenance()
+    {
+        var downloadedAt = DateTimeOffset.Parse("2026-04-29T00:05:00Z");
+        var artifact = new SymphonyReleaseArtifact(
+            "  v1.2.3  ",
+            "  symphony-win-x64.zip  ",
+            new Uri("https://github.com/ReleasedGroup/Symphony/releases/download/v1.2.3/symphony-win-x64.zip"),
+            downloadedAt,
+            "  sha256:abc123  ");
+
+        Assert.Equal("v1.2.3", artifact.ReleaseTag);
+        Assert.Equal("symphony-win-x64.zip", artifact.AssetName);
+        Assert.Equal(downloadedAt, artifact.DownloadedAtUtc);
+        Assert.Equal("sha256:abc123", artifact.Checksum);
+    }
+
+    [Fact]
+    public void SecretDescriptor_Stores_Metadata_Without_A_Secret_Value()
+    {
+        var createdAt = DateTimeOffset.Parse("2026-04-29T00:10:00Z");
+        var rotatedAt = createdAt.AddMinutes(30);
+        var instanceId = SymphonyInstanceId.New();
+        var descriptor = new SecretDescriptor(
+            SecretId.New(),
+            "  GitHub PAT  ",
+            SecretType.GitHubToken,
+            SecretScopeType.SymphonyInstance,
+            instanceId.ToString(),
+            createdAt);
+
+        descriptor.MarkRotated(rotatedAt);
+
+        Assert.Equal("GitHub PAT", descriptor.Name);
+        Assert.Equal(SecretType.GitHubToken, descriptor.SecretType);
+        Assert.Equal(SecretScopeType.SymphonyInstance, descriptor.ScopeType);
+        Assert.Equal(instanceId.ToString(), descriptor.ScopeId);
+        Assert.Equal(createdAt, descriptor.CreatedAtUtc);
+        Assert.Equal(rotatedAt, descriptor.RotatedAtUtc);
+        Assert.DoesNotContain(
+            typeof(SecretDescriptor).GetProperties(),
+            property => property.Name.Contains("Value", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void SecretDescriptor_Requires_Scope_Id_For_Non_Global_Secrets()
+    {
+        var createdAt = DateTimeOffset.Parse("2026-04-29T00:10:00Z");
+
+        var error = Assert.Throws<ArgumentException>(() => new SecretDescriptor(
+            SecretId.New(),
+            "Repository PAT",
+            SecretType.GitHubToken,
+            SecretScopeType.Repository,
+            scopeId: " ",
+            createdAt));
+
+        Assert.Equal("scopeId", error.ParamName);
+    }
+
+    [Fact]
+    public void SecretDescriptor_Rejects_Scope_Id_For_Global_Secrets()
+    {
+        var createdAt = DateTimeOffset.Parse("2026-04-29T00:10:00Z");
+
+        var error = Assert.Throws<ArgumentException>(() => new SecretDescriptor(
+            SecretId.New(),
+            "Default OpenAI key",
+            SecretType.OpenAiApiKey,
+            SecretScopeType.Global,
+            scopeId: "default",
+            createdAt));
+
+        Assert.Equal("scopeId", error.ParamName);
+    }
+}


### PR DESCRIPTION
## Summary
- Add a domain `SecretDescriptor` entity with secret scope/type metadata and scope validation.
- Move secret metadata enums into the domain namespace and have `ISecretStore` return the domain descriptor.
- Add focused tests covering `WorkflowProfile`, `SymphonyReleaseArtifact`, and `SecretDescriptor`, plus a README note.

Fixes #13

## Validation
- `dotnet restore Conductor.slnx`: passed
- `dotnet build Conductor.slnx --no-restore --warnaserror`: passed with 0 warnings
- `dotnet test Conductor.slnx --no-build`: passed
- `dotnet format Conductor.slnx --verify-no-changes`: passed
- `git diff --check`: passed