### PR TITLE
Add dashboard component test coverage

### DIFF
--- a/tests/Conductor.Blazor.Tests/DashboardSmokeTests.cs
+++ b/tests/Conductor.Blazor.Tests/DashboardSmokeTests.cs
@@ -1,3 +1,4 @@
+using AngleSharp.Dom;
 using Bunit;
 using Conductor.Host.Components.Pages;
 
@@ -18,5 +19,54 @@ public sealed class DashboardSmokeTests
         Assert.Contains("Release Portal", dashboard.Markup, StringComparison.Ordinal);
         Assert.Contains("Startup verification", dashboard.Markup, StringComparison.Ordinal);
         Assert.Contains("/health/live", dashboard.Markup, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Home_Renders_Dashboard_Metric_Tiles_With_Baseline_States()
+    {
+        using BunitContext context = new();
+
+        IRenderedComponent<Home> dashboard = context.Render<Home>();
+
+        IElement metricGrid = dashboard.Find("section[aria-label='Dashboard metrics']");
+        IReadOnlyList<IElement> tiles = dashboard.FindAll(".metric-tile");
+
+        Assert.Equal("Dashboard metrics", metricGrid.GetAttribute("aria-label"));
+        Assert.Collection(
+            tiles,
+            tile => AssertMetricTile(tile, "Projects", "0", "Ready for Sprint 1 seed data"),
+            tile => AssertMetricTile(tile, "Repositories", "0", "Import workflow pending"),
+            tile => AssertMetricTile(tile, "Instances", "0", "Provisioning starts in later sprints"),
+            tile => AssertMetricTile(tile, "Alerts", "0", "In-app rules not active yet"));
+    }
+
+    [Fact]
+    public void Home_Renders_Startup_Verification_Cards()
+    {
+        using BunitContext context = new();
+
+        IRenderedComponent<Home> dashboard = context.Render<Home>();
+
+        IReadOnlyList<IElement> checks = dashboard.FindAll(".startup-panel dl > div");
+
+        Assert.Collection(
+            checks,
+            check => AssertStartupCheck(check, "Dashboard route", "/", "Dashboard served"),
+            check => AssertStartupCheck(check, "Live health", "/health/live", "Probe available"),
+            check => AssertStartupCheck(check, "Ready health", "/health/ready", "Probe available"));
+    }
+
+    private static void AssertMetricTile(IElement tile, string label, string value, string hint)
+    {
+        Assert.Equal(label, tile.QuerySelector("span")?.TextContent);
+        Assert.Equal(value, tile.QuerySelector("strong")?.TextContent);
+        Assert.Equal(hint, tile.QuerySelector("small")?.TextContent);
+    }
+
+    private static void AssertStartupCheck(IElement check, string label, string route, string state)
+    {
+        Assert.Equal(label, check.QuerySelector("dt")?.TextContent);
+        Assert.Equal(route, check.QuerySelector("code")?.TextContent);
+        Assert.Equal(state, check.QuerySelector("span")?.TextContent);
     }
 }

--- a/tests/Conductor.Blazor.Tests/HealthHeatmapTests.cs
+++ b/tests/Conductor.Blazor.Tests/HealthHeatmapTests.cs
@@ -1,3 +1,4 @@
+using AngleSharp.Dom;
 using Bunit;
 using Conductor.Host.Components.Dashboard;
 
