### PR TITLE
Build needs attention dashboard panel

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -5,3 +5,7 @@ Status: Planned
 This guide will explain how operators use Conductor once the application shell and workflows are implemented.
 
 Initial user workflows will cover dashboard review, repository import, instance registration, lifecycle actions, alert triage, and report generation.
+
+## Dashboard Review
+
+The dashboard includes a needs-attention panel for active critical and warning items. Each row shows the affected repository or Symphony instance, the current severity, the reason it needs attention, and a link to the source area for follow-up.

--- a/src/Conductor.Core/Application/Dashboard/DashboardAttentionItem.cs
+++ b/src/Conductor.Core/Application/Dashboard/DashboardAttentionItem.cs
@@ -1,0 +1,20 @@
+using Conductor.Core.Domain;
+
+namespace Conductor.Core.Application.Dashboard;
+
+public sealed class DashboardAttentionItem
+{
+    public AlertSeverity Severity { get; init; } = AlertSeverity.Warning;
+
+    public string SourceName { get; init; } = string.Empty;
+
+    public string Summary { get; init; } = string.Empty;
+
+    public string TargetHref { get; init; } = "#";
+
+    public string TargetKind { get; init; } = "source";
+
+    public DateTimeOffset CreatedAtUtc { get; init; } = DateTimeOffset.UnixEpoch;
+
+    public string AgeLabel { get; init; } = string.Empty;
+}

--- a/src/Conductor.Core/Application/Dashboard/DashboardProjection.cs
+++ b/src/Conductor.Core/Application/Dashboard/DashboardProjection.cs
@@ -6,5 +6,7 @@ public sealed class DashboardProjection
 
     public IReadOnlyList<DashboardMetric> Metrics { get; init; } = Array.Empty<DashboardMetric>();
 
+    public IReadOnlyList<DashboardAttentionItem> AttentionItems { get; init; } = Array.Empty<DashboardAttentionItem>();
+
     public static DashboardProjection Empty { get; } = new();
 }

--- a/src/Conductor.Host/Components/Dashboard/NeedsAttentionPanel.razor
+++ b/src/Conductor.Host/Components/Dashboard/NeedsAttentionPanel.razor
@@ -1,0 +1,78 @@
+@using System.Globalization
+@using Conductor.Core.Application.Dashboard
+@using Conductor.Core.Domain
+
+<section class="needs-attention-panel" aria-labelledby="@headingId">
+    <header class="needs-attention-header">
+        <div class="needs-attention-title">
+            <h2 id="@headingId">Needs attention</h2>
+            <span class="attention-count">@attentionItems.Count</span>
+        </div>
+        <a class="panel-link" href="/alerts">View all</a>
+    </header>
+
+    @if (attentionItems.Count == 0)
+    {
+        <div class="attention-empty-state">
+            <strong>All clear</strong>
+            <span>No critical or warning items are active.</span>
+        </div>
+    }
+    else
+    {
+        <ul class="attention-list">
+            @foreach (DashboardAttentionItem item in attentionItems)
+            {
+                <li class="@GetSeverityClass(item.Severity)">
+                    <a class="attention-item" href="@item.TargetHref" aria-label="@BuildItemLabel(item)">
+                        <span class="severity-marker" aria-hidden="true">@GetSeverityMarker(item.Severity)</span>
+                        <span class="attention-copy">
+                            <span class="attention-title-row">
+                                <strong>@item.SourceName</strong>
+                                <span class="severity-badge">@item.Severity</span>
+                            </span>
+                            <span class="attention-summary">@item.Summary</span>
+                        </span>
+                        <time datetime="@item.CreatedAtUtc.ToString("O", CultureInfo.InvariantCulture)">@item.AgeLabel</time>
+                    </a>
+                </li>
+            }
+        </ul>
+    }
+</section>
+
+@code {
+    private readonly string headingId = $"needs-attention-{Guid.NewGuid():N}";
+    private IReadOnlyList<DashboardAttentionItem> attentionItems = [];
+
+    [Parameter]
+    public IReadOnlyList<DashboardAttentionItem> Items { get; set; } = [];
+
+    protected override void OnParametersSet()
+    {
+        attentionItems = Items
+            .Where(item => item.Severity is AlertSeverity.Critical or AlertSeverity.Warning)
+            .OrderBy(item => item.Severity is AlertSeverity.Critical ? 0 : 1)
+            .ThenByDescending(item => item.CreatedAtUtc)
+            .ToArray();
+    }
+
+    private static string GetSeverityClass(AlertSeverity severity) =>
+        severity switch
+        {
+            AlertSeverity.Critical => "attention-severity-critical",
+            AlertSeverity.Warning => "attention-severity-warning",
+            _ => "attention-severity-info",
+        };
+
+    private static string GetSeverityMarker(AlertSeverity severity) =>
+        severity switch
+        {
+            AlertSeverity.Critical => "!!",
+            AlertSeverity.Warning => "!",
+            _ => "i",
+        };
+
+    private static string BuildItemLabel(DashboardAttentionItem item) =>
+        $"Open {item.TargetKind} {item.SourceName}: {item.Severity} - {item.Summary}";
+}

