### PR TITLE
[codex] Implement operational domain entities

### DIFF
--- a/src/Conductor.Core/Common/Guard.cs
+++ b/src/Conductor.Core/Common/Guard.cs
@@ -12,6 +12,11 @@ internal static class Guard
         return value.Trim();
     }
 
+    public static string? OptionalTrimmed(string? value)
+    {
+        return string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+    }
+
     public static Uri AbsoluteUri(Uri value, string parameterName)
     {
         ArgumentNullException.ThrowIfNull(value);
@@ -19,6 +24,46 @@ internal static class Guard
         if (!value.IsAbsoluteUri)
         {
             throw new ArgumentException("An absolute URI is required.", parameterName);
+        }
+
+        return value;
+    }
+
+    public static Uri? OptionalAbsoluteUri(Uri? value, string parameterName)
+    {
+        if (value is null)
+        {
+            return null;
+        }
+
+        return AbsoluteUri(value, parameterName);
+    }
+
+    public static int Positive(int value, string parameterName)
+    {
+        if (value <= 0)
+        {
+            throw new ArgumentOutOfRangeException(parameterName, "A positive value is required.");
+        }
+
+        return value;
+    }
+
+    public static int NonNegative(int value, string parameterName)
+    {
+        if (value < 0)
+        {
+            throw new ArgumentOutOfRangeException(parameterName, "A non-negative value is required.");
+        }
+
+        return value;
+    }
+
+    public static long NonNegative(long value, string parameterName)
+    {
+        if (value < 0)
+        {
+            throw new ArgumentOutOfRangeException(parameterName, "A non-negative value is required.");
         }
 
         return value;

--- a/src/Conductor.Core/Domain/Alerts/Alert.cs
+++ b/src/Conductor.Core/Domain/Alerts/Alert.cs
@@ -1,0 +1,80 @@
+using Conductor.Core.Common;
+using Conductor.Core.Domain.Ids;
+
+namespace Conductor.Core.Domain.Alerts;
+
+public sealed class Alert
+{
+    public Alert(
+        AlertId id,
+        AlertSeverity severity,
+        string source,
+        string summary,
+        string? recommendedAction,
+        DateTimeOffset createdAtUtc,
+        SymphonyInstanceId? symphonyInstanceId = null,
+        RepositoryId? repositoryId = null,
+        RunId? runId = null,
+        int? gitHubIssueNumber = null)
+    {
+        Id = id;
+        Status = AlertStatus.Active;
+        Severity = severity;
+        Source = Guard.NotWhiteSpace(source, nameof(source));
+        Summary = Guard.NotWhiteSpace(summary, nameof(summary));
+        RecommendedAction = Guard.OptionalTrimmed(recommendedAction);
+        CreatedAtUtc = createdAtUtc;
+        SymphonyInstanceId = symphonyInstanceId;
+        RepositoryId = repositoryId;
+        RunId = runId;
+        GitHubIssueNumber = gitHubIssueNumber.HasValue
+            ? Guard.Positive(gitHubIssueNumber.Value, nameof(gitHubIssueNumber))
+            : null;
+    }
+
+    public AlertId Id { get; }
+
+    public AlertStatus Status { get; private set; }
+
+    public AlertSeverity Severity { get; }
+
+    public string Source { get; }
+
+    public string Summary { get; }
+
+    public string? RecommendedAction { get; }
+
+    public DateTimeOffset CreatedAtUtc { get; }
+
+    public DateTimeOffset? ResolvedAtUtc { get; private set; }
+
+    public string? ResolutionNote { get; private set; }
+
+    public SymphonyInstanceId? SymphonyInstanceId { get; }
+
+    public RepositoryId? RepositoryId { get; }
+
+    public RunId? RunId { get; }
+
+    public int? GitHubIssueNumber { get; }
+
+    public void Acknowledge()
+    {
+        if (Status == AlertStatus.Active)
+        {
+            Status = AlertStatus.Acknowledged;
+        }
+    }
+
+    public void Resolve(DateTimeOffset resolvedAtUtc, string? resolutionNote)
+    {
+        if (resolvedAtUtc < CreatedAtUtc)
+        {
+            throw new ArgumentOutOfRangeException(nameof(resolvedAtUtc), "Resolved time cannot be before the alert was created.");
+        }
+
+        Status = AlertStatus.Resolved;
+        ResolvedAtUtc = resolvedAtUtc;
+        ResolutionNote = Guard.OptionalTrimmed(resolutionNote);
+    }
+}

--- a/src/Conductor.Core/Domain/Auditing/AuditEvent.cs
+++ b/src/Conductor.Core/Domain/Auditing/AuditEvent.cs
@@ -1,0 +1,51 @@
+using Conductor.Core.Common;
+using Conductor.Core.Domain.Ids;
+
+namespace Conductor.Core.Domain.Auditing;
+
+public sealed class AuditEvent
+{
+    public AuditEvent(
+        AuditEventId id,
+        string actorUserId,
+        string action,
+        string targetResourceType,
+        string? targetResourceId,
+        DateTimeOffset occurredAtUtc,
+        AuditEventOutcome outcome,
+        string? correlationId,
+        string? message,
+        string? metadataJson)
+    {
+        Id = id;
+        ActorUserId = Guard.NotWhiteSpace(actorUserId, nameof(actorUserId));
+        Action = Guard.NotWhiteSpace(action, nameof(action));
+        TargetResourceType = Guard.NotWhiteSpace(targetResourceType, nameof(targetResourceType));
+        TargetResourceId = Guard.OptionalTrimmed(targetResourceId);
+        OccurredAtUtc = occurredAtUtc;
+        Outcome = outcome;
+        CorrelationId = Guard.OptionalTrimmed(correlationId);
+        Message = Guard.OptionalTrimmed(message);
+        MetadataJson = Guard.OptionalTrimmed(metadataJson);
+    }
+
+    public AuditEventId Id { get; }
+
+    public string ActorUserId { get; }
+
+    public string Action { get; }
+
+    public string TargetResourceType { get; }
+
+    public string? TargetResourceId { get; }
+
+    public DateTimeOffset OccurredAtUtc { get; }
+
+    public AuditEventOutcome Outcome { get; }
+
+    public string? CorrelationId { get; }
+
+    public string? Message { get; }
+
+    public string? MetadataJson { get; }
+}

--- a/src/Conductor.Core/Domain/ConductorEnums.cs
+++ b/src/Conductor.Core/Domain/ConductorEnums.cs
@@ -1,10 +1,48 @@
 namespace Conductor.Core.Domain;
 
+public enum AlertSeverity
+{
+    Info,
+    Warning,
+    Critical,
+}
+
+public enum AlertStatus
+{
+    Active,
+    Acknowledged,
+    Resolved,
+}
+
+public enum AuditEventOutcome
+{
+    Succeeded,
+    Failed,
+    Denied,
+}
+
+public enum BackgroundOperationStatus
+{
+    Queued,
+    Running,
+    Succeeded,
+    Failed,
+    Canceled,
+}
+
 public enum CredentialInheritanceMode
 {
     InheritDefault,
     SpecificSecret,
     None,
+}
+
+public enum EventSeverity
+{
+    Information,
+    Warning,
+    Error,
+    Critical,
 }
 
 public enum ExecutionMode
@@ -44,4 +82,39 @@ public enum ProjectStatus
 public enum RepositoryProvider
 {
     GitHub,
+}
+
+public enum ReportType
+{
+    DailyDeliveryBrief,
+    WeeklySoftwareFactory,
+    Project,
+    EngineeringReliability,
+}
+
+public enum RunStatus
+{
+    Queued,
+    Running,
+    Succeeded,
+    Failed,
+    Canceled,
+    TimedOut,
+}
+
+public enum SymphonyIssueStatus
+{
+    Unknown,
+    Queued,
+    Running,
+    Succeeded,
+    Failed,
+    Blocked,
+    NoSession,
+}
+
+public enum TrackedIssueState
+{
+    Open,
+    Closed,
 }

--- a/src/Conductor.Core/Domain/Events/Event.cs
+++ b/src/Conductor.Core/Domain/Events/Event.cs
@@ -1,0 +1,47 @@
+using Conductor.Core.Common;
+using Conductor.Core.Domain.Ids;
+
+namespace Conductor.Core.Domain.Events;
+
+public sealed class Event
+{
+    public Event(
+        EventId id,
+        SymphonyInstanceId? symphonyInstanceId,
+        RepositoryId? repositoryId,
+        int? issueNumber,
+        EventSeverity severity,
+        string eventType,
+        string message,
+        string? payloadJson,
+        DateTimeOffset occurredAtUtc)
+    {
+        Id = id;
+        SymphonyInstanceId = symphonyInstanceId;
+        RepositoryId = repositoryId;
+        IssueNumber = issueNumber.HasValue ? Guard.Positive(issueNumber.Value, nameof(issueNumber)) : null;
+        Severity = severity;
+        EventType = Guard.NotWhiteSpace(eventType, nameof(eventType));
+        Message = Guard.NotWhiteSpace(message, nameof(message));
+        PayloadJson = Guard.OptionalTrimmed(payloadJson);
+        OccurredAtUtc = occurredAtUtc;
+    }
+
+    public EventId Id { get; }
+
+    public SymphonyInstanceId? SymphonyInstanceId { get; }
+
+    public RepositoryId? RepositoryId { get; }
+
+    public int? IssueNumber { get; }
+
+    public EventSeverity Severity { get; }
+
+    public string EventType { get; }
+
+    public string Message { get; }
+
+    public string? PayloadJson { get; }
+
+    public DateTimeOffset OccurredAtUtc { get; }
+}

--- a/src/Conductor.Core/Domain/Ids/EntityIds.cs
+++ b/src/Conductor.Core/Domain/Ids/EntityIds.cs
@@ -1,8 +1,36 @@
 namespace Conductor.Core.Domain.Ids;
 
+public readonly record struct AlertId(Guid Value)
+{
+    public static AlertId New() => new(Guid.NewGuid());
+
+    public override string ToString() => Value.ToString("D");
+}
+
+public readonly record struct AuditEventId(Guid Value)
+{
+    public static AuditEventId New() => new(Guid.NewGuid());
+
+    public override string ToString() => Value.ToString("D");
+}
+
 public readonly record struct BackgroundOperationId(Guid Value)
 {
     public static BackgroundOperationId New() => new(Guid.NewGuid());
+
+    public override string ToString() => Value.ToString("D");
+}
+
+public readonly record struct EventId(Guid Value)
+{
+    public static EventId New() => new(Guid.NewGuid());
+
+    public override string ToString() => Value.ToString("D");
+}
+
+public readonly record struct InstanceSnapshotId(Guid Value)
+{
+    public static InstanceSnapshotId New() => new(Guid.NewGuid());
 
     public override string ToString() => Value.ToString("D");
 }
@@ -35,6 +63,13 @@ public readonly record struct RunId(Guid Value)
     public override string ToString() => Value.ToString("D");
 }
 
