### PR TITLE
[codex] Add dashboard metric tiles

### DIFF
--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -1,0 +1,20 @@
+# Dashboard
+
+The dashboard renders fleet-level projection data through `IDashboardProjectionStore`.
+The first implementation stores a deterministic JSON projection at
+`src/Conductor.Host/Data/dashboard-projection.json` so the Blazor dashboard can
+render from persisted data before the EF Core dashboard query projection lands.
+
+Current metric tile keys:
+
+- `healthy-repositories`
+- `active-agents`
+- `blocked-issues`
+- `open-pull-requests`
+- `ai-spend-today`
+
+Run the dashboard slice checks with:
+
+```powershell
+dotnet test Conductor.slnx
+```

--- a/src/Conductor.Core/Application/Dashboard/DashboardMetric.cs
+++ b/src/Conductor.Core/Application/Dashboard/DashboardMetric.cs
@@ -1,0 +1,20 @@
+namespace Conductor.Core.Application.Dashboard;
+
+public sealed class DashboardMetric
+{
+    public required string Key { get; init; }
+
+    public required string Label { get; init; }
+
+    public required string Value { get; init; }
+
+    public string? Detail { get; init; }
+
+    public string? TrendText { get; init; }
+
+    public MetricTrendDirection TrendDirection { get; init; } = MetricTrendDirection.Neutral;
+
+    public MetricTone Tone { get; init; } = MetricTone.Neutral;
+
+    public required string Icon { get; init; }
+}

--- a/src/Conductor.Core/Application/Dashboard/DashboardProjection.cs
+++ b/src/Conductor.Core/Application/Dashboard/DashboardProjection.cs
@@ -1,0 +1,10 @@
+namespace Conductor.Core.Application.Dashboard;
+
+public sealed class DashboardProjection
+{
+    public DateTimeOffset CapturedAtUtc { get; init; } = DateTimeOffset.UnixEpoch;
+
+    public IReadOnlyList<DashboardMetric> Metrics { get; init; } = Array.Empty<DashboardMetric>();
+
+    public static DashboardProjection Empty { get; } = new();
+}