--- a/src/Conductor.Host/Components/Pages/Home.razor
+++ b/src/Conductor.Host/Components/Pages/Home.razor
@@ -44,44 +44,55 @@
         </section>
     }
 
-    <HealthHeatmap Buckets="HealthBuckets" />
+    <section class="dashboard-body">
+        <div class="dashboard-stack">
+            <HealthHeatmap Buckets="HealthBuckets" />
 
-    <section class="activity-panel">
-        <div>
-            <h2>Operational baseline</h2>
-            <p>The host is running with the initial project, persistence, dashboard, and test structure in place.</p>
-        </div>
-        <ul>
-            @foreach (string indicator in Indicators)
-            {
-                <li>@indicator</li>
-            }
-        </ul>
-    </section>
-
-    <section class="startup-panel" aria-label="Startup verification">
-        <div>
-            <h2>Startup verification</h2>
-            <p>The local host can be checked from the dashboard route and the built-in health probes.</p>
-        </div>
-        <dl>
-            @foreach ((string Label, string Route, string State) check in StartupChecks)
-            {
+            <section class="activity-panel">
                 <div>
-                    <dt>@check.Label</dt>
-                    <dd>
-                        <code>@check.Route</code>
-                        <span>@check.State</span>
-                    </dd>
+                    <h2>Operational baseline</h2>
+                    <p>The host is running with the initial project, persistence, dashboard, and test structure in place.</p>
                 </div>
-            }
-        </dl>
+                <ul>
+                    @foreach (string indicator in Indicators)
+                    {
+                        <li>@indicator</li>
+                    }
+                </ul>
+            </section>
+
+            <section class="startup-panel" aria-label="Startup verification">
+                <div>
+                    <h2>Startup verification</h2>
+                    <p>The local host can be checked from the dashboard route and the built-in health probes.</p>
+                </div>
+                <dl>
+                    @foreach ((string Label, string Route, string State) check in StartupChecks)
+                    {
+                        <div>
+                            <dt>@check.Label</dt>
+                            <dd>
+                                <code>@check.Route</code>
+                                <span>@check.State</span>
+                            </dd>
+                        </div>
+                    }
+                </dl>
+            </section>
+        </div>
+
+        <aside class="dashboard-rail" aria-label="Dashboard attention">
+            <NeedsAttentionPanel Items="AttentionItems" />
+        </aside>
     </section>
 </section>
 
 @code {
     private DashboardProjection? projection;
     private string? loadError;
+
+    private IReadOnlyList<DashboardAttentionItem> AttentionItems =>
+        projection?.AttentionItems ?? Array.Empty<DashboardAttentionItem>();
 
     private static readonly HealthHeatmapBucket[] HealthBuckets =
     [

--- a/src/Conductor.Host/Data/dashboard-projection.json
+++ b/src/Conductor.Host/Data/dashboard-projection.json
@@ -51,5 +51,34 @@
       "tone": "Cost",
       "icon": "cost"
     }
+  ],
+  "attentionItems": [
+    {
+      "severity": "Critical",
+      "sourceName": "billing-api",
+      "summary": "2 failed runs in the last 30 minutes",
+      "targetHref": "/repositories/billing-api",
+      "targetKind": "repository",
+      "createdAtUtc": "2026-04-29T01:58:00Z",
+      "ageLabel": "2m ago"
+    },
+    {
+      "severity": "Warning",
+      "sourceName": "client-mobile",
+      "summary": "Symphony instance is offline",
+      "targetHref": "/instances/client-mobile",
+      "targetKind": "instance",
+      "createdAtUtc": "2026-04-29T01:52:00Z",
+      "ageLabel": "8m ago"
+    },
+    {
+      "severity": "Warning",
+      "sourceName": "acme-portal",
+      "summary": "PR #128 waiting for review for 3 days",
+      "targetHref": "/repositories/acme-portal",
+      "targetKind": "repository",
+      "createdAtUtc": "2026-04-29T01:45:00Z",
+      "ageLabel": "15m ago"
+    }
   ]
 }