+public readonly record struct RunAttemptId(Guid Value)
+{
+    public static RunAttemptId New() => new(Guid.NewGuid());
+
+    public override string ToString() => Value.ToString("D");
+}
+
 public readonly record struct SecretId(Guid Value)
 {
     public static SecretId New() => new(Guid.NewGuid());
@@ -45,6 +80,13 @@ public readonly record struct SecretId(Guid Value)
 public readonly record struct SymphonyInstanceId(Guid Value)
 {
     public static SymphonyInstanceId New() => new(Guid.NewGuid());
+
+    public override string ToString() => Value.ToString("D");
+}
+
+public readonly record struct TrackedIssueId(Guid Value)
+{
+    public static TrackedIssueId New() => new(Guid.NewGuid());
 
     public override string ToString() => Value.ToString("D");
 }

--- a/src/Conductor.Core/Domain/Issues/TrackedIssue.cs
+++ b/src/Conductor.Core/Domain/Issues/TrackedIssue.cs
@@ -1,0 +1,91 @@
+using Conductor.Core.Common;
+using Conductor.Core.Domain.Ids;
+
+namespace Conductor.Core.Domain.Issues;
+
+public sealed class TrackedIssue
+{
+    public TrackedIssue(
+        TrackedIssueId id,
+        RepositoryId repositoryId,
+        int gitHubIssueNumber,
+        string title,
+        TrackedIssueState state,
+        string? labelsJson,
+        string? milestone,
+        string? assigneeLoginsJson,
+        Uri url,
+        SymphonyIssueStatus symphonyStatus,
+        RunStatus? lastRunStatus,
+        DateTimeOffset lastActivityAtUtc,
+        bool isBlocked,
+        string? blockerReason)
+    {
+        Id = id;
+        RepositoryId = repositoryId;
+        GitHubIssueNumber = Guard.Positive(gitHubIssueNumber, nameof(gitHubIssueNumber));
+        Title = Guard.NotWhiteSpace(title, nameof(title));
+        State = state;
+        LabelsJson = Guard.OptionalTrimmed(labelsJson);
+        Milestone = Guard.OptionalTrimmed(milestone);
+        AssigneeLoginsJson = Guard.OptionalTrimmed(assigneeLoginsJson);
+        Url = Guard.AbsoluteUri(url, nameof(url));
+        SymphonyStatus = symphonyStatus;
+        LastRunStatus = lastRunStatus;
+        LastActivityAtUtc = lastActivityAtUtc;
+        IsBlocked = isBlocked;
+        BlockerReason = isBlocked ? Guard.OptionalTrimmed(blockerReason) : null;
+    }
+
+    public TrackedIssueId Id { get; }
+
+    public RepositoryId RepositoryId { get; }
+
+    public int GitHubIssueNumber { get; }
+
+    public string Title { get; }
+
+    public TrackedIssueState State { get; }
+
+    public string? LabelsJson { get; }
+
+    public string? Milestone { get; }
+
+    public string? AssigneeLoginsJson { get; }
+
+    public Uri Url { get; }
+
+    public SymphonyIssueStatus SymphonyStatus { get; private set; }
+
+    public RunStatus? LastRunStatus { get; private set; }
+
+    public DateTimeOffset LastActivityAtUtc { get; private set; }
+
+    public bool IsBlocked { get; private set; }
+
+    public string? BlockerReason { get; private set; }
+
+    public void MarkBlocked(string blockerReason, DateTimeOffset blockedAtUtc)
+    {
+        IsBlocked = true;
+        BlockerReason = Guard.NotWhiteSpace(blockerReason, nameof(blockerReason));
+        LastActivityAtUtc = blockedAtUtc;
+    }
+
+    public void ClearBlocker(DateTimeOffset clearedAtUtc)
+    {
+        IsBlocked = false;
+        BlockerReason = null;
+        LastActivityAtUtc = clearedAtUtc;
+    }
+
+    public void UpdateSymphonyStatus(
+        SymphonyIssueStatus symphonyStatus,
+        RunStatus? lastRunStatus,
+        DateTimeOffset activityAtUtc)
+    {
+        SymphonyStatus = symphonyStatus;
+        LastRunStatus = lastRunStatus;
+        LastActivityAtUtc = activityAtUtc;
+    }
+}

--- a/src/Conductor.Core/Domain/Operations/BackgroundOperation.cs
+++ b/src/Conductor.Core/Domain/Operations/BackgroundOperation.cs
@@ -1,0 +1,100 @@
+using Conductor.Core.Common;
+using Conductor.Core.Domain.Ids;
+
+namespace Conductor.Core.Domain.Operations;
+
+public sealed class BackgroundOperation
+{
+    public BackgroundOperation(
+        BackgroundOperationId id,
+        string operationType,
+        DateTimeOffset createdAtUtc,
+        string? targetResourceType,
+        string? targetResourceId,
+        string? correlationId)
+    {
+        Id = id;
+        OperationType = Guard.NotWhiteSpace(operationType, nameof(operationType));
+        Status = BackgroundOperationStatus.Queued;
+        CreatedAtUtc = createdAtUtc;
+        TargetResourceType = Guard.OptionalTrimmed(targetResourceType);
+        TargetResourceId = Guard.OptionalTrimmed(targetResourceId);
+        CorrelationId = Guard.OptionalTrimmed(correlationId);
+    }
+
+    public BackgroundOperationId Id { get; }
+
+    public string OperationType { get; }
+
+    public BackgroundOperationStatus Status { get; private set; }
+
+    public DateTimeOffset CreatedAtUtc { get; }
+
+    public DateTimeOffset? StartedAtUtc { get; private set; }
+
+    public DateTimeOffset? CompletedAtUtc { get; private set; }
+
+    public string? TargetResourceType { get; }
+
+    public string? TargetResourceId { get; }
+
+    public string? CorrelationId { get; }
+
+    public string? Summary { get; private set; }
+
+    public string? ErrorDetail { get; private set; }
+
+    public void MarkRunning(DateTimeOffset startedAtUtc)
+    {
+        EnsureNotBeforeCreated(startedAtUtc, nameof(startedAtUtc));
+
+        Status = BackgroundOperationStatus.Running;
+        StartedAtUtc = startedAtUtc;
+    }
+
+    public void Succeed(DateTimeOffset completedAtUtc, string? summary)
+    {
+        Complete(BackgroundOperationStatus.Succeeded, completedAtUtc, summary, errorDetail: null);
+    }
+
+    public void Fail(DateTimeOffset completedAtUtc, string errorDetail)
+    {
+        Complete(
+            BackgroundOperationStatus.Failed,
+            completedAtUtc,
+            summary: null,
+            Guard.NotWhiteSpace(errorDetail, nameof(errorDetail)));
+    }
+
+    public void Cancel(DateTimeOffset completedAtUtc, string? summary)
+    {
+        Complete(BackgroundOperationStatus.Canceled, completedAtUtc, summary, errorDetail: null);
+    }
+
+    private void Complete(
+        BackgroundOperationStatus status,
+        DateTimeOffset completedAtUtc,
+        string? summary,
+        string? errorDetail)
+    {
+        EnsureNotBeforeCreated(completedAtUtc, nameof(completedAtUtc));
+
+        if (StartedAtUtc.HasValue && completedAtUtc < StartedAtUtc.Value)
+        {
+            throw new ArgumentOutOfRangeException(nameof(completedAtUtc), "Completed time cannot be before the operation started.");
+        }
+
+        Status = status;
+        CompletedAtUtc = completedAtUtc;
+        Summary = Guard.OptionalTrimmed(summary);
+        ErrorDetail = errorDetail;
+    }
+
+    private void EnsureNotBeforeCreated(DateTimeOffset value, string parameterName)
+    {
+        if (value < CreatedAtUtc)
+        {
+            throw new ArgumentOutOfRangeException(parameterName, "Timestamp cannot be before the operation was created.");
+        }
+    }
+}

--- a/src/Conductor.Core/Domain/Reports/Report.cs
+++ b/src/Conductor.Core/Domain/Reports/Report.cs
@@ -1,0 +1,56 @@
+using Conductor.Core.Common;
+using Conductor.Core.Domain.Ids;
+
+namespace Conductor.Core.Domain.Reports;
+
+public sealed class Report
+{
+    public Report(
+        ReportId id,
+        ReportType reportType,
+        string scope,
+        DateTimeOffset periodStartUtc,
+        DateTimeOffset periodEndUtc,
+        DateTimeOffset generatedAtUtc,
+        string markdown,
+        string html,
+        string? pdfPath,
+        string? metadataJson)
+    {
+        if (periodEndUtc < periodStartUtc)
+        {
+            throw new ArgumentOutOfRangeException(nameof(periodEndUtc), "Report period cannot end before it starts.");
+        }
+
+        Id = id;
+        ReportType = reportType;
+        Scope = Guard.NotWhiteSpace(scope, nameof(scope));
+        PeriodStartUtc = periodStartUtc;
+        PeriodEndUtc = periodEndUtc;
+        GeneratedAtUtc = generatedAtUtc;
+        Markdown = Guard.NotWhiteSpace(markdown, nameof(markdown));
+        Html = Guard.NotWhiteSpace(html, nameof(html));
+        PdfPath = Guard.OptionalTrimmed(pdfPath);
+        MetadataJson = Guard.OptionalTrimmed(metadataJson);
+    }
+
+    public ReportId Id { get; }
+
+    public ReportType ReportType { get; }
+
+    public string Scope { get; }
+
+    public DateTimeOffset PeriodStartUtc { get; }
+
+    public DateTimeOffset PeriodEndUtc { get; }
+
+    public DateTimeOffset GeneratedAtUtc { get; }
+
+    public string Markdown { get; }
+
+    public string Html { get; }
+
+    public string? PdfPath { get; }
+
+    public string? MetadataJson { get; }
+}

--- a/src/Conductor.Core/Domain/Runs/Run.cs
+++ b/src/Conductor.Core/Domain/Runs/Run.cs
@@ -1,0 +1,102 @@
+using Conductor.Core.Common;
+using Conductor.Core.Domain.Ids;
+
+namespace Conductor.Core.Domain.Runs;
+
+public sealed class Run
+{
+    public Run(
+        RunId id,
+        SymphonyInstanceId symphonyInstanceId,
+        RepositoryId repositoryId,
+        int gitHubIssueNumber,
+        string? symphonyRunId,
+        RunStatus status,
+        DateTimeOffset startedAtUtc,
+        DateTimeOffset? finishedAtUtc,
+        int attemptCount,
+        long tokenInput,
+        long tokenOutput,
+        string? errorSummary,
+        string? branchName,
+        Uri? pullRequestUrl)
+    {
+        if (finishedAtUtc.HasValue && finishedAtUtc.Value < startedAtUtc)
+        {
+            throw new ArgumentOutOfRangeException(nameof(finishedAtUtc), "Finished time cannot be before the run started.");
+        }
+
+        Id = id;
+        SymphonyInstanceId = symphonyInstanceId;
+        RepositoryId = repositoryId;
+        GitHubIssueNumber = Guard.Positive(gitHubIssueNumber, nameof(gitHubIssueNumber));
+        SymphonyRunId = Guard.OptionalTrimmed(symphonyRunId);
+        Status = status;
+        StartedAtUtc = startedAtUtc;
+        FinishedAtUtc = finishedAtUtc;
+        AttemptCount = Guard.NonNegative(attemptCount, nameof(attemptCount));
+        TokenInput = Guard.NonNegative(tokenInput, nameof(tokenInput));
+        TokenOutput = Guard.NonNegative(tokenOutput, nameof(tokenOutput));
+        ErrorSummary = Guard.OptionalTrimmed(errorSummary);
+        BranchName = Guard.OptionalTrimmed(branchName);
+        PullRequestUrl = Guard.OptionalAbsoluteUri(pullRequestUrl, nameof(pullRequestUrl));
+    }
+
+    public RunId Id { get; }
+
+    public SymphonyInstanceId SymphonyInstanceId { get; }
+
+    public RepositoryId RepositoryId { get; }
+
+    public int GitHubIssueNumber { get; }
+
+    public string? SymphonyRunId { get; }
+
+    public RunStatus Status { get; private set; }
+
+    public DateTimeOffset StartedAtUtc { get; }
+
+    public DateTimeOffset? FinishedAtUtc { get; private set; }
+
+    public int AttemptCount { get; private set; }
+
+    public long TokenInput { get; private set; }
+
+    public long TokenOutput { get; private set; }
+
+    public long TokenTotal => TokenInput + TokenOutput;
+
+    public string? ErrorSummary { get; private set; }
+
+    public string? BranchName { get; }
+
+    public Uri? PullRequestUrl { get; }
+
+    public void RecordAttempt()
+    {
+        AttemptCount++;
+    }
+
+    public void RecordTokenUsage(long tokenInput, long tokenOutput)
+    {
+        TokenInput = Guard.NonNegative(tokenInput, nameof(tokenInput));
+        TokenOutput = Guard.NonNegative(tokenOutput, nameof(tokenOutput));
+    }
+
+    public void Complete(RunStatus terminalStatus, DateTimeOffset finishedAtUtc, string? errorSummary)
+    {
+        if (terminalStatus is RunStatus.Queued or RunStatus.Running)
+        {
+            throw new ArgumentException("A terminal run status is required.", nameof(terminalStatus));
+        }
+
+        if (finishedAtUtc < StartedAtUtc)
+        {
+            throw new ArgumentOutOfRangeException(nameof(finishedAtUtc), "Finished time cannot be before the run started.");
+        }
+
+        Status = terminalStatus;
+        FinishedAtUtc = finishedAtUtc;
+        ErrorSummary = Guard.OptionalTrimmed(errorSummary);
+    }
+}

--- a/src/Conductor.Core/Domain/Runs/RunAttempt.cs
+++ b/src/Conductor.Core/Domain/Runs/RunAttempt.cs
@@ -1,0 +1,66 @@
+using Conductor.Core.Common;
+using Conductor.Core.Domain.Ids;
+
+namespace Conductor.Core.Domain.Runs;
+
+public sealed class RunAttempt
+{
+    public RunAttempt(
+        RunAttemptId id,
+        RunId runId,
+        int attemptNumber,
+        RunStatus status,
+        DateTimeOffset startedAtUtc,
+        DateTimeOffset? finishedAtUtc,
+        string? exitReason,
+        string? errorDetail)
+    {
+        if (finishedAtUtc.HasValue && finishedAtUtc.Value < startedAtUtc)
+        {
+            throw new ArgumentOutOfRangeException(nameof(finishedAtUtc), "Finished time cannot be before the attempt started.");
+        }
+
+        Id = id;
+        RunId = runId;
+        AttemptNumber = Guard.Positive(attemptNumber, nameof(attemptNumber));
+        Status = status;
+        StartedAtUtc = startedAtUtc;
+        FinishedAtUtc = finishedAtUtc;
+        ExitReason = Guard.OptionalTrimmed(exitReason);
+        ErrorDetail = Guard.OptionalTrimmed(errorDetail);
+    }
+
+    public RunAttemptId Id { get; }
+
+    public RunId RunId { get; }
+
+    public int AttemptNumber { get; }
+
+    public RunStatus Status { get; private set; }
+
+    public DateTimeOffset StartedAtUtc { get; }
+
+    public DateTimeOffset? FinishedAtUtc { get; private set; }
+
+    public string? ExitReason { get; private set; }
+
+    public string? ErrorDetail { get; private set; }
+
+    public void Complete(RunStatus terminalStatus, DateTimeOffset finishedAtUtc, string? exitReason, string? errorDetail)
+    {
+        if (terminalStatus is RunStatus.Queued or RunStatus.Running)
+        {
+            throw new ArgumentException("A terminal run status is required.", nameof(terminalStatus));
+        }
+
+        if (finishedAtUtc < StartedAtUtc)
+        {
+            throw new ArgumentOutOfRangeException(nameof(finishedAtUtc), "Finished time cannot be before the attempt started.");
+        }
+
+        Status = terminalStatus;
+        FinishedAtUtc = finishedAtUtc;
+        ExitReason = Guard.OptionalTrimmed(exitReason);
+        ErrorDetail = Guard.OptionalTrimmed(errorDetail);
+    }
+}

--- a/src/Conductor.Core/Domain/Snapshots/InstanceSnapshot.cs
+++ b/src/Conductor.Core/Domain/Snapshots/InstanceSnapshot.cs
@@ -1,11 +1,65 @@
+using Conductor.Core.Common;
 using Conductor.Core.Domain.Ids;
 
 namespace Conductor.Core.Domain.Snapshots;
 
-public sealed record InstanceSnapshot(
-    SymphonyInstanceId SymphonyInstanceId,
-    DateTimeOffset CapturedAtUtc,
-    InstanceHealthStatus HealthStatus,
-    string? HealthJson,
-    string? RuntimeJson,
-    string? StateJson);
+public sealed class InstanceSnapshot
+{
+    public InstanceSnapshot(
+        InstanceSnapshotId id,
+        SymphonyInstanceId symphonyInstanceId,
+        DateTimeOffset capturedAtUtc,
+        InstanceHealthStatus healthStatus,
+        string? healthJson,
+        string? runtimeJson,
+        string? stateJson,
+        int activeIssueCount,
+        int runningSessionCount,
+        int retryQueueCount,
+        int failedRunCount,
+        long tokenInputTotal,
+        long tokenOutputTotal)
+    {
+        Id = id;
+        SymphonyInstanceId = symphonyInstanceId;
+        CapturedAtUtc = capturedAtUtc;
+        HealthStatus = healthStatus;
+        HealthJson = Guard.OptionalTrimmed(healthJson);
+        RuntimeJson = Guard.OptionalTrimmed(runtimeJson);
+        StateJson = Guard.OptionalTrimmed(stateJson);
+        ActiveIssueCount = Guard.NonNegative(activeIssueCount, nameof(activeIssueCount));
+        RunningSessionCount = Guard.NonNegative(runningSessionCount, nameof(runningSessionCount));
+        RetryQueueCount = Guard.NonNegative(retryQueueCount, nameof(retryQueueCount));
+        FailedRunCount = Guard.NonNegative(failedRunCount, nameof(failedRunCount));
+        TokenInputTotal = Guard.NonNegative(tokenInputTotal, nameof(tokenInputTotal));
+        TokenOutputTotal = Guard.NonNegative(tokenOutputTotal, nameof(tokenOutputTotal));
+    }
+
+    public InstanceSnapshotId Id { get; }
+
+    public SymphonyInstanceId SymphonyInstanceId { get; }
+
+    public DateTimeOffset CapturedAtUtc { get; }
+
+    public InstanceHealthStatus HealthStatus { get; }
+
+    public string? HealthJson { get; }
+
+    public string? RuntimeJson { get; }
+
+    public string? StateJson { get; }
+
+    public int ActiveIssueCount { get; }
+
+    public int RunningSessionCount { get; }
+
+    public int RetryQueueCount { get; }
+
+    public int FailedRunCount { get; }
+
+    public long TokenInputTotal { get; }
+
+    public long TokenOutputTotal { get; }
+
+    public long TokenTotal => TokenInputTotal + TokenOutputTotal;
+}

--- a/tests/Conductor.Core.Tests/OperationalDomainEntityTests.cs
+++ b/tests/Conductor.Core.Tests/OperationalDomainEntityTests.cs
@@ -1,0 +1,237 @@
+using Conductor.Core.Domain;
+using Conductor.Core.Domain.Alerts;
+using Conductor.Core.Domain.Auditing;
+using Conductor.Core.Domain.Events;
+using Conductor.Core.Domain.Ids;
+using Conductor.Core.Domain.Issues;
+using Conductor.Core.Domain.Operations;
+using Conductor.Core.Domain.Reports;
+using Conductor.Core.Domain.Runs;
+using Conductor.Core.Domain.Snapshots;
+
+namespace Conductor.Core.Tests;
+
+public sealed class OperationalDomainEntityTests
+{
+    [Fact]
+    public void InstanceSnapshot_Trims_Raw_Json_And_Tracks_Aggregates()
+    {
+        var snapshot = new InstanceSnapshot(
+            InstanceSnapshotId.New(),
+            SymphonyInstanceId.New(),
+            DateTimeOffset.Parse("2026-04-29T01:00:00Z"),
+            InstanceHealthStatus.Warning,
+            "  {\"status\":\"warning\"}  ",
+            "   ",
+            null,
+            activeIssueCount: 8,
+            runningSessionCount: 2,
+            retryQueueCount: 1,
+            failedRunCount: 3,
+            tokenInputTotal: 120,
+            tokenOutputTotal: 30);
+
+        Assert.Equal("{\"status\":\"warning\"}", snapshot.HealthJson);
+        Assert.Null(snapshot.RuntimeJson);
+        Assert.Null(snapshot.StateJson);
+        Assert.Equal(150, snapshot.TokenTotal);
+    }
+
+    [Fact]
+    public void TrackedIssue_Normalizes_Metadata_And_Blocker_State()
+    {
+        var lastActivityAt = DateTimeOffset.Parse("2026-04-29T01:00:00Z");
+        var blockedAt = lastActivityAt.AddMinutes(10);
+        var clearedAt = blockedAt.AddMinutes(5);
+        var issue = new TrackedIssue(
+            TrackedIssueId.New(),
+            RepositoryId.New(),
+            gitHubIssueNumber: 14,
+            "  Implement entities  ",
+            TrackedIssueState.Open,
+            " [\"domain\"] ",
+            " Sprint 1 ",
+            " [\"nickbeau\"] ",
+            new Uri("https://github.com/ReleasedGroup/TheConductor/issues/14"),
+            SymphonyIssueStatus.Queued,
+            RunStatus.Running,
+            lastActivityAt,
+            isBlocked: false,
+            blockerReason: " ignored ");
+
+        issue.MarkBlocked(" Waiting on dependency ", blockedAt);
+        issue.ClearBlocker(clearedAt);
+        issue.UpdateSymphonyStatus(SymphonyIssueStatus.Succeeded, RunStatus.Succeeded, clearedAt.AddMinutes(1));
+
+        Assert.Equal("Implement entities", issue.Title);
+        Assert.Equal("[\"domain\"]", issue.LabelsJson);
+        Assert.Equal("Sprint 1", issue.Milestone);
+        Assert.Equal("[\"nickbeau\"]", issue.AssigneeLoginsJson);
+        Assert.False(issue.IsBlocked);
+        Assert.Null(issue.BlockerReason);
+        Assert.Equal(SymphonyIssueStatus.Succeeded, issue.SymphonyStatus);
+        Assert.Equal(RunStatus.Succeeded, issue.LastRunStatus);
+    }
+
+    [Fact]
+    public void Run_And_Attempt_Track_Terminal_State_And_Tokens()
+    {
+        var startedAt = DateTimeOffset.Parse("2026-04-29T01:00:00Z");
+        var finishedAt = startedAt.AddMinutes(8);
+        var run = new Run(
+            RunId.New(),
+            SymphonyInstanceId.New(),
+            RepositoryId.New(),
+            gitHubIssueNumber: 14,
+            symphonyRunId: "  symphony-run-1  ",
+            RunStatus.Running,
+            startedAt,
+            finishedAtUtc: null,
+            attemptCount: 0,
+            tokenInput: 0,
+            tokenOutput: 0,
+            errorSummary: null,
+            branchName: " symphony/14 ",
+            pullRequestUrl: new Uri("https://github.com/ReleasedGroup/TheConductor/pull/116"));
+        var attempt = new RunAttempt(
+            RunAttemptId.New(),
+            run.Id,
+            attemptNumber: 1,
+            RunStatus.Running,
+            startedAt,
+            finishedAtUtc: null,
+            exitReason: null,
+            errorDetail: null);
+
+        run.RecordAttempt();
+        run.RecordTokenUsage(400, 125);
+        attempt.Complete(RunStatus.Succeeded, finishedAt, " completed ", "  ");
+        run.Complete(RunStatus.Succeeded, finishedAt, errorSummary: null);
+
+        Assert.Equal("symphony-run-1", run.SymphonyRunId);
+        Assert.Equal("symphony/14", run.BranchName);
+        Assert.Equal(1, run.AttemptCount);
+        Assert.Equal(525, run.TokenTotal);
+        Assert.Equal(finishedAt, run.FinishedAtUtc);
+        Assert.Equal(RunStatus.Succeeded, attempt.Status);
+        Assert.Equal("completed", attempt.ExitReason);
+        Assert.Null(attempt.ErrorDetail);
+    }
+
+    [Fact]
+    public void Run_Rejects_Non_Terminal_Completion()
+    {
+        var startedAt = DateTimeOffset.Parse("2026-04-29T01:00:00Z");
+        var run = new Run(
+            RunId.New(),
+            SymphonyInstanceId.New(),
+            RepositoryId.New(),
+            gitHubIssueNumber: 14,
+            symphonyRunId: null,
+            RunStatus.Running,
+            startedAt,
+            finishedAtUtc: null,
+            attemptCount: 0,
+            tokenInput: 0,
+            tokenOutput: 0,
+            errorSummary: null,
+            branchName: null,
+            pullRequestUrl: null);
+
+        Assert.Throws<ArgumentException>(() =>
+            run.Complete(RunStatus.Running, startedAt.AddMinutes(1), errorSummary: null));
+    }
+
+    [Fact]
+    public void Event_Alert_Report_Audit_And_BackgroundOperation_Capture_Operational_Metadata()
+    {
+        var occurredAt = DateTimeOffset.Parse("2026-04-29T01:00:00Z");
+        var repositoryId = RepositoryId.New();
+        var instanceId = SymphonyInstanceId.New();
+        var runId = RunId.New();
+        var recordedEvent = new Event(
+            EventId.New(),
+            instanceId,
+            repositoryId,
+            issueNumber: 14,
+            EventSeverity.Warning,
+            "  RunFailed  ",
+            "  Attempt failed  ",
+            " {\"attempt\":1} ",
+            occurredAt);
+        var alert = new Alert(
+            AlertId.New(),
+            AlertSeverity.Critical,
+            "  run-monitor  ",
+            "  Repeated run failures  ",
+            "  Inspect attempt logs  ",
+            occurredAt,
+            instanceId,
+            repositoryId,
+            runId,
+            gitHubIssueNumber: 14);
+        var report = new Report(
+            ReportId.New(),
+            ReportType.WeeklySoftwareFactory,
+            " all-projects ",
+            occurredAt.AddDays(-7),
+            occurredAt,
+            occurredAt,
+            " # Weekly ",
+            " <h1>Weekly</h1> ",
+            " reports/weekly.html ",
+            " {\"source\":\"test\"} ");
+        var auditEvent = new AuditEvent(
+            AuditEventId.New(),
+            "  nickbeau  ",
+            "  ResolveAlert  ",
+            "  Alert  ",
+            alert.Id.ToString(),
+            occurredAt.AddMinutes(1),
+            AuditEventOutcome.Succeeded,
+            " correlation-1 ",
+            "  Resolved from alert center  ",
+            null);
+        var operation = new BackgroundOperation(
+            BackgroundOperationId.New(),
+            "  GenerateReport  ",
+            occurredAt,
+            "Report",
+            report.Id.ToString(),
+            " correlation-1 ");
+
+        alert.Acknowledge();
+        alert.Resolve(occurredAt.AddMinutes(2), " recovered ");
+        operation.MarkRunning(occurredAt.AddMinutes(1));
+        operation.Succeed(occurredAt.AddMinutes(3), " completed ");
+
+        Assert.Equal("RunFailed", recordedEvent.EventType);
+        Assert.Equal("Attempt failed", recordedEvent.Message);
+        Assert.Equal("{\"attempt\":1}", recordedEvent.PayloadJson);
+        Assert.Equal(AlertStatus.Resolved, alert.Status);
+        Assert.Equal("recovered", alert.ResolutionNote);
+        Assert.Equal("all-projects", report.Scope);
+        Assert.Equal("# Weekly", report.Markdown);
+        Assert.Equal("<h1>Weekly</h1>", report.Html);
+        Assert.Equal("{\"source\":\"test\"}", report.MetadataJson);
+        Assert.Equal("nickbeau", auditEvent.ActorUserId);
+        Assert.Equal("ResolveAlert", auditEvent.Action);
+        Assert.Equal(BackgroundOperationStatus.Succeeded, operation.Status);
+        Assert.Equal("completed", operation.Summary);
+    }
+
+    [Fact]
+    public void BackgroundOperation_Rejects_Out_Of_Order_Timestamps()
+    {
+        var createdAt = DateTimeOffset.Parse("2026-04-29T01:00:00Z");
+        var operation = new BackgroundOperation(
+            BackgroundOperationId.New(),
+            "ProvisionInstance",
+            createdAt,
+            targetResourceType: null,
+            targetResourceId: null,
+            correlationId: null);
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => operation.MarkRunning(createdAt.AddSeconds(-1)));
+    }
+}


### PR DESCRIPTION
Closes #14.

## Summary
- Adds strongly typed IDs and status enums for operational domain records.
- Expands `InstanceSnapshot` and adds `TrackedIssue`, `Run`, `RunAttempt`, `Event`, `Alert`, `Report`, `AuditEvent`, and `BackgroundOperation` entities.
- Adds focused core-domain tests for normalization, counters, lifecycle transitions, terminal status validation, and timestamp ordering.

## Validation
- `dotnet restore Conductor.slnx`
- `dotnet build Conductor.slnx --no-restore`
- `dotnet test Conductor.slnx --no-build --verbosity normal`
- `dotnet format Conductor.slnx --verify-no-changes --no-restore`