### PR TITLE
Add dashboard startup verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,5 @@ dotnet test Conductor.slnx --no-build
 ```powershell
 dotnet run --project src/Conductor.Host/Conductor.Host.csproj
 ```
+
+The root route (`/`) serves the placeholder dashboard for local startup checks. The same startup baseline also exposes `/health/live` and `/health/ready`.

--- a/src/Conductor.Host/Components/Pages/Home.razor
+++ b/src/Conductor.Host/Components/Pages/Home.razor
@@ -34,6 +34,25 @@
             }
         </ul>
     </section>
+
+    <section class="startup-panel" aria-label="Startup verification">
+        <div>
+            <h2>Startup verification</h2>
+            <p>The local host can be checked from the dashboard route and the built-in health probes.</p>
+        </div>
+        <dl>
+            @foreach ((string Label, string Route, string State) check in StartupChecks)
+            {
+                <div>
+                    <dt>@check.Label</dt>
+                    <dd>
+                        <code>@check.Route</code>
+                        <span>@check.State</span>
+                    </dd>
+                </div>
+            }
+        </dl>
+    </section>
 </section>
 
 @code {
@@ -51,5 +70,12 @@
         "SQLite persistence registration",
         "Health endpoints",
         "Layered test projects",
+    ];
+
+    private static readonly (string Label, string Route, string State)[] StartupChecks =
+    [
+        ("Dashboard route", "/", "Placeholder served"),
+        ("Live health", "/health/live", "Probe available"),
+        ("Ready health", "/health/ready", "Probe available"),
     ];
 }

--- a/src/Conductor.Host/wwwroot/app.css
+++ b/src/Conductor.Host/wwwroot/app.css
@@ -181,6 +181,63 @@ h2 {
   color: #dbe6ee;
 }
 
+.startup-panel {
+  display: grid;
+  gap: 18px;
+  padding: 24px;
+  border: 1px solid #2b3138;
+  border-radius: 8px;
+  background: #151a1f;
+}
+
+.startup-panel p {
+  margin-bottom: 0;
+  color: #aeb9c5;
+}
+
+.startup-panel dl {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  margin: 0;
+}
+
+.startup-panel dl div {
+  display: grid;
+  gap: 8px;
+  min-height: 96px;
+  padding: 16px;
+  border: 1px solid #2b3138;
+  border-radius: 8px;
+  background: #1b2228;
+}
+
+.startup-panel dt {
+  color: #aeb9c5;
+  font-size: 0.9rem;
+  font-weight: 700;
+}
+
+.startup-panel dd {
+  display: grid;
+  gap: 8px;
+  margin: 0;
+}
+
+.startup-panel code {
+  width: fit-content;
+  max-width: 100%;
+  padding: 4px 6px;
+  border-radius: 4px;
+  background: #232a31;
+  color: #f2c14e;
+  overflow-wrap: anywhere;
+}
+
+.startup-panel span {
+  color: #dbe6ee;
+}
+
 .empty-state {
   padding: 24px;
   border: 1px solid #2b3138;
@@ -201,7 +258,8 @@ h2 {
 
   .side-nav nav,
   .metric-grid,
-  .activity-panel {
+  .activity-panel,
+  .startup-panel dl {
     grid-template-columns: 1fr;
   }
 

--- a/tests/Conductor.Blazor.Tests/DashboardSmokeTests.cs
+++ b/tests/Conductor.Blazor.Tests/DashboardSmokeTests.cs
@@ -14,5 +14,7 @@ public sealed class DashboardSmokeTests
 
         Assert.Contains("Conductor Dashboard", dashboard.Markup, StringComparison.Ordinal);
         Assert.Contains("SQLite persistence registration", dashboard.Markup, StringComparison.Ordinal);
+        Assert.Contains("Startup verification", dashboard.Markup, StringComparison.Ordinal);
+        Assert.Contains("/health/live", dashboard.Markup, StringComparison.Ordinal);
     }
 }

--- a/tests/Conductor.Host.Tests/HostSmokeTests.cs
+++ b/tests/Conductor.Host.Tests/HostSmokeTests.cs
@@ -32,6 +32,8 @@ public sealed class HostSmokeTests : IClassFixture<WebApplicationFactory<global:
         Assert.Contains("Conductor Dashboard", content);
         Assert.Contains("Operational baseline", content);
         Assert.Contains("Health endpoints", content);
+        Assert.Contains("Startup verification", content);
+        Assert.Contains("/health/ready", content);
     }
 
     private HttpClient CreateClient() =>


### PR DESCRIPTION
## Summary
- Add an explicit startup verification section to the placeholder dashboard for `/`, `/health/live`, and `/health/ready`.
- Extend the host and bUnit smoke tests to assert the dashboard startup verification content.
- Document the local startup verification routes in the README.

Closes #10

## Validation
- `dotnet restore Conductor.slnx`: passed with no errors or warnings
- `dotnet build Conductor.slnx --no-restore --warnaserror`: passed with no errors or warnings
- `dotnet test Conductor.slnx --no-build --collect:"XPlat Code Coverage"`: passed, 12 tests
- `dotnet format Conductor.slnx --verify-no-changes`: passed with no changes
- `git diff --check`: passed
- Local startup smoke check on `http://127.0.0.1:5410`: `/`, `/health/live`, and `/health/ready` returned 200; dashboard contained startup verification content; logs had no warning/error lines

## Notes
- The branch was fast-forwarded to the merged Sprint 0 scaffold and Blazor host work before implementation.