@@ -47,5 +48,150 @@ public sealed class HealthHeatmapTests
             component.Markup,
             StringComparison.Ordinal);
         Assert.DoesNotContain("<table", component.Markup, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void HealthHeatmap_Renders_Status_Summary_For_All_Visual_States()
+    {
+        using BunitContext context = new();
+        HealthHeatmapBucket[] buckets =
+        [
+            new("API", "09:00", HealthHeatmapStatus.Healthy, 99, "Current."),
+            new("API", "10:00", HealthHeatmapStatus.Warning, 72, "Retry queue elevated."),
+            new("Worker", "09:00", HealthHeatmapStatus.Critical, 33, "Failed runs."),
+            new("Docs", "09:00", HealthHeatmapStatus.Offline, 0, "No heartbeat."),
+            new("Docs", "10:00", HealthHeatmapStatus.Healthy, 98, "Recovered."),
+        ];
+
+        IRenderedComponent<HealthHeatmap> component = context.Render<HealthHeatmap>(parameters => parameters
+            .Add(component => component.Buckets, buckets));
+
+        IReadOnlyList<IElement> summaries = component.FindAll(".heatmap-legend-item");
+
+        Assert.Collection(
+            summaries,
+            summary => AssertLegendItem(summary, "Healthy", "2", "heatmap-cell--healthy"),
+            summary => AssertLegendItem(summary, "Warning", "1", "heatmap-cell--warning"),
+            summary => AssertLegendItem(summary, "Critical", "1", "heatmap-cell--critical"),
+            summary => AssertLegendItem(summary, "Offline", "1", "heatmap-cell--offline"));
+    }
+
+    [Fact]
+    public void HealthHeatmap_Applies_Status_Classes_Labels_And_Clamped_Scores()
+    {
+        using BunitContext context = new();
+        HealthHeatmapBucket[] buckets =
+        [
+            new("Healthy Repo", "Now", HealthHeatmapStatus.Healthy, 110, string.Empty),
+            new("Warning Repo", "Now", HealthHeatmapStatus.Warning, -7, "Retry queue elevated."),
+            new("Critical Repo", "Now", HealthHeatmapStatus.Critical, 38, "Deployment blocked."),
+            new("Offline Repo", "Now", HealthHeatmapStatus.Offline, 0, "No heartbeat received."),
+        ];
+
+        IRenderedComponent<HealthHeatmap> component = context.Render<HealthHeatmap>(parameters => parameters
+            .Add(component => component.Buckets, buckets));
+
+        AssertHeatmapCell(
+            component,
+            "Healthy Repo Now: Healthy with health score 100. No detail recorded.",
+            "heatmap-cell--healthy",
+            "OK",
+            "100");
+        AssertHeatmapCell(
+            component,
+            "Warning Repo Now: Warning with health score 0. Retry queue elevated.",
+            "heatmap-cell--warning",
+            "Warn",
+            "0");
+        AssertHeatmapCell(
+            component,
+            "Critical Repo Now: Critical with health score 38. Deployment blocked.",
+            "heatmap-cell--critical",
+            "Crit",
+            "38");
+        AssertHeatmapCell(
+            component,
+            "Offline Repo Now: Offline with health score 0. No heartbeat received.",
+            "heatmap-cell--offline",
+            "Off",
+            "0");
+    }
+
+    [Fact]
+    public void HealthHeatmap_Renders_Empty_Cells_For_Missing_Periods()
+    {
+        using BunitContext context = new();
+        HealthHeatmapBucket[] buckets =
+        [
+            new("Billing API", "Mon", HealthHeatmapStatus.Healthy, 99, "All jobs completed."),
+            new("Billing API", "Tue", HealthHeatmapStatus.Warning, 74, "Retry queue elevated."),
+            new("Portal", "Mon", HealthHeatmapStatus.Critical, 38, "Deployment blocked."),
+        ];
+
+        IRenderedComponent<HealthHeatmap> component = context.Render<HealthHeatmap>(parameters => parameters
+            .Add(component => component.Buckets, buckets));
+
+        IElement emptyCell = FindCellByAriaLabel(component, "Portal Tue: No data");
+
+        AssertClassContains(emptyCell, "heatmap-cell-empty");
+        Assert.Equal("None", emptyCell.QuerySelector(".heatmap-cell-status")?.TextContent);
+        Assert.Equal("-", emptyCell.QuerySelector(".heatmap-cell-score")?.TextContent);
+    }
+
+    [Fact]
+    public void HealthHeatmap_Ignores_Buckets_Without_Row_Or_Period_Labels()
+    {
+        using BunitContext context = new();
+        HealthHeatmapBucket[] buckets =
+        [
+            new("Valid Repo", "Mon", HealthHeatmapStatus.Healthy, 99, "Included."),
+            new("", "Mon", HealthHeatmapStatus.Warning, 70, "Missing repository."),
+            new("Missing Period", "", HealthHeatmapStatus.Critical, 30, "Missing period."),
+            new("   ", "Tue", HealthHeatmapStatus.Offline, 0, "Blank repository."),
+        ];
+
+        IRenderedComponent<HealthHeatmap> component = context.Render<HealthHeatmap>(parameters => parameters
+            .Add(component => component.Buckets, buckets));
+
+        Assert.Contains("Valid Repo", component.Markup, StringComparison.Ordinal);
+        Assert.DoesNotContain("Missing Period", component.Markup, StringComparison.Ordinal);
+
+        IReadOnlyList<IElement> rows = component.FindAll("tbody tr");
+        IReadOnlyList<IElement> periods = component.FindAll("thead th:not(:first-child)");
+
+        Assert.Single(rows);
+        Assert.Single(periods);
+        Assert.Equal("Mon", periods[0].TextContent);
+    }
+
+    private static void AssertLegendItem(IElement summary, string label, string count, string expectedClass)
+    {
+        Assert.Contains(label, summary.TextContent, StringComparison.Ordinal);
+        Assert.Equal(count, summary.QuerySelector("strong")?.TextContent);
+        AssertClassContains(summary.QuerySelector(".heatmap-legend-swatch"), expectedClass);
+    }
+
+    private static void AssertHeatmapCell(
+        IRenderedComponent<HealthHeatmap> component,
+        string ariaLabel,
+        string expectedClass,
+        string shortLabel,
+        string score)
+    {
+        IElement cell = FindCellByAriaLabel(component, ariaLabel);
+
+        AssertClassContains(cell, expectedClass);
+        Assert.Equal(shortLabel, cell.QuerySelector(".heatmap-cell-status")?.TextContent);
+        Assert.Equal(score, cell.QuerySelector(".heatmap-cell-score")?.TextContent);
+    }
+
+    private static IElement FindCellByAriaLabel(IRenderedComponent<HealthHeatmap> component, string ariaLabel) =>
+        component.FindAll(".heatmap-cell")
+            .Single(cell => string.Equals(cell.GetAttribute("aria-label"), ariaLabel, StringComparison.Ordinal));
+
+    private static void AssertClassContains(IElement? element, string expectedClass)
+    {
+        Assert.NotNull(element);
+        Assert.Contains(expectedClass, element.GetAttribute("class") ?? string.Empty, StringComparison.Ordinal);
     }
 }


### PR DESCRIPTION
## Summary
- Add DOM-level bUnit coverage for dashboard metric tiles and startup verification cards.
- Add health heatmap tests for all visual status classes, summary counts, clamped scores, missing data cells, and ignored invalid buckets.

Closes #28

## Validation
- `dotnet restore Conductor.slnx`: passed with no errors or warnings
- `dotnet build Conductor.slnx --no-restore --warnaserror`: passed with 0 warnings and 0 errors
- `dotnet test Conductor.slnx --no-build --collect:"XPlat Code Coverage"`: passed
- `dotnet format Conductor.slnx --no-restore --verify-no-changes`: passed
- `./scripts/validate-docs.ps1`: passed

## Notes
- No runtime UI changes; this PR only expands Blazor component coverage.