### PR TITLE
[codex] Add SQLite persistence wiring

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,6 +9,7 @@
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.5" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.5" />
   </ItemGroup>
 
   <ItemGroup Label="Testing">

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Conductor is the fleet control layer above Symphony. It is being built as a .NET
 - `Conductor.slnx` is the .NET solution entry point.
 - `src/Conductor.Host` contains the Blazor Web App host, health endpoints, worker registration, and the placeholder dashboard.
 - `src/Conductor.Core` contains domain types, value objects, and infrastructure-facing contracts.
-- `src/Conductor.Infrastructure.Persistence.Sqlite` contains the EF Core SQLite persistence shell.
+- `src/Conductor.Infrastructure.Persistence.Sqlite` contains the EF Core SQLite persistence project, DbContext registration, and migration target.
 - `src/Conductor.Infrastructure.*` projects contain adapter boundaries for GitHub, Symphony HTTP, runners, secrets, reporting, and notifications.
 - `tests/Conductor.*.Tests` projects contain the initial unit, persistence, API, Blazor, host, and integration test suites.
 
@@ -24,3 +24,13 @@ dotnet test Conductor.slnx --no-build
 ```powershell
 dotnet run --project src/Conductor.Host/Conductor.Host.csproj
 ```
+
+## Persistence Configuration
+
+The host registers `ConductorDbContext` from `src/Conductor.Infrastructure.Persistence.Sqlite` using the `ConnectionStrings:Conductor` value. The default is:
+
+```text
+Data Source=./data/conductor.db;Cache=Shared
+```
+
+The SQLite registration creates the database directory when a file-backed connection string is used and applies the required startup PRAGMAs for foreign keys, WAL journaling, and a 5 second busy timeout when EF Core opens a connection.

--- a/src/Conductor.Infrastructure.Persistence.Sqlite/Conductor.Infrastructure.Persistence.Sqlite.csproj
+++ b/src/Conductor.Infrastructure.Persistence.Sqlite/Conductor.Infrastructure.Persistence.Sqlite.csproj
@@ -1,6 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Data.Sqlite" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
   </ItemGroup>
 

--- a/src/Conductor.Infrastructure.Persistence.Sqlite/ConductorDbContextFactory.cs
+++ b/src/Conductor.Infrastructure.Persistence.Sqlite/ConductorDbContextFactory.cs
@@ -1,0 +1,25 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+
+namespace Conductor.Infrastructure.Persistence.Sqlite;
+
+public sealed class ConductorDbContextFactory : IDesignTimeDbContextFactory<ConductorDbContext>
+{
+    public ConductorDbContext CreateDbContext(string[] args)
+    {
+        string connectionString = ResolveConnectionString(args);
+        SqliteConnectionPragmaInterceptor pragmaInterceptor = new();
+
+        DbContextOptionsBuilder<ConductorDbContext> optionsBuilder = new();
+        optionsBuilder
+            .UseConductorSqlite(connectionString)
+            .AddInterceptors(pragmaInterceptor);
+
+        return new ConductorDbContext(optionsBuilder.Options);
+    }
+
+    private static string ResolveConnectionString(string[] args) =>
+        args.FirstOrDefault(argument => !string.IsNullOrWhiteSpace(argument))
+        ?? Environment.GetEnvironmentVariable("ConnectionStrings__Conductor")
+        ?? SqlitePersistenceOptions.DefaultConnectionString;
+}

--- a/src/Conductor.Infrastructure.Persistence.Sqlite/ConductorSqliteDbContextOptionsBuilderExtensions.cs
+++ b/src/Conductor.Infrastructure.Persistence.Sqlite/ConductorSqliteDbContextOptionsBuilderExtensions.cs
@@ -1,0 +1,19 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Conductor.Infrastructure.Persistence.Sqlite;
+
+internal static class ConductorSqliteDbContextOptionsBuilderExtensions
+{
+    public static DbContextOptionsBuilder UseConductorSqlite(
+        this DbContextOptionsBuilder optionsBuilder,
+        string connectionString)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
+
+        SqliteDatabaseDirectory.EnsureExists(connectionString);
+
+        return optionsBuilder.UseSqlite(
+            connectionString,
+            sqliteOptions => sqliteOptions.MigrationsAssembly(typeof(ConductorDbContext).Assembly.GetName().Name!));
+    }
+}

