### PR TITLE
[codex] Build repository health heatmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Conductor is the fleet control layer above Symphony. It is being built as a .NET
 ## Solution Layout
 
 - `Conductor.slnx` is the .NET solution entry point.
-- `src/Conductor.Host` contains the Blazor Web App host, health endpoints, worker registration, and the placeholder dashboard.
+- `src/Conductor.Host` contains the Blazor Web App host, health endpoints, worker registration, the dashboard, and reusable dashboard components.
 - `src/Conductor.Core` contains domain types, value objects, and infrastructure-facing contracts, including the workflow profile, release artifact, and secret descriptor entities.
 - `src/Conductor.Infrastructure.Persistence.Sqlite` contains the EF Core SQLite persistence shell.
 - `src/Conductor.Infrastructure.*` projects contain adapter boundaries for GitHub, Symphony HTTP, runners, secrets, reporting, and notifications.
@@ -26,4 +26,4 @@ dotnet format Conductor.slnx --no-restore --verify-no-changes
 dotnet run --project src/Conductor.Host/Conductor.Host.csproj
 ```
 
-The root route (`/`) serves the placeholder dashboard for local startup checks. The same startup baseline also exposes `/health/live` and `/health/ready`.
+The root route (`/`) serves the dashboard baseline for local startup checks, including a reusable repository orchestration health heatmap populated with starter projection data. The same startup baseline also exposes `/health/live` and `/health/ready`.

--- a/src/Conductor.Host/Components/Dashboard/HealthHeatmap.razor
+++ b/src/Conductor.Host/Components/Dashboard/HealthHeatmap.razor
@@ -1,0 +1,184 @@
+@using System.Globalization
+
+<section class="health-heatmap" aria-labelledby="@headingId">
+    <header class="health-heatmap-header">
+        <div>
+            <p class="eyebrow">Orchestration health</p>
+            <h2 id="@headingId">@Title</h2>
+            @if (!string.IsNullOrWhiteSpace(Description))
+            {
+                <p>@Description</p>
+            }
+        </div>
+    </header>
+
+    @if (!HasBuckets)
+    {
+        <p class="empty-state">No repository health buckets are available yet.</p>
+    }
+    else
+    {
+        <div class="heatmap-summary" aria-label="Health status summary">
+            @foreach (StatusSummary summary in statusSummaries)
+            {
+                <span class="heatmap-legend-item">
+                    <span class="@GetLegendSwatchClass(summary.Status)" aria-hidden="true"></span>
+                    <span>@GetStatusLabel(summary.Status)</span>
+                    <strong>@summary.Count.ToString(CultureInfo.InvariantCulture)</strong>
+                </span>
+            }
+        </div>
+
+        <div class="heatmap-table-wrap">
+            <table class="heatmap-grid">
+                <caption class="sr-only">@Title</caption>
+                <thead>
+                    <tr>
+                        <th scope="col">Repository</th>
+                        @foreach (string period in periods)
+                        {
+                            <th scope="col">@period</th>
+                        }
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (HeatmapRow row in rows)
+                    {
+                        <tr>
+                            <th scope="row">@row.RepositoryName</th>
+                            @foreach (string period in periods)
+                            {
+                                bool hasBucket = row.Buckets.TryGetValue(period, out HealthHeatmapBucket? bucket);
+
+                                <td>
+                                    @if (hasBucket && bucket is not null)
+                                    {
+                                        <span class="@GetCellClass(bucket.Status)" aria-label="@GetCellLabel(bucket)">
+                                            <span class="heatmap-cell-status">@GetShortStatusLabel(bucket.Status)</span>
+                                            <span class="heatmap-cell-score">@GetScoreText(bucket.Score)</span>
+                                        </span>
+                                    }
+                                    else
+                                    {
+                                        <span class="heatmap-cell heatmap-cell-empty" aria-label="@($"{row.RepositoryName} {period}: No data")">
+                                            <span class="heatmap-cell-status">None</span>
+                                            <span class="heatmap-cell-score">-</span>
+                                        </span>
+                                    }
+                                </td>
+                            }
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+    }
+</section>
+
+@code {
+    private static readonly HealthHeatmapStatus[] StatusOrder =
+    [
+        HealthHeatmapStatus.Healthy,
+        HealthHeatmapStatus.Warning,
+        HealthHeatmapStatus.Critical,
+        HealthHeatmapStatus.Offline,
+    ];
+
+    private readonly string headingId = $"health-heatmap-{Guid.NewGuid():N}";
+    private string[] periods = [];
+    private HeatmapRow[] rows = [];
+    private StatusSummary[] statusSummaries = [];
+
+    [Parameter]
+    public string Title { get; set; } = "Repository orchestration health";
+
+    [Parameter]
+    public string? Description { get; set; } = "Repository health over the latest orchestration windows.";
+
+    [Parameter]
+    public IReadOnlyList<HealthHeatmapBucket>? Buckets { get; set; }
+
+    private bool HasBuckets => periods.Length > 0 && rows.Length > 0;
+
+    protected override void OnParametersSet()
+    {
+        HealthHeatmapBucket[] validBuckets = (Buckets ?? [])
+            .Where(bucket => !string.IsNullOrWhiteSpace(bucket.RepositoryName)
+                && !string.IsNullOrWhiteSpace(bucket.PeriodLabel))
+            .ToArray();
+
+        periods = validBuckets
+            .Select(bucket => bucket.PeriodLabel)
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+
+        rows = validBuckets
+            .GroupBy(bucket => bucket.RepositoryName, StringComparer.Ordinal)
+            .Select(group => new HeatmapRow(
+                group.Key,
+                group.GroupBy(bucket => bucket.PeriodLabel, StringComparer.Ordinal)
+                    .ToDictionary(
+                        periodGroup => periodGroup.Key,
+                        periodGroup => periodGroup.Last(),
+                        StringComparer.Ordinal)))
+            .ToArray();
+
+        statusSummaries = StatusOrder
+            .Select(status => new StatusSummary(
+                status,
+                validBuckets.Count(bucket => bucket.Status == status)))
+            .ToArray();
+    }
+
+    private static string GetCellClass(HealthHeatmapStatus status) =>
+        $"heatmap-cell heatmap-cell--{GetStatusCssName(status)}";
+
+    private static string GetLegendSwatchClass(HealthHeatmapStatus status) =>
+        $"heatmap-legend-swatch heatmap-cell--{GetStatusCssName(status)}";
+
+    private static string GetCellLabel(HealthHeatmapBucket bucket)
+    {
+        string detail = string.IsNullOrWhiteSpace(bucket.Detail) ? "No detail recorded." : bucket.Detail;
+
+        return $"{bucket.RepositoryName} {bucket.PeriodLabel}: {GetStatusLabel(bucket.Status)} with health score {GetScoreText(bucket.Score)}. {detail}";
+    }
+
+    private static string GetStatusLabel(HealthHeatmapStatus status) =>
+        status switch
+        {
+            HealthHeatmapStatus.Healthy => "Healthy",
+            HealthHeatmapStatus.Warning => "Warning",
+            HealthHeatmapStatus.Critical => "Critical",
+            HealthHeatmapStatus.Offline => "Offline",
+            _ => "Unknown",
+        };
+
+    private static string GetShortStatusLabel(HealthHeatmapStatus status) =>
+        status switch
+        {
+            HealthHeatmapStatus.Healthy => "OK",
+            HealthHeatmapStatus.Warning => "Warn",
+            HealthHeatmapStatus.Critical => "Crit",
+            HealthHeatmapStatus.Offline => "Off",
+            _ => "Unknown",
+        };
+
+    private static string GetStatusCssName(HealthHeatmapStatus status) =>
+        status switch
+        {
+            HealthHeatmapStatus.Healthy => "healthy",
+            HealthHeatmapStatus.Warning => "warning",
+            HealthHeatmapStatus.Critical => "critical",
+            HealthHeatmapStatus.Offline => "offline",
+            _ => "unknown",
+        };
+
+    private static string GetScoreText(int score) =>
+        Math.Clamp(score, 0, 100).ToString(CultureInfo.InvariantCulture);
+
+    private sealed record HeatmapRow(
+        string RepositoryName,
+        IReadOnlyDictionary<string, HealthHeatmapBucket> Buckets);
+
+    private readonly record struct StatusSummary(HealthHeatmapStatus Status, int Count);
+}

--- a/src/Conductor.Host/Components/Dashboard/HealthHeatmapBucket.cs
+++ b/src/Conductor.Host/Components/Dashboard/HealthHeatmapBucket.cs
@@ -1,0 +1,8 @@
+namespace Conductor.Host.Components.Dashboard;
+
+public sealed record HealthHeatmapBucket(
+    string RepositoryName,
+    string PeriodLabel,
+    HealthHeatmapStatus Status,
+    int Score,
+    string Detail);

--- a/src/Conductor.Host/Components/Dashboard/HealthHeatmapStatus.cs
+++ b/src/Conductor.Host/Components/Dashboard/HealthHeatmapStatus.cs
@@ -1,0 +1,9 @@
+namespace Conductor.Host.Components.Dashboard;
+
+public enum HealthHeatmapStatus
+{
+    Healthy,
+    Warning,
+    Critical,
+    Offline,
+}

--- a/src/Conductor.Host/Components/Pages/Home.razor
+++ b/src/Conductor.Host/Components/Pages/Home.razor
@@ -8,7 +8,7 @@
             <p class="eyebrow">Fleet overview</p>
             <h1>Conductor Dashboard</h1>
         </div>
-        <span class="status-pill">Sprint 0 scaffold</span>
+        <span class="status-pill">Sprint 2 dashboard</span>
     </header>
 
     <section class="metric-grid" aria-label="Dashboard metrics">
@@ -22,10 +22,12 @@
         }
     </section>
 
+    <HealthHeatmap Buckets="HealthBuckets" />
+
     <section class="activity-panel">
         <div>
             <h2>Operational baseline</h2>
-            <p>The host is running with the initial project, persistence, and test structure in place.</p>
+            <p>The host is running with the initial project, persistence, dashboard, and test structure in place.</p>
         </div>
         <ul>
             @foreach (string indicator in Indicators)
@@ -64,6 +66,34 @@
         ("Alerts", "0", "In-app rules not active yet"),
     ];
 
+    private static readonly HealthHeatmapBucket[] HealthBuckets =
+    [
+        new("Conductor", "08:00", HealthHeatmapStatus.Healthy, 99, "All orchestration checks completed."),
+        new("Conductor", "10:00", HealthHeatmapStatus.Healthy, 98, "Workers and health probes are responsive."),
+        new("Conductor", "12:00", HealthHeatmapStatus.Warning, 82, "One repository sync ran behind schedule."),
+        new("Conductor", "14:00", HealthHeatmapStatus.Healthy, 97, "Backlog recovered after retry."),
+        new("Conductor", "16:00", HealthHeatmapStatus.Healthy, 99, "No active orchestration alerts."),
+        new("Conductor", "18:00", HealthHeatmapStatus.Healthy, 100, "All repositories are within policy."),
+        new("Symphony", "08:00", HealthHeatmapStatus.Healthy, 95, "Runtime checks passed."),
+        new("Symphony", "10:00", HealthHeatmapStatus.Warning, 76, "Release polling reported elevated latency."),
+        new("Symphony", "12:00", HealthHeatmapStatus.Warning, 73, "Two issue sync jobs are queued."),
+        new("Symphony", "14:00", HealthHeatmapStatus.Critical, 41, "Workflow dispatch failed repeatedly."),
+        new("Symphony", "16:00", HealthHeatmapStatus.Warning, 78, "Dispatch recovered with retry backlog."),
+        new("Symphony", "18:00", HealthHeatmapStatus.Healthy, 93, "Queue returned to normal."),
+        new("Release Portal", "08:00", HealthHeatmapStatus.Offline, 0, "No agent heartbeat received."),
+        new("Release Portal", "10:00", HealthHeatmapStatus.Critical, 38, "Repository credentials need rotation."),
+        new("Release Portal", "12:00", HealthHeatmapStatus.Warning, 69, "Credential rotation started."),
+        new("Release Portal", "14:00", HealthHeatmapStatus.Warning, 72, "Pending PR checks are draining."),
+        new("Release Portal", "16:00", HealthHeatmapStatus.Healthy, 91, "Credential rotation completed."),
+        new("Release Portal", "18:00", HealthHeatmapStatus.Healthy, 94, "Orchestration checks are current."),
+        new("Operations Docs", "08:00", HealthHeatmapStatus.Healthy, 96, "Documentation validation passed."),
+        new("Operations Docs", "10:00", HealthHeatmapStatus.Healthy, 96, "No blocked documentation runs."),
+        new("Operations Docs", "12:00", HealthHeatmapStatus.Healthy, 97, "Review queue is clear."),
+        new("Operations Docs", "14:00", HealthHeatmapStatus.Healthy, 96, "Scheduled checks completed."),
+        new("Operations Docs", "16:00", HealthHeatmapStatus.Warning, 80, "One stale branch requires attention."),
+        new("Operations Docs", "18:00", HealthHeatmapStatus.Healthy, 95, "Stale branch warning cleared."),
+    ];
+
     private static readonly string[] Indicators =
     [
         "Blazor Web App host",
@@ -74,7 +104,7 @@
 
     private static readonly (string Label, string Route, string State)[] StartupChecks =
     [
-        ("Dashboard route", "/", "Placeholder served"),
+        ("Dashboard route", "/", "Dashboard served"),
         ("Live health", "/health/live", "Probe available"),
         ("Ready health", "/health/ready", "Probe available"),
     ];

--- a/src/Conductor.Host/Components/_Imports.razor
+++ b/src/Conductor.Host/Components/_Imports.razor
@@ -5,4 +5,5 @@
 @using static Microsoft.AspNetCore.Components.Web.RenderMode
 @using Conductor.Host
 @using Conductor.Host.Components
+@using Conductor.Host.Components.Dashboard
 @using Conductor.Host.Components.Layout

--- a/src/Conductor.Host/wwwroot/app.css
+++ b/src/Conductor.Host/wwwroot/app.css
@@ -181,6 +181,161 @@ h2 {
   color: #dbe6ee;
 }
 
+.health-heatmap {
+  display: grid;
+  gap: 18px;
+  padding: 24px;
+  border: 1px solid #2b3138;
+  border-radius: 8px;
+  background: #151a1f;
+}
+
+.health-heatmap-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.health-heatmap-header p:not(.eyebrow) {
+  margin-bottom: 0;
+  color: #aeb9c5;
+}
+
+.heatmap-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.heatmap-legend-item {
+  display: inline-flex;
+  align-items: center;
+  min-height: 34px;
+  gap: 8px;
+  padding: 6px 10px;
+  border: 1px solid #2b3138;
+  border-radius: 6px;
+  background: #1b2228;
+  color: #dbe6ee;
+  font-size: 0.85rem;
+}
+
+.heatmap-legend-item strong {
+  color: #ffffff;
+  font-size: 0.9rem;
+}
+
+.heatmap-legend-swatch {
+  width: 12px;
+  height: 12px;
+  border-radius: 3px;
+  border-width: 1px;
+  border-style: solid;
+}
+
+.heatmap-table-wrap {
+  overflow-x: auto;
+}
+
+.heatmap-grid {
+  width: 100%;
+  min-width: 720px;
+  table-layout: fixed;
+  border-collapse: separate;
+  border-spacing: 6px;
+}
+
+.heatmap-grid th {
+  color: #aeb9c5;
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-align: left;
+}
+
+.heatmap-grid thead th:not(:first-child) {
+  text-align: center;
+}
+
+.heatmap-grid tbody th {
+  width: 180px;
+  padding-right: 10px;
+  color: #e6edf3;
+}
+
+.heatmap-grid td {
+  padding: 0;
+}
+
+.heatmap-cell {
+  display: grid;
+  align-content: center;
+  justify-items: center;
+  min-width: 64px;
+  min-height: 54px;
+  gap: 3px;
+  padding: 6px;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  text-align: center;
+}
+
+.heatmap-cell-status {
+  color: currentColor;
+  font-size: 0.68rem;
+  font-weight: 800;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+.heatmap-cell-score {
+  font-size: 1rem;
+  font-weight: 800;
+  line-height: 1;
+}
+
+.heatmap-cell--healthy {
+  border-color: #2d6f5e;
+  background: #12382d;
+  color: #9ee7d7;
+}
+
+.heatmap-cell--warning {
+  border-color: #8a6823;
+  background: #3d3015;
+  color: #f2c14e;
+}
+
+.heatmap-cell--critical {
+  border-color: #904247;
+  background: #452022;
+  color: #ffb4ab;
+}
+
+.heatmap-cell--offline {
+  border-color: #53606d;
+  background: #272d34;
+  color: #c7d0d9;
+}
+
+.heatmap-cell-empty {
+  border-color: #2b3138;
+  background: #151a1f;
+  color: #74808d;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .startup-panel {
   display: grid;
   gap: 18px;
@@ -261,6 +416,14 @@ h2 {
   .activity-panel,
   .startup-panel dl {
     grid-template-columns: 1fr;
+  }
+
+  .health-heatmap-header {
+    display: grid;
+  }
+
+  .heatmap-grid {
+    min-width: 640px;
   }
 
   .dashboard-header {

--- a/tests/Conductor.Blazor.Tests/DashboardSmokeTests.cs
+++ b/tests/Conductor.Blazor.Tests/DashboardSmokeTests.cs
@@ -14,6 +14,8 @@ public sealed class DashboardSmokeTests
 
         Assert.Contains("Conductor Dashboard", dashboard.Markup, StringComparison.Ordinal);
         Assert.Contains("SQLite persistence registration", dashboard.Markup, StringComparison.Ordinal);
+        Assert.Contains("Repository orchestration health", dashboard.Markup, StringComparison.Ordinal);
+        Assert.Contains("Release Portal", dashboard.Markup, StringComparison.Ordinal);
         Assert.Contains("Startup verification", dashboard.Markup, StringComparison.Ordinal);
         Assert.Contains("/health/live", dashboard.Markup, StringComparison.Ordinal);
     }

--- a/tests/Conductor.Blazor.Tests/HealthHeatmapTests.cs
+++ b/tests/Conductor.Blazor.Tests/HealthHeatmapTests.cs
@@ -1,0 +1,51 @@
+using Bunit;
+using Conductor.Host.Components.Dashboard;
+
+namespace Conductor.Blazor.Tests;
+
+public sealed class HealthHeatmapTests
+{
+    [Fact]
+    public void HealthHeatmap_Renders_Buckets_Across_Periods()
+    {
+        using BunitContext context = new();
+        HealthHeatmapBucket[] buckets =
+        [
+            new("Billing API", "Mon", HealthHeatmapStatus.Healthy, 99, "All jobs completed."),
+            new("Billing API", "Tue", HealthHeatmapStatus.Warning, 74, "Retry queue elevated."),
+            new("Portal", "Mon", HealthHeatmapStatus.Critical, 38, "Deployment blocked."),
+        ];
+
+        IRenderedComponent<HealthHeatmap> component = context.Render<HealthHeatmap>(parameters => parameters
+            .Add(component => component.Title, "Repository orchestration health")
+            .Add(component => component.Description, "Last 48 hours")
+            .Add(component => component.Buckets, buckets));
+
+        Assert.Contains("Repository orchestration health", component.Markup, StringComparison.Ordinal);
+        Assert.Contains("Last 48 hours", component.Markup, StringComparison.Ordinal);
+        Assert.Contains("Billing API", component.Markup, StringComparison.Ordinal);
+        Assert.Contains("Portal", component.Markup, StringComparison.Ordinal);
+        Assert.Contains("Mon", component.Markup, StringComparison.Ordinal);
+        Assert.Contains("Tue", component.Markup, StringComparison.Ordinal);
+        Assert.Contains("Warn", component.Markup, StringComparison.Ordinal);
+        Assert.Contains("Crit", component.Markup, StringComparison.Ordinal);
+        Assert.Contains(
+            "Billing API Tue: Warning with health score 74. Retry queue elevated.",
+            component.Markup,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void HealthHeatmap_Renders_Empty_State_Without_Buckets()
+    {
+        using BunitContext context = new();
+
+        IRenderedComponent<HealthHeatmap> component = context.Render<HealthHeatmap>();
+
+        Assert.Contains(
+            "No repository health buckets are available yet.",
+            component.Markup,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain("<table", component.Markup, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## Summary
- Add a reusable Blazor `HealthHeatmap` component for repository orchestration health over time.
- Wire the heatmap into the dashboard with starter projection data and accessible status labels.
- Add bUnit coverage for populated and empty heatmap states, and update README dashboard notes.

## Validation
- `dotnet restore Conductor.slnx`
- `dotnet build Conductor.slnx --no-restore --warnaserror` (0 warnings)
- `dotnet test Conductor.slnx --no-build`
- `dotnet format Conductor.slnx --no-restore --verify-no-changes`
- Dashboard smoke check at `http://localhost:5122` returned 200 and contained the heatmap markup.

Closes #22