--- a/src/Conductor.Host/wwwroot/app.css
+++ b/src/Conductor.Host/wwwroot/app.css
@@ -288,6 +288,18 @@ h2 {
   color: #fecdd3;
 }
 
+.dashboard-body {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(280px, 360px);
+  gap: 14px;
+  align-items: start;
+}
+
+.dashboard-stack {
+  display: grid;
+  gap: 24px;
+}
+
 .activity-panel {
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(220px, 320px);
@@ -461,6 +473,164 @@ h2 {
   color: #74808d;
 }
 
+.dashboard-rail {
+  display: grid;
+  gap: 14px;
+}
+
+.needs-attention-panel {
+  display: grid;
+  gap: 16px;
+  padding: 18px;
+  border: 1px solid #2b3138;
+  border-radius: 8px;
+  background: #151a1f;
+}
+
+.needs-attention-header,
+.needs-attention-title,
+.attention-title-row {
+  display: flex;
+  align-items: center;
+}
+
+.needs-attention-header {
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.needs-attention-title {
+  min-width: 0;
+  gap: 10px;
+}
+
+.needs-attention-title h2 {
+  margin-bottom: 0;
+}
+
+.attention-count {
+  display: inline-grid;
+  min-width: 28px;
+  height: 28px;
+  place-items: center;
+  border-radius: 999px;
+  background: #6b2a24;
+  color: #ffd5cb;
+  font-size: 0.8rem;
+  font-weight: 800;
+}
+
+.panel-link {
+  flex: 0 0 auto;
+  color: #9cc2ff;
+  font-size: 0.85rem;
+  font-weight: 700;
+}
+
+.panel-link:hover,
+.attention-item:hover .attention-title-row strong {
+  color: #ffffff;
+}
+
+.attention-list {
+  display: grid;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.attention-list li + li {
+  border-top: 1px solid #2b3138;
+}
+
+.attention-item {
+  display: grid;
+  grid-template-columns: 28px minmax(0, 1fr) auto;
+  gap: 12px;
+  align-items: start;
+  padding: 14px 0;
+}
+
+.severity-marker {
+  display: inline-grid;
+  width: 24px;
+  height: 24px;
+  place-items: center;
+  border-radius: 999px;
+  font-size: 0.9rem;
+  font-weight: 900;
+  line-height: 1;
+}
+
+.attention-severity-critical .severity-marker {
+  background: #6b2a24;
+  color: #ffb5a6;
+}
+
+.attention-severity-warning .severity-marker {
+  background: #4f3b11;
+  color: #ffd668;
+}
+
+.attention-copy {
+  display: grid;
+  min-width: 0;
+  gap: 5px;
+}
+
+.attention-title-row {
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.attention-title-row strong {
+  overflow-wrap: anywhere;
+}
+
+.severity-badge {
+  padding: 3px 8px;
+  border-radius: 999px;
+  background: #232a31;
+  color: #dbe6ee;
+  font-size: 0.72rem;
+  font-weight: 800;
+}
+
+.attention-severity-critical .severity-badge {
+  background: #3b1715;
+  color: #ffb5a6;
+}
+
+.attention-severity-warning .severity-badge {
+  background: #3b2d0f;
+  color: #ffd668;
+}
+
+.attention-summary,
+.attention-item time,
+.attention-empty-state span {
+  color: #aeb9c5;
+}
+
+.attention-summary {
+  font-size: 0.88rem;
+  line-height: 1.4;
+}
+
+.attention-item time {
+  white-space: nowrap;
+  font-size: 0.8rem;
+}
+
+.attention-empty-state {
+  display: grid;
+  gap: 5px;
+  padding: 18px;
+  border: 1px dashed #39424c;
+  border-radius: 8px;
+  background: #191f25;
+}
+
 .startup-panel {
   display: grid;
   gap: 18px;
@@ -543,6 +713,7 @@ h2 {
   }
 
   .side-nav nav,
+  .dashboard-body,
   .activity-panel,
   .startup-panel dl {
     grid-template-columns: 1fr;

--- a/tests/Conductor.Blazor.Tests/Dashboard/JsonFileDashboardProjectionStoreTests.cs
+++ b/tests/Conductor.Blazor.Tests/Dashboard/JsonFileDashboardProjectionStoreTests.cs
@@ -29,6 +29,17 @@ public sealed class JsonFileDashboardProjectionStoreTests
                       "tone": "Healthy",
                       "icon": "pulse"
                     }
+                  ],
+                  "attentionItems": [
+                    {
+                      "severity": "Critical",
+                      "sourceName": "billing-api",
+                      "summary": "2 failed runs in the last 30 minutes",
+                      "targetHref": "/repositories/billing-api",
+                      "targetKind": "repository",
+                      "createdAtUtc": "2026-04-29T01:58:00Z",
+                      "ageLabel": "2m ago"
+                    }
                   ]
                 }
                 """);
@@ -44,6 +55,9 @@ public sealed class JsonFileDashboardProjectionStoreTests
             Assert.Equal("healthy-repositories", metric.Key);
             Assert.Equal(MetricTrendDirection.Positive, metric.TrendDirection);
             Assert.Equal(MetricTone.Healthy, metric.Tone);
+            DashboardAttentionItem attentionItem = Assert.Single(projection.AttentionItems);
+            Assert.Equal("billing-api", attentionItem.SourceName);
+            Assert.Equal("/repositories/billing-api", attentionItem.TargetHref);
         }
         finally
         {

--- a/tests/Conductor.Blazor.Tests/DashboardSmokeTests.cs
+++ b/tests/Conductor.Blazor.Tests/DashboardSmokeTests.cs
@@ -1,5 +1,7 @@
 using Bunit;
 using Conductor.Core.Application.Dashboard;
+using Conductor.Core.Domain;
+using Conductor.Host.Components.Dashboard;
 using Conductor.Host.Components.Pages;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -21,6 +23,21 @@ public sealed class DashboardSmokeTests
                 Metric("blocked-issues", "Blocked Issues", "7"),
                 Metric("open-pull-requests", "PRs Open", "23"),
                 Metric("ai-spend-today", "AI Spend Today", "$128.40")
+            ],
+            AttentionItems =
+            [
+                Attention(
+                    AlertSeverity.Critical,
+                    "billing-api",
+                    "2 failed runs in the last 30 minutes",
+                    "/repositories/billing-api",
+                    "repository"),
+                Attention(
+                    AlertSeverity.Warning,
+                    "client-mobile",
+                    "Symphony instance is offline",
+                    "/instances/client-mobile",
+                    "instance")
             ]
         }));
 
@@ -36,6 +53,11 @@ public sealed class DashboardSmokeTests
         Assert.Contains("SQLite persistence registration", dashboard.Markup, StringComparison.Ordinal);
         Assert.Contains("Repository orchestration health", dashboard.Markup, StringComparison.Ordinal);
         Assert.Contains("Release Portal", dashboard.Markup, StringComparison.Ordinal);
+        Assert.Contains("Needs attention", dashboard.Markup, StringComparison.Ordinal);
+        Assert.Contains("billing-api", dashboard.Markup, StringComparison.Ordinal);
+        Assert.Contains("Critical", dashboard.Markup, StringComparison.Ordinal);
+        Assert.Contains("href=\"/repositories/billing-api\"", dashboard.Markup, StringComparison.Ordinal);
+        Assert.Contains("href=\"/instances/client-mobile\"", dashboard.Markup, StringComparison.Ordinal);
         Assert.Contains("Startup verification", dashboard.Markup, StringComparison.Ordinal);
         Assert.Contains("/health/live", dashboard.Markup, StringComparison.Ordinal);
     }
@@ -52,6 +74,63 @@ public sealed class DashboardSmokeTests
         Assert.Contains("No dashboard metrics are available yet.", dashboard.Markup, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void NeedsAttentionPanel_Renders_Critical_And_Warning_Source_Links()
+    {
+        using BunitContext context = new();
+        DashboardAttentionItem[] items =
+        [
+            Attention(
+                AlertSeverity.Info,
+                "release-notes",
+                "Daily digest is available",
+                "/reports/daily",
+                "report"),
+            Attention(
+                AlertSeverity.Warning,
+                "client-mobile",
+                "Symphony instance is offline",
+                "/instances/client-mobile",
+                "instance"),
+            Attention(
+                AlertSeverity.Critical,
+                "billing-api",
+                "2 failed runs in the last 30 minutes",
+                "/repositories/billing-api",
+                "repository"),
+        ];
+
+        IRenderedComponent<NeedsAttentionPanel> panel = context.Render<NeedsAttentionPanel>(
+            parameters => parameters.Add(component => component.Items, items));
+
+        Assert.Contains("Needs attention", panel.Markup, StringComparison.Ordinal);
+        Assert.Contains("billing-api", panel.Markup, StringComparison.Ordinal);
+        Assert.Contains("client-mobile", panel.Markup, StringComparison.Ordinal);
+        Assert.Contains("href=\"/repositories/billing-api\"", panel.Markup, StringComparison.Ordinal);
+        Assert.Contains("href=\"/instances/client-mobile\"", panel.Markup, StringComparison.Ordinal);
+        Assert.DoesNotContain("release-notes", panel.Markup, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void NeedsAttentionPanel_Renders_Empty_State_When_No_Blocking_Items_Exist()
+    {
+        using BunitContext context = new();
+
+        IRenderedComponent<NeedsAttentionPanel> panel = context.Render<NeedsAttentionPanel>(
+            parameters => parameters.Add(
+                component => component.Items,
+                [Attention(
+                    AlertSeverity.Info,
+                    "release-notes",
+                    "Daily digest is available",
+                    "/reports/daily",
+                    "report")]));
+
+        Assert.Contains("All clear", panel.Markup, StringComparison.Ordinal);
+        Assert.Contains("No critical or warning items are active.", panel.Markup, StringComparison.Ordinal);
+        Assert.DoesNotContain("release-notes", panel.Markup, StringComparison.Ordinal);
+    }
+
     private static DashboardMetric Metric(string key, string label, string value)
     {
         return new DashboardMetric
@@ -62,6 +141,25 @@ public sealed class DashboardSmokeTests
             Detail = "Sample detail",
             TrendText = "Within target",
             Icon = "pulse"
+        };
+    }
+
+    private static DashboardAttentionItem Attention(
+        AlertSeverity severity,
+        string sourceName,
+        string summary,
+        string targetHref,
+        string targetKind)
+    {
+        return new DashboardAttentionItem
+        {
+            Severity = severity,
+            SourceName = sourceName,
+            Summary = summary,
+            TargetHref = targetHref,
+            TargetKind = targetKind,
+            CreatedAtUtc = DateTimeOffset.Parse("2026-04-29T01:58:00Z"),
+            AgeLabel = "2m ago"
         };
     }
 


### PR DESCRIPTION
## Summary
- Adds a reusable Blazor needs-attention panel for active critical and warning items.
- Links each item to its source repository or Symphony instance and adds responsive panel styling.
- Adds bUnit coverage for rendered links, severity filtering, and the empty state.
- Documents the dashboard attention panel in the user guide.

Closes #24

## Validation
- `dotnet restore Conductor.slnx`: passed with no errors or warnings
- `dotnet build Conductor.slnx --no-restore --warnaserror`: passed with 0 warnings
- `dotnet test Conductor.slnx --no-build --collect:"XPlat Code Coverage"`: passed with all tests green
- `dotnet format Conductor.slnx --verify-no-changes`: passed with no changes required

## Notes
- Merged latest `origin/main` into `symphony/24` before the final validation run.