--- a/src/Conductor.Infrastructure.Persistence.Sqlite/SqliteConnectionPragmaInterceptor.cs
+++ b/src/Conductor.Infrastructure.Persistence.Sqlite/SqliteConnectionPragmaInterceptor.cs
@@ -1,0 +1,60 @@
+using System.Data.Common;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
+namespace Conductor.Infrastructure.Persistence.Sqlite;
+
+internal sealed class SqliteConnectionPragmaInterceptor : DbConnectionInterceptor
+{
+    private static readonly string[] RequiredPragmas =
+    [
+        "PRAGMA foreign_keys=ON;",
+        $"PRAGMA busy_timeout={SqlitePersistenceOptions.DefaultBusyTimeoutMilliseconds};",
+        "PRAGMA journal_mode=WAL;",
+    ];
+
+    public override void ConnectionOpened(DbConnection connection, ConnectionEndEventData eventData)
+    {
+        ConfigureConnection(connection);
+        base.ConnectionOpened(connection, eventData);
+    }
+
+    public override async Task ConnectionOpenedAsync(
+        DbConnection connection,
+        ConnectionEndEventData eventData,
+        CancellationToken cancellationToken = default)
+    {
+        await ConfigureConnectionAsync(connection, cancellationToken);
+        await base.ConnectionOpenedAsync(connection, eventData, cancellationToken);
+    }
+
+    private static void ConfigureConnection(DbConnection connection)
+    {
+        if (connection is not SqliteConnection)
+        {
+            return;
+        }
+
+        foreach (string pragma in RequiredPragmas)
+        {
+            using DbCommand command = connection.CreateCommand();
+            command.CommandText = pragma;
+            command.ExecuteNonQuery();
+        }
+    }
+
+    private static async Task ConfigureConnectionAsync(DbConnection connection, CancellationToken cancellationToken)
+    {
+        if (connection is not SqliteConnection)
+        {
+            return;
+        }
+
+        foreach (string pragma in RequiredPragmas)
+        {
+            await using DbCommand command = connection.CreateCommand();
+            command.CommandText = pragma;
+            await command.ExecuteNonQueryAsync(cancellationToken);
+        }
+    }
+}