--- a/src/Conductor.Core/Application/Dashboard/IDashboardProjectionStore.cs
+++ b/src/Conductor.Core/Application/Dashboard/IDashboardProjectionStore.cs
@@ -1,0 +1,6 @@
+namespace Conductor.Core.Application.Dashboard;
+
+public interface IDashboardProjectionStore
+{
+    Task<DashboardProjection> GetCurrentAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Conductor.Core/Application/Dashboard/MetricTone.cs
+++ b/src/Conductor.Core/Application/Dashboard/MetricTone.cs
@@ -1,0 +1,11 @@
+namespace Conductor.Core.Application.Dashboard;
+
+public enum MetricTone
+{
+    Neutral,
+    Healthy,
+    Active,
+    Warning,
+    Critical,
+    Cost
+}

--- a/src/Conductor.Core/Application/Dashboard/MetricTrendDirection.cs
+++ b/src/Conductor.Core/Application/Dashboard/MetricTrendDirection.cs
@@ -1,0 +1,8 @@
+namespace Conductor.Core.Application.Dashboard;
+
+public enum MetricTrendDirection
+{
+    Neutral,
+    Positive,
+    Negative
+}

--- a/src/Conductor.Host/Components/Dashboard/MetricTile.razor
+++ b/src/Conductor.Host/Components/Dashboard/MetricTile.razor
@@ -1,0 +1,61 @@
+@using Conductor.Core.Application.Dashboard
+
+<article class="metric-tile metric-tile--@ToneClass" data-dashboard-metric="@Metric.Key" aria-label="@Metric.Label metric">
+    <div class="metric-tile__icon" aria-hidden="true">
+        @switch (Metric.Icon)
+        {
+            case "pulse":
+                <svg viewBox="0 0 24 24" role="img">
+                    <path d="M3 12h4l2-6 4 12 3-8 2 2h3" />
+                </svg>
+                break;
+            case "agents":
+                <svg viewBox="0 0 24 24" role="img">
+                    <path d="M8 11a3 3 0 1 0 0-6 3 3 0 0 0 0 6Zm8 0a3 3 0 1 0 0-6 3 3 0 0 0 0 6ZM4 19c0-3 2-5 4-5s4 2 4 5m0 0c0-3 2-5 4-5s4 2 4 5" />
+                </svg>
+                break;
+            case "warning":
+                <svg viewBox="0 0 24 24" role="img">
+                    <path d="M12 4 3 20h18L12 4Zm0 5v5m0 3h.01" />
+                </svg>
+                break;
+            case "pull-request":
+                <svg viewBox="0 0 24 24" role="img">
+                    <path d="M6 6v12m0 0a2 2 0 1 0 0 .1M18 6a2 2 0 1 0 0 .1M18 8v3a4 4 0 0 1-4 4h-2m0 0 2-2m-2 2 2 2" />
+                </svg>
+                break;
+            default:
+                <span>$</span>
+                break;
+        }
+    </div>
+
+    <div class="metric-tile__content">
+        <p class="metric-tile__label">@Metric.Label</p>
+        <p class="metric-tile__value">@Metric.Value</p>
+
+        <div class="metric-tile__meta">
+            @if (!string.IsNullOrWhiteSpace(Metric.Detail))
+            {
+                <span>@Metric.Detail</span>
+            }
+
+            @if (!string.IsNullOrWhiteSpace(Metric.TrendText))
+            {
+                <span class="metric-tile__trend metric-tile__trend--@TrendClass">
+                    <span class="sr-only">Trend:</span>
+                    @Metric.TrendText
+                </span>
+            }
+        </div>
+    </div>
+</article>
+
+@code {
+    [Parameter, EditorRequired]
+    public required DashboardMetric Metric { get; set; }
+
+    private string ToneClass => Metric.Tone.ToString().ToLowerInvariant();
+
+    private string TrendClass => Metric.TrendDirection.ToString().ToLowerInvariant();
+}

--- a/src/Conductor.Host/Components/Pages/Home.razor
+++ b/src/Conductor.Host/Components/Pages/Home.razor
@@ -1,4 +1,6 @@
 @page "/"
+@using System.Text.Json
+@inject IDashboardProjectionStore DashboardProjectionStore
 
 <PageTitle>Conductor Dashboard</PageTitle>
 
@@ -7,20 +9,40 @@
         <div>
             <p class="eyebrow">Fleet overview</p>
             <h1>Conductor Dashboard</h1>
+            <p class="dashboard-summary">Good morning, Nick. Here's what's happening across your software orchestra.</p>
         </div>
-        <span class="status-pill">Sprint 2 dashboard</span>
+        <div class="dashboard-meta">
+            <span class="status-pill">Sprint 2 metrics</span>
+            @if (projection is not null)
+            {
+                <span class="projection-stamp">Projection @projection.CapturedAtUtc.ToLocalTime().ToString("MMM d, yyyy HH:mm")</span>
+            }
+        </div>
     </header>
 
-    <section class="metric-grid" aria-label="Dashboard metrics">
-        @foreach ((string Label, string Value, string Hint) metric in Metrics)
-        {
-            <article class="metric-tile">
-                <span>@metric.Label</span>
-                <strong>@metric.Value</strong>
-                <small>@metric.Hint</small>
-            </article>
-        }
-    </section>
+    @if (loadError is not null)
+    {
+        <div class="dashboard-state dashboard-state--error" role="alert">
+            Dashboard metrics could not be loaded.
+        </div>
+    }
+    else if (projection is null)
+    {
+        <div class="dashboard-state">Loading dashboard metrics...</div>
+    }
+    else if (projection.Metrics.Count == 0)
+    {
+        <div class="dashboard-state">No dashboard metrics are available yet.</div>
+    }
+    else
+    {
+        <section class="metric-grid" aria-label="Dashboard metrics">
+            @foreach (DashboardMetric metric in projection.Metrics)
+            {
+                <MetricTile Metric="metric" />
+            }
+        </section>
+    }
 
     <HealthHeatmap Buckets="HealthBuckets" />
 
@@ -58,13 +80,8 @@
 </section>
 
 @code {
-    private static readonly (string Label, string Value, string Hint)[] Metrics =
-    [
-        ("Projects", "0", "Ready for Sprint 1 seed data"),
-        ("Repositories", "0", "Import workflow pending"),
-        ("Instances", "0", "Provisioning starts in later sprints"),
-        ("Alerts", "0", "In-app rules not active yet"),
-    ];
+    private DashboardProjection? projection;
+    private string? loadError;
 
     private static readonly HealthHeatmapBucket[] HealthBuckets =
     [
@@ -104,8 +121,20 @@
 
     private static readonly (string Label, string Route, string State)[] StartupChecks =
     [
-        ("Dashboard route", "/", "Dashboard served"),
+        ("Dashboard route", "/", "Metric tiles served"),
         ("Live health", "/health/live", "Probe available"),
         ("Ready health", "/health/ready", "Probe available"),
     ];
+
+    protected override async Task OnInitializedAsync()
+    {
+        try
+        {
+            projection = await DashboardProjectionStore.GetCurrentAsync();
+        }
+        catch (Exception ex) when (ex is IOException or JsonException or UnauthorizedAccessException)
+        {
+            loadError = ex.Message;
+        }
+    }
 }

--- a/src/Conductor.Host/Components/_Imports.razor
+++ b/src/Conductor.Host/Components/_Imports.razor
@@ -3,6 +3,7 @@
 @using Microsoft.AspNetCore.Components.Web
 @using Microsoft.AspNetCore.Components.Web.Virtualization
 @using static Microsoft.AspNetCore.Components.Web.RenderMode
+@using Conductor.Core.Application.Dashboard
 @using Conductor.Host
 @using Conductor.Host.Components
 @using Conductor.Host.Components.Dashboard

--- a/src/Conductor.Host/Conductor.Host.csproj
+++ b/src/Conductor.Host/Conductor.Host.csproj
@@ -5,4 +5,8 @@
     <ProjectReference Include="..\Conductor.Infrastructure.Persistence.Sqlite\Conductor.Infrastructure.Persistence.Sqlite.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Update="Data\dashboard-projection.json" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
+  </ItemGroup>
+
 </Project>

--- a/src/Conductor.Host/Dashboard/DashboardProjectionOptions.cs
+++ b/src/Conductor.Host/Dashboard/DashboardProjectionOptions.cs
@@ -1,0 +1,8 @@
+namespace Conductor.Host.Dashboard;
+
+public sealed class DashboardProjectionOptions
+{
+    public const string SectionName = "DashboardProjection";
+
+    public string Path { get; set; } = "Data/dashboard-projection.json";
+}

--- a/src/Conductor.Host/Dashboard/JsonFileDashboardProjectionStore.cs
+++ b/src/Conductor.Host/Dashboard/JsonFileDashboardProjectionStore.cs
@@ -1,0 +1,36 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Conductor.Core.Application.Dashboard;
+using Microsoft.Extensions.Options;
+
+namespace Conductor.Host.Dashboard;
+
+public sealed class JsonFileDashboardProjectionStore(
+    IOptions<DashboardProjectionOptions> options,
+    IHostEnvironment environment) : IDashboardProjectionStore
+{
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        Converters = { new JsonStringEnumConverter() }
+    };
+
+    public async Task<DashboardProjection> GetCurrentAsync(CancellationToken cancellationToken = default)
+    {
+        string projectionPath = ResolvePath(options.Value.Path);
+
+        await using FileStream stream = File.OpenRead(projectionPath);
+        DashboardProjection? projection = await JsonSerializer.DeserializeAsync<DashboardProjection>(
+            stream,
+            JsonOptions,
+            cancellationToken);
+
+        return projection ?? DashboardProjection.Empty;
+    }
+
+    private string ResolvePath(string configuredPath)
+    {
+        return Path.IsPathRooted(configuredPath)
+            ? configuredPath
+            : Path.Combine(environment.ContentRootPath, configuredPath);
+    }
+}

--- a/src/Conductor.Host/Data/dashboard-projection.json
+++ b/src/Conductor.Host/Data/dashboard-projection.json
@@ -1,0 +1,55 @@
+{
+  "capturedAtUtc": "2026-04-29T00:00:00Z",
+  "metrics": [
+    {
+      "key": "healthy-repositories",
+      "label": "Healthy Repos",
+      "value": "36 / 42",
+      "detail": "85% healthy",
+      "trendText": "Up 8%",
+      "trendDirection": "Positive",
+      "tone": "Healthy",
+      "icon": "pulse"
+    },
+    {
+      "key": "active-agents",
+      "label": "Active Agents",
+      "value": "18",
+      "detail": "Running now",
+      "trendText": "Up 3 from yesterday",
+      "trendDirection": "Positive",
+      "tone": "Active",
+      "icon": "agents"
+    },
+    {
+      "key": "blocked-issues",
+      "label": "Blocked Issues",
+      "value": "7",
+      "detail": "Needs operator review",
+      "trendText": "Up 2 from yesterday",
+      "trendDirection": "Negative",
+      "tone": "Warning",
+      "icon": "warning"
+    },
+    {
+      "key": "open-pull-requests",
+      "label": "PRs Open",
+      "value": "23",
+      "detail": "Awaiting review",
+      "trendText": "Down 1 from yesterday",
+      "trendDirection": "Positive",
+      "tone": "Critical",
+      "icon": "pull-request"
+    },
+    {
+      "key": "ai-spend-today",
+      "label": "AI Spend Today",
+      "value": "$128.40",
+      "detail": "Est. weekly $842.12",
+      "trendText": "Within budget",
+      "trendDirection": "Neutral",
+      "tone": "Cost",
+      "icon": "cost"
+    }
+  ]
+}

--- a/src/Conductor.Host/Program.cs
+++ b/src/Conductor.Host/Program.cs
@@ -1,4 +1,6 @@
+using Conductor.Core.Application.Dashboard;
 using Conductor.Host.Components;
+using Conductor.Host.Dashboard;
 using Conductor.Host.Endpoints;
 using Conductor.Host.Workers;
 using Conductor.Infrastructure.Persistence.Sqlite;
@@ -9,6 +11,9 @@ builder.Services
     .AddRazorComponents()
     .AddInteractiveServerComponents();
 
+builder.Services.Configure<DashboardProjectionOptions>(
+    builder.Configuration.GetSection(DashboardProjectionOptions.SectionName));
+builder.Services.AddSingleton<IDashboardProjectionStore, JsonFileDashboardProjectionStore>();
 builder.Services.AddHealthChecks();
 builder.Services.AddConductorPersistence(builder.Configuration);
 builder.Services.AddConductorWorkers();

--- a/src/Conductor.Host/appsettings.json
+++ b/src/Conductor.Host/appsettings.json
@@ -1,4 +1,7 @@
 {
+  "DashboardProjection": {
+    "Path": "Data/dashboard-projection.json"
+  },
   "ConnectionStrings": {
     "Conductor": "Data Source=./data/conductor.db;Cache=Shared"
   },

--- a/src/Conductor.Host/wwwroot/app.css
+++ b/src/Conductor.Host/wwwroot/app.css
@@ -3,6 +3,7 @@
   font-family: "Segoe UI", system-ui, sans-serif;
   background: #111417;
   color: #e6edf3;
+  letter-spacing: 0;
 }
 
 * {
@@ -17,6 +18,18 @@ body {
 a {
   color: inherit;
   text-decoration: none;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .app-shell {
@@ -79,7 +92,7 @@ a {
 .dashboard {
   display: grid;
   gap: 24px;
-  max-width: 1120px;
+  max-width: 1220px;
 }
 
 .dashboard-header {
@@ -87,6 +100,18 @@ a {
   align-items: flex-start;
   justify-content: space-between;
   gap: 16px;
+}
+
+.dashboard-summary {
+  margin: 8px 0 0;
+  color: #aeb9c5;
+}
+
+.dashboard-meta {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
 }
 
 .eyebrow {
@@ -105,7 +130,7 @@ p {
 
 h1 {
   margin-bottom: 0;
-  font-size: clamp(2rem, 5vw, 3.25rem);
+  font-size: 2.3rem;
   line-height: 1.05;
 }
 
@@ -114,41 +139,153 @@ h2 {
   font-size: 1.25rem;
 }
 
-.status-pill {
+.status-pill,
+.projection-stamp {
   flex: 0 0 auto;
   padding: 8px 12px;
-  border: 1px solid #45666d;
-  border-radius: 999px;
-  background: #17373b;
-  color: #9ee7d7;
   font-size: 0.85rem;
   font-weight: 700;
 }
 
+.status-pill {
+  border: 1px solid #45666d;
+  border-radius: 999px;
+  background: #17373b;
+  color: #9ee7d7;
+}
+
+.projection-stamp {
+  border: 1px solid #2b3138;
+  border-radius: 8px;
+  background: #191f25;
+  color: #aeb9c5;
+}
+
 .metric-grid {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 14px;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 12px;
 }
 
 .metric-tile {
   display: grid;
+  grid-template-columns: 50px minmax(0, 1fr);
+  gap: 14px;
+  align-items: center;
   min-height: 132px;
-  gap: 8px;
   padding: 18px;
   border: 1px solid #2b3138;
   border-radius: 8px;
   background: #191f25;
 }
 
-.metric-tile span,
-.metric-tile small {
+.metric-tile__icon {
+  display: grid;
+  width: 50px;
+  height: 50px;
+  place-items: center;
+  border-radius: 50%;
+  background: #232a31;
+  color: #dbe6ee;
+}
+
+.metric-tile__icon svg {
+  width: 28px;
+  height: 28px;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.8;
+}
+
+.metric-tile__icon span {
+  font-size: 1.55rem;
+  font-weight: 800;
+}
+
+.metric-tile__content {
+  min-width: 0;
+}
+
+.metric-tile__label {
+  margin: 0;
+  color: #dbe6ee;
+  font-size: 0.88rem;
+  font-weight: 700;
+}
+
+.metric-tile__value {
+  margin: 6px 0 0;
+  color: #ffffff;
+  font-size: 2rem;
+  line-height: 1;
+  font-weight: 800;
+}
+
+.metric-tile__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+  min-height: 22px;
+  align-items: center;
+  margin-top: 10px;
+  color: #aeb9c5;
+  font-size: 0.82rem;
+}
+
+.metric-tile__trend {
+  font-weight: 700;
+}
+
+.metric-tile__trend--positive {
+  color: #4ade80;
+}
+
+.metric-tile__trend--negative {
+  color: #fb7185;
+}
+
+.metric-tile__trend--neutral {
+  color: #7dd3fc;
+}
+
+.metric-tile--healthy .metric-tile__icon {
+  background: rgba(22, 163, 74, 0.24);
+  color: #4ade80;
+}
+
+.metric-tile--active .metric-tile__icon {
+  background: rgba(37, 99, 235, 0.28);
+  color: #60a5fa;
+}
+
+.metric-tile--warning .metric-tile__icon {
+  background: rgba(245, 158, 11, 0.28);
+  color: #fbbf24;
+}
+
+.metric-tile--critical .metric-tile__icon {
+  background: rgba(124, 58, 237, 0.28);
+  color: #c084fc;
+}
+
+.metric-tile--cost .metric-tile__icon {
+  background: rgba(20, 184, 166, 0.25);
+  color: #2dd4bf;
+}
+
+.dashboard-state {
+  padding: 24px;
+  border: 1px solid #2b3138;
+  border-radius: 8px;
+  background: #191f25;
   color: #aeb9c5;
 }
 
-.metric-tile strong {
-  font-size: 2.4rem;
-  line-height: 1;
+.dashboard-state--error {
+  border-color: #7f1d1d;
+  color: #fecdd3;
 }
 
 .activity-panel {
@@ -324,18 +461,6 @@ h2 {
   color: #74808d;
 }
 
-.sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
-}
-
 .startup-panel {
   display: grid;
   gap: 18px;
@@ -400,6 +525,12 @@ h2 {
   background: #191f25;
 }
 
+@media (max-width: 1180px) {
+  .metric-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
 @media (max-width: 760px) {
   .app-shell {
     grid-template-columns: 1fr;
@@ -412,7 +543,6 @@ h2 {
   }
 
   .side-nav nav,
-  .metric-grid,
   .activity-panel,
   .startup-panel dl {
     grid-template-columns: 1fr;
@@ -426,8 +556,16 @@ h2 {
     min-width: 640px;
   }
 
+  .metric-grid {
+    grid-template-columns: 1fr;
+  }
+
   .dashboard-header {
     display: grid;
+  }
+
+  .dashboard-meta {
+    justify-content: flex-start;
   }
 
   .main-panel {

--- a/tests/Conductor.Blazor.Tests/Conductor.Blazor.Tests.csproj
+++ b/tests/Conductor.Blazor.Tests/Conductor.Blazor.Tests.csproj
@@ -23,6 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Conductor.Core\Conductor.Core.csproj" />
     <ProjectReference Include="..\..\src\Conductor.Host\Conductor.Host.csproj" />
   </ItemGroup>
 

--- a/tests/Conductor.Blazor.Tests/Dashboard/JsonFileDashboardProjectionStoreTests.cs
+++ b/tests/Conductor.Blazor.Tests/Dashboard/JsonFileDashboardProjectionStoreTests.cs
@@ -1,0 +1,67 @@
+using Conductor.Core.Application.Dashboard;
+using Conductor.Host.Dashboard;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+
+namespace Conductor.Blazor.Tests.Dashboard;
+
+public sealed class JsonFileDashboardProjectionStoreTests
+{
+    [Fact]
+    public async Task StoreReadsDashboardProjectionFromJsonFile()
+    {
+        string tempPath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.json");
+
+        try
+        {
+            await File.WriteAllTextAsync(
+                tempPath,
+                """
+                {
+                  "capturedAtUtc": "2026-04-29T00:00:00Z",
+                  "metrics": [
+                    {
+                      "key": "healthy-repositories",
+                      "label": "Healthy Repos",
+                      "value": "36 / 42",
+                      "trendDirection": "Positive",
+                      "tone": "Healthy",
+                      "icon": "pulse"
+                    }
+                  ]
+                }
+                """);
+
+            var store = new JsonFileDashboardProjectionStore(
+                Options.Create(new DashboardProjectionOptions { Path = tempPath }),
+                new TestHostEnvironment());
+
+            DashboardProjection projection = await store.GetCurrentAsync();
+
+            Assert.Equal(DateTimeOffset.Parse("2026-04-29T00:00:00Z"), projection.CapturedAtUtc);
+            DashboardMetric metric = Assert.Single(projection.Metrics);
+            Assert.Equal("healthy-repositories", metric.Key);
+            Assert.Equal(MetricTrendDirection.Positive, metric.TrendDirection);
+            Assert.Equal(MetricTone.Healthy, metric.Tone);
+        }
+        finally
+        {
+            if (File.Exists(tempPath))
+            {
+                File.Delete(tempPath);
+            }
+        }
+    }
+
+    private sealed class TestHostEnvironment : IHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = Environments.Development;
+
+        public string ApplicationName { get; set; } = "Conductor.Blazor.Tests";
+
+        public string ContentRootPath { get; set; } = Directory.GetCurrentDirectory();
+
+        public IFileProvider ContentRootFileProvider { get; set; } = new NullFileProvider();
+    }
+}

--- a/tests/Conductor.Blazor.Tests/Dashboard/MetricTileTests.cs
+++ b/tests/Conductor.Blazor.Tests/Dashboard/MetricTileTests.cs
@@ -1,0 +1,57 @@
+using Bunit;
+using Conductor.Core.Application.Dashboard;
+using Conductor.Host.Components.Dashboard;
+
+namespace Conductor.Blazor.Tests.Dashboard;
+
+public sealed class MetricTileTests
+{
+    [Fact]
+    public void MetricTileRendersCoreMetricText()
+    {
+        using BunitContext context = new();
+        var metric = new DashboardMetric
+        {
+            Key = "active-agents",
+            Label = "Active Agents",
+            Value = "18",
+            Detail = "Running now",
+            TrendText = "Up 3 from yesterday",
+            TrendDirection = MetricTrendDirection.Positive,
+            Tone = MetricTone.Active,
+            Icon = "agents"
+        };
+
+        IRenderedComponent<MetricTile> tile = context.Render<MetricTile>(parameters => parameters
+            .Add(component => component.Metric, metric));
+
+        var article = tile.Find("[data-dashboard-metric='active-agents']");
+        Assert.Contains("Active Agents", article.TextContent, StringComparison.Ordinal);
+        Assert.Contains("18", article.TextContent, StringComparison.Ordinal);
+        Assert.Contains("Running now", article.TextContent, StringComparison.Ordinal);
+        Assert.Contains("Up 3 from yesterday", article.TextContent, StringComparison.Ordinal);
+        Assert.Contains("metric-tile--active", article.ClassList);
+    }
+
+    [Fact]
+    public void MetricTileIncludesAccessibleTrendLabel()
+    {
+        using BunitContext context = new();
+        var metric = new DashboardMetric
+        {
+            Key = "blocked-issues",
+            Label = "Blocked Issues",
+            Value = "7",
+            TrendText = "Up 2 from yesterday",
+            TrendDirection = MetricTrendDirection.Negative,
+            Tone = MetricTone.Warning,
+            Icon = "warning"
+        };
+
+        IRenderedComponent<MetricTile> tile = context.Render<MetricTile>(parameters => parameters
+            .Add(component => component.Metric, metric));
+
+        Assert.Equal("Trend:", tile.Find(".sr-only").TextContent);
+        Assert.Contains("metric-tile__trend--negative", tile.Find(".metric-tile__trend").ClassList);
+    }
+}

--- a/tests/Conductor.Blazor.Tests/DashboardSmokeTests.cs
+++ b/tests/Conductor.Blazor.Tests/DashboardSmokeTests.cs
@@ -1,5 +1,7 @@
 using Bunit;
+using Conductor.Core.Application.Dashboard;
 using Conductor.Host.Components.Pages;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Conductor.Blazor.Tests;
 
@@ -9,14 +11,65 @@ public sealed class DashboardSmokeTests
     public void Home_Renders_Initial_Dashboard()
     {
         using BunitContext context = new();
+        context.Services.AddSingleton<IDashboardProjectionStore>(new StaticDashboardProjectionStore(new DashboardProjection
+        {
+            CapturedAtUtc = DateTimeOffset.Parse("2026-04-29T00:00:00Z"),
+            Metrics =
+            [
+                Metric("healthy-repositories", "Healthy Repos", "36 / 42"),
+                Metric("active-agents", "Active Agents", "18"),
+                Metric("blocked-issues", "Blocked Issues", "7"),
+                Metric("open-pull-requests", "PRs Open", "23"),
+                Metric("ai-spend-today", "AI Spend Today", "$128.40")
+            ]
+        }));
 
         IRenderedComponent<Home> dashboard = context.Render<Home>();
 
         Assert.Contains("Conductor Dashboard", dashboard.Markup, StringComparison.Ordinal);
+        Assert.Equal(5, dashboard.FindAll("[data-dashboard-metric]").Count);
+        Assert.Contains("Healthy Repos", dashboard.Markup, StringComparison.Ordinal);
+        Assert.Contains("Active Agents", dashboard.Markup, StringComparison.Ordinal);
+        Assert.Contains("Blocked Issues", dashboard.Markup, StringComparison.Ordinal);
+        Assert.Contains("PRs Open", dashboard.Markup, StringComparison.Ordinal);
+        Assert.Contains("AI Spend Today", dashboard.Markup, StringComparison.Ordinal);
         Assert.Contains("SQLite persistence registration", dashboard.Markup, StringComparison.Ordinal);
         Assert.Contains("Repository orchestration health", dashboard.Markup, StringComparison.Ordinal);
         Assert.Contains("Release Portal", dashboard.Markup, StringComparison.Ordinal);
         Assert.Contains("Startup verification", dashboard.Markup, StringComparison.Ordinal);
         Assert.Contains("/health/live", dashboard.Markup, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Home_Renders_Empty_State_When_No_Metrics_Exist()
+    {
+        using BunitContext context = new();
+        context.Services.AddSingleton<IDashboardProjectionStore>(
+            new StaticDashboardProjectionStore(DashboardProjection.Empty));
+
+        IRenderedComponent<Home> dashboard = context.Render<Home>();
+
+        Assert.Contains("No dashboard metrics are available yet.", dashboard.Markup, StringComparison.Ordinal);
+    }
+
+    private static DashboardMetric Metric(string key, string label, string value)
+    {
+        return new DashboardMetric
+        {
+            Key = key,
+            Label = label,
+            Value = value,
+            Detail = "Sample detail",
+            TrendText = "Within target",
+            Icon = "pulse"
+        };
+    }
+
+    private sealed class StaticDashboardProjectionStore(DashboardProjection projection) : IDashboardProjectionStore
+    {
+        public Task<DashboardProjection> GetCurrentAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(projection);
+        }
     }
 }


### PR DESCRIPTION
Closes #21

## Summary
- Add a dashboard projection contract and JSON-backed projection store for the initial metric data source.
- Render the required fleet metric tiles for healthy repositories, active agents, blocked issues, open PRs, and AI spend.
- Keep the existing startup and health heatmap dashboard content, and add dashboard documentation plus bUnit/provider coverage.

## Validation
- `dotnet restore Conductor.slnx`
- `dotnet build Conductor.slnx --no-restore --warnaserror`
- `dotnet test Conductor.slnx --no-build`
- `dotnet format Conductor.slnx --verify-no-changes`
- `pwsh -NoProfile -File scripts\validate-docs.ps1`
- Runtime smoke check at `http://localhost:5121` confirmed the dashboard rendered all five metric labels and the health heatmap.