--- a/src/Conductor.Infrastructure.Persistence.Sqlite/SqliteDatabaseDirectory.cs
+++ b/src/Conductor.Infrastructure.Persistence.Sqlite/SqliteDatabaseDirectory.cs
@@ -1,0 +1,42 @@
+using Microsoft.Data.Sqlite;
+
+namespace Conductor.Infrastructure.Persistence.Sqlite;
+
+internal static class SqliteDatabaseDirectory
+{
+    public static void EnsureExists(string connectionString)
+    {
+        SqliteConnectionStringBuilder builder = new(connectionString);
+
+        if (IsInMemoryDatabase(builder))
+        {
+            return;
+        }
+
+        string? directory = GetDirectory(builder.DataSource);
+
+        if (!string.IsNullOrWhiteSpace(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+    }
+
+    private static bool IsInMemoryDatabase(SqliteConnectionStringBuilder builder) =>
+        builder.Mode == SqliteOpenMode.Memory
+        || string.Equals(builder.DataSource, ":memory:", StringComparison.OrdinalIgnoreCase)
+        || builder.DataSource.Contains("mode=memory", StringComparison.OrdinalIgnoreCase);
+
+    private static string? GetDirectory(string dataSource)
+    {
+        string path = dataSource;
+
+        if (Uri.TryCreate(dataSource, UriKind.Absolute, out Uri? uri) && uri.IsFile)
+        {
+            path = uri.LocalPath;
+        }
+
+        string? directory = Path.GetDirectoryName(path);
+
+        return string.IsNullOrWhiteSpace(directory) ? null : directory;
+    }
+}

--- a/src/Conductor.Infrastructure.Persistence.Sqlite/SqlitePersistenceOptions.cs
+++ b/src/Conductor.Infrastructure.Persistence.Sqlite/SqlitePersistenceOptions.cs
@@ -1,0 +1,8 @@
+namespace Conductor.Infrastructure.Persistence.Sqlite;
+
+public static class SqlitePersistenceOptions
+{
+    public const string ConnectionStringName = "Conductor";
+    public const string DefaultConnectionString = "Data Source=./data/conductor.db;Cache=Shared";
+    public const int DefaultBusyTimeoutMilliseconds = 5000;
+}

--- a/src/Conductor.Infrastructure.Persistence.Sqlite/SqlitePersistenceServiceCollectionExtensions.cs
+++ b/src/Conductor.Infrastructure.Persistence.Sqlite/SqlitePersistenceServiceCollectionExtensions.cs
@@ -6,15 +6,21 @@ namespace Conductor.Infrastructure.Persistence.Sqlite;
 
 public static class SqlitePersistenceServiceCollectionExtensions
 {
-    private const string DefaultConnectionString = "Data Source=./data/conductor.db;Cache=Shared";
-
     public static IServiceCollection AddConductorPersistence(
         this IServiceCollection services,
         IConfiguration configuration)
     {
-        string connectionString = configuration.GetConnectionString("Conductor") ?? DefaultConnectionString;
+        string connectionString = configuration.GetConnectionString(SqlitePersistenceOptions.ConnectionStringName)
+            ?? SqlitePersistenceOptions.DefaultConnectionString;
 
-        services.AddDbContext<ConductorDbContext>(options => options.UseSqlite(connectionString));
+        services.AddSingleton<SqliteConnectionPragmaInterceptor>();
+
+        services.AddDbContext<ConductorDbContext>((serviceProvider, options) =>
+        {
+            options
+                .UseConductorSqlite(connectionString)
+                .AddInterceptors(serviceProvider.GetRequiredService<SqliteConnectionPragmaInterceptor>());
+        });
 
         return services;
     }

--- a/tests/Conductor.Persistence.Tests/Conductor.Persistence.Tests.csproj
+++ b/tests/Conductor.Persistence.Tests/Conductor.Persistence.Tests.csproj
@@ -9,6 +9,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio">

--- a/tests/Conductor.Persistence.Tests/SqlitePersistenceSmokeTests.cs
+++ b/tests/Conductor.Persistence.Tests/SqlitePersistenceSmokeTests.cs
@@ -1,5 +1,9 @@
+using System.Data.Common;
+using System.Globalization;
 using Conductor.Infrastructure.Persistence.Sqlite;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Conductor.Persistence.Tests;
 
@@ -18,5 +22,87 @@ public sealed class SqlitePersistenceSmokeTests
         await dbContext.Database.EnsureCreatedAsync();
 
         Assert.True(await dbContext.Database.CanConnectAsync());
+    }
+
+    [Fact]
+    public async Task AddConductorPersistence_Registers_Configured_DbContext()
+    {
+        string databasePath = CreateTemporaryDatabasePath();
+        IConfiguration configuration = BuildConfiguration(databasePath);
+        ServiceCollection services = new();
+
+        services.AddConductorPersistence(configuration);
+
+        await using ServiceProvider provider = services.BuildServiceProvider(validateScopes: true);
+        await using AsyncServiceScope scope = provider.CreateAsyncScope();
+        ConductorDbContext dbContext = scope.ServiceProvider.GetRequiredService<ConductorDbContext>();
+
+        await dbContext.Database.OpenConnectionAsync();
+
+        Assert.True(await dbContext.Database.CanConnectAsync());
+        Assert.True(Directory.Exists(Path.GetDirectoryName(databasePath)));
+    }
+
+    [Fact]
+    public async Task AddConductorPersistence_Applies_Required_Sqlite_Pragmas()
+    {
+        string databasePath = CreateTemporaryDatabasePath();
+        IConfiguration configuration = BuildConfiguration(databasePath);
+        ServiceCollection services = new();
+
+        services.AddConductorPersistence(configuration);
+
+        await using ServiceProvider provider = services.BuildServiceProvider(validateScopes: true);
+        await using AsyncServiceScope scope = provider.CreateAsyncScope();
+        ConductorDbContext dbContext = scope.ServiceProvider.GetRequiredService<ConductorDbContext>();
+
+        await dbContext.Database.OpenConnectionAsync();
+
+        DbConnection connection = dbContext.Database.GetDbConnection();
+
+        Assert.Equal(1, await ExecuteLongPragmaAsync(connection, "PRAGMA foreign_keys;"));
+        Assert.Equal(SqlitePersistenceOptions.DefaultBusyTimeoutMilliseconds, await ExecuteLongPragmaAsync(connection, "PRAGMA busy_timeout;"));
+        Assert.Equal("wal", await ExecuteTextPragmaAsync(connection, "PRAGMA journal_mode;"));
+    }
+
+    private static IConfiguration BuildConfiguration(string databasePath)
+    {
+        Dictionary<string, string?> values = new()
+        {
+            [$"ConnectionStrings:{SqlitePersistenceOptions.ConnectionStringName}"] = $"Data Source={databasePath};Cache=Shared",
+        };
+
+        return new ConfigurationBuilder()
+            .AddInMemoryCollection(values)
+            .Build();
+    }
+
+    private static string CreateTemporaryDatabasePath() =>
+        Path.Combine(
+            Path.GetTempPath(),
+            "conductor-persistence-tests",
+            Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture),
+            "conductor.db");
+
+    private static async Task<long> ExecuteLongPragmaAsync(DbConnection connection, string commandText)
+    {
+        object? value = await ExecuteScalarAsync(connection, commandText);
+
+        return Convert.ToInt64(value, CultureInfo.InvariantCulture);
+    }
+
+    private static async Task<string?> ExecuteTextPragmaAsync(DbConnection connection, string commandText)
+    {
+        object? value = await ExecuteScalarAsync(connection, commandText);
+
+        return Convert.ToString(value, CultureInfo.InvariantCulture);
+    }
+
+    private static async Task<object?> ExecuteScalarAsync(DbConnection connection, string commandText)
+    {
+        await using DbCommand command = connection.CreateCommand();
+        command.CommandText = commandText;
+
+        return await command.ExecuteScalarAsync();
     }
 }


### PR DESCRIPTION
Closes #4

## Summary
- Adds EF Core SQLite persistence wiring with a shared `ConductorDbContext` configuration path and explicit migrations assembly targeting.
- Adds SQLite design-time `DbContext` factory support for future EF migrations.
- Applies required SQLite connection PRAGMAs for foreign keys, WAL journaling, and busy timeout when EF opens connections.
- Creates file-backed database directories during persistence registration and documents the connection-string behavior.
- Adds persistence tests covering DI registration and SQLite PRAGMA setup.

## Validation
- `dotnet restore Conductor.slnx`
- `dotnet build Conductor.slnx --no-restore --warnaserror`
- `dotnet test Conductor.slnx --no-build`
- `dotnet format Conductor.slnx --verify-no-changes`
- `dotnet test Conductor.slnx --no-build --collect:"XPlat Code Coverage"`