### PR TITLE
Add shared UI states and status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ dotnet format Conductor.slnx --no-restore --verify-no-changes
 dotnet run --project src/Conductor.Host/Conductor.Host.csproj
 ```
 
-The root route (`/`) serves the dashboard baseline for local startup checks, including a reusable repository orchestration health heatmap populated with starter projection data. The same startup baseline also exposes `/health/live` and `/health/ready`.
+The root route (`/`) serves the dashboard baseline for local startup checks, including reusable status badges, shared UI state components, and a repository orchestration health heatmap populated with starter projection data. The same startup baseline also exposes `/health/live` and `/health/ready`.
 
 ## Persistence Configuration
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -11,7 +11,7 @@ The solution includes the Sprint 0 test skeletons from `docs/technical.md`:
 | `tests/Conductor.Core.Tests` | Unit tests for domain rules, application services, workflow generation, release selection, secret behavior, and alert logic. |
 | `tests/Conductor.Persistence.Tests` | SQLite persistence tests for migrations, repositories, query projections, retention, and audit writes. |
 | `tests/Conductor.Api.Tests` | Minimal API tests using `WebApplicationFactory` for endpoint behavior, authorization, and validation responses. |
-| `tests/Conductor.Blazor.Tests` | bUnit component tests for dashboard UI, status badges, forms, and secret-safe rendering. |
+| `tests/Conductor.Blazor.Tests` | bUnit component tests for dashboard UI, shared loading/empty/error/success states, status badges, forms, and secret-safe rendering. |
 | `tests/Conductor.Integration.Tests` | Fixture-backed integration tests for clients, runners, and cross-project workflows that do not require external credentials by default. |
 | `tests/Conductor.Host.Tests` | Host smoke tests for application startup, routing, and health behavior. |
 

--- a/src/Conductor.Host/Components/Dashboard/HealthHeatmap.razor
+++ b/src/Conductor.Host/Components/Dashboard/HealthHeatmap.razor
@@ -14,18 +14,18 @@
 
     @if (!HasBuckets)
     {
-        <p class="empty-state">No repository health buckets are available yet.</p>
+        <EmptyState
+            Title="No repository health buckets are available yet."
+            Message="Repository health snapshots will appear after dashboard projections are available." />
     }
     else
     {
         <div class="heatmap-summary" aria-label="Health status summary">
             @foreach (StatusSummary summary in statusSummaries)
             {
-                <span class="heatmap-legend-item">
-                    <span class="@GetLegendSwatchClass(summary.Status)" aria-hidden="true"></span>
-                    <span>@GetStatusLabel(summary.Status)</span>
-                    <strong>@summary.Count.ToString(CultureInfo.InvariantCulture)</strong>
-                </span>
+                <StatusBadge
+                    Text="@GetSummaryLabel(summary)"
+                    Tone="@GetBadgeTone(summary.Status)" />
             }
         </div>
 
@@ -133,9 +133,6 @@
     private static string GetCellClass(HealthHeatmapStatus status) =>
         $"heatmap-cell heatmap-cell--{GetStatusCssName(status)}";
 
-    private static string GetLegendSwatchClass(HealthHeatmapStatus status) =>
-        $"heatmap-legend-swatch heatmap-cell--{GetStatusCssName(status)}";
-
     private static string GetCellLabel(HealthHeatmapBucket bucket)
     {
         string detail = string.IsNullOrWhiteSpace(bucket.Detail) ? "No detail recorded." : bucket.Detail;
@@ -173,8 +170,21 @@
             _ => "unknown",
         };
 
+    private static StatusBadgeTone GetBadgeTone(HealthHeatmapStatus status) =>
+        status switch
+        {
+            HealthHeatmapStatus.Healthy => StatusBadgeTone.Success,
+            HealthHeatmapStatus.Warning => StatusBadgeTone.Warning,
+            HealthHeatmapStatus.Critical => StatusBadgeTone.Critical,
+            HealthHeatmapStatus.Offline => StatusBadgeTone.Neutral,
+            _ => StatusBadgeTone.Neutral,
+        };
+
     private static string GetScoreText(int score) =>
         Math.Clamp(score, 0, 100).ToString(CultureInfo.InvariantCulture);
+
+    private static string GetSummaryLabel(StatusSummary summary) =>
+        $"{GetStatusLabel(summary.Status)} {summary.Count.ToString(CultureInfo.InvariantCulture)}";
 
     private sealed record HeatmapRow(
         string RepositoryName,

--- a/src/Conductor.Host/Components/Pages/Home.razor
+++ b/src/Conductor.Host/Components/Pages/Home.razor
@@ -8,7 +8,7 @@
             <p class="eyebrow">Fleet overview</p>
             <h1>Conductor Dashboard</h1>
         </div>
-        <span class="status-pill">Sprint 2 dashboard</span>
+        <StatusBadge Text="Sprint 2 dashboard" Tone="@StatusBadgeTone.Info" />
     </header>
 
     <section class="metric-grid" aria-label="Dashboard metrics">
@@ -38,10 +38,9 @@
     </section>
 
     <section class="startup-panel" aria-label="Startup verification">
-        <div>
-            <h2>Startup verification</h2>
-            <p>The local host can be checked from the dashboard route and the built-in health probes.</p>
-        </div>
+        <SuccessState
+            Title="Startup verification"
+            Message="The local host can be checked from the dashboard route and the built-in health probes." />
         <dl>
             @foreach ((string Label, string Route, string State) check in StartupChecks)
             {

--- a/src/Conductor.Host/Components/Routes.razor
+++ b/src/Conductor.Host/Components/Routes.razor
@@ -6,9 +6,9 @@
     <NotFound>
         <LayoutView Layout="@typeof(MainLayout)">
             <PageTitle>Not found - Conductor</PageTitle>
-            <section class="empty-state">
-                <p>That Conductor page is not available yet.</p>
-            </section>
+            <EmptyState
+                Title="That Conductor page is not available yet."
+                Message="Use the primary navigation to return to an available workspace." />
         </LayoutView>
     </NotFound>
 </Router>

--- a/src/Conductor.Host/Components/Shared/EmptyState.razor
+++ b/src/Conductor.Host/Components/Shared/EmptyState.razor
@@ -1,0 +1,35 @@
+<section class="@CssClass" aria-label="@Title">
+    <span class="ui-state-icon ui-state-icon--empty" aria-hidden="true"></span>
+    <div class="ui-state-copy">
+        <h2>@Title</h2>
+        @if (!string.IsNullOrWhiteSpace(Message))
+        {
+            <p>@Message</p>
+        }
+        @if (ChildContent is not null)
+        {
+            <div class="ui-state-actions">
+                @ChildContent
+            </div>
+        }
+    </div>
+</section>
+
+@code {
+    [Parameter]
+    public string Title { get; set; } = "Nothing to show";
+
+    [Parameter]
+    public string? Message { get; set; }
+
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    [Parameter]
+    public string? Class { get; set; }
+
+    private string CssClass =>
+        string.IsNullOrWhiteSpace(Class)
+            ? "ui-state ui-state--empty"
+            : $"ui-state ui-state--empty {Class}";
+}

--- a/src/Conductor.Host/Components/Shared/ErrorState.razor
+++ b/src/Conductor.Host/Components/Shared/ErrorState.razor
@@ -1,0 +1,42 @@
+<section class="@CssClass" role="alert">
+    <span class="ui-state-icon ui-state-icon--error" aria-hidden="true"></span>
+    <div class="ui-state-copy">
+        <h2>@Title</h2>
+        @if (!string.IsNullOrWhiteSpace(Message))
+        {
+            <p>@Message</p>
+        }
+        @if (!string.IsNullOrWhiteSpace(Detail))
+        {
+            <small>@Detail</small>
+        }
+        @if (ChildContent is not null)
+        {
+            <div class="ui-state-actions">
+                @ChildContent
+            </div>
+        }
+    </div>
+</section>
+
+@code {
+    [Parameter]
+    public string Title { get; set; } = "Something went wrong";
+
+    [Parameter]
+    public string? Message { get; set; }
+
+    [Parameter]
+    public string? Detail { get; set; }
+
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    [Parameter]
+    public string? Class { get; set; }
+
+    private string CssClass =>
+        string.IsNullOrWhiteSpace(Class)
+            ? "ui-state ui-state--error"
+            : $"ui-state ui-state--error {Class}";
+}

--- a/src/Conductor.Host/Components/Shared/LoadingState.razor
+++ b/src/Conductor.Host/Components/Shared/LoadingState.razor
@@ -1,0 +1,30 @@
+<section class="@CssClass" role="status" aria-live="polite" aria-busy="true">
+    <span class="ui-state-spinner" aria-hidden="true"></span>
+    <div class="ui-state-copy">
+        <h2>@Title</h2>
+        @if (!string.IsNullOrWhiteSpace(Message))
+        {
+            <p>@Message</p>
+        }
+        @ChildContent
+    </div>
+</section>
+
+@code {
+    [Parameter]
+    public string Title { get; set; } = "Loading";
+
+    [Parameter]
+    public string? Message { get; set; }
+
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    [Parameter]
+    public string? Class { get; set; }
+
+    private string CssClass =>
+        string.IsNullOrWhiteSpace(Class)
+            ? "ui-state ui-state--loading"
+            : $"ui-state ui-state--loading {Class}";
+}

--- a/src/Conductor.Host/Components/Shared/StatusBadge.razor
+++ b/src/Conductor.Host/Components/Shared/StatusBadge.razor
@@ -1,0 +1,47 @@
+<span class="@CssClass" aria-label="@AccessibleLabel">
+    <span class="status-badge-indicator" aria-hidden="true"></span>
+    <span>@EffectiveText</span>
+</span>
+
+@code {
+    [Parameter]
+    public string? Text { get; set; }
+
+    [Parameter]
+    public StatusBadgeTone Tone { get; set; } = StatusBadgeTone.Neutral;
+
+    [Parameter]
+    public string? Class { get; set; }
+
+    private string EffectiveText =>
+        string.IsNullOrWhiteSpace(Text) ? GetToneLabel(Tone) : Text;
+
+    private string AccessibleLabel => $"{GetToneLabel(Tone)} status: {EffectiveText}";
+
+    private string CssClass =>
+        string.IsNullOrWhiteSpace(Class)
+            ? $"status-badge status-badge--{GetToneCssName(Tone)}"
+            : $"status-badge status-badge--{GetToneCssName(Tone)} {Class}";
+
+    private static string GetToneLabel(StatusBadgeTone tone) =>
+        tone switch
+        {
+            StatusBadgeTone.Neutral => "Neutral",
+            StatusBadgeTone.Info => "Info",
+            StatusBadgeTone.Success => "Success",
+            StatusBadgeTone.Warning => "Warning",
+            StatusBadgeTone.Critical => "Critical",
+            _ => "Neutral",
+        };
+
+    private static string GetToneCssName(StatusBadgeTone tone) =>
+        tone switch
+        {
+            StatusBadgeTone.Neutral => "neutral",
+            StatusBadgeTone.Info => "info",
+            StatusBadgeTone.Success => "success",
+            StatusBadgeTone.Warning => "warning",
+            StatusBadgeTone.Critical => "critical",
+            _ => "neutral",
+        };
+}

--- a/src/Conductor.Host/Components/Shared/StatusBadgeTone.cs
+++ b/src/Conductor.Host/Components/Shared/StatusBadgeTone.cs
@@ -1,0 +1,10 @@
+namespace Conductor.Host.Components.Shared;
+
+public enum StatusBadgeTone
+{
+    Neutral,
+    Info,
+    Success,
+    Warning,
+    Critical,
+}

--- a/src/Conductor.Host/Components/Shared/SuccessState.razor
+++ b/src/Conductor.Host/Components/Shared/SuccessState.razor
@@ -1,0 +1,35 @@
+<section class="@CssClass" role="status" aria-live="polite">
+    <span class="ui-state-icon ui-state-icon--success" aria-hidden="true"></span>
+    <div class="ui-state-copy">
+        <h2>@Title</h2>
+        @if (!string.IsNullOrWhiteSpace(Message))
+        {
+            <p>@Message</p>
+        }
+        @if (ChildContent is not null)
+        {
+            <div class="ui-state-actions">
+                @ChildContent
+            </div>
+        }
+    </div>
+</section>
+
+@code {
+    [Parameter]
+    public string Title { get; set; } = "Completed";
+
+    [Parameter]
+    public string? Message { get; set; }
+
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    [Parameter]
+    public string? Class { get; set; }
+
+    private string CssClass =>
+        string.IsNullOrWhiteSpace(Class)
+            ? "ui-state ui-state--success"
+            : $"ui-state ui-state--success {Class}";
+}

--- a/src/Conductor.Host/Components/_Imports.razor
+++ b/src/Conductor.Host/Components/_Imports.razor
@@ -7,3 +7,4 @@
 @using Conductor.Host.Components
 @using Conductor.Host.Components.Dashboard
 @using Conductor.Host.Components.Layout
+@using Conductor.Host.Components.Shared

--- a/src/Conductor.Host/wwwroot/app.css
+++ b/src/Conductor.Host/wwwroot/app.css
@@ -114,15 +114,59 @@ h2 {
   font-size: 1.25rem;
 }
 
-.status-pill {
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 34px;
+  gap: 8px;
   flex: 0 0 auto;
-  padding: 8px 12px;
-  border: 1px solid #45666d;
+  width: fit-content;
+  max-width: 100%;
+  padding: 7px 11px;
+  border: 1px solid #3b4652;
   border-radius: 999px;
-  background: #17373b;
-  color: #9ee7d7;
   font-size: 0.85rem;
   font-weight: 700;
+  line-height: 1.2;
+  overflow-wrap: anywhere;
+}
+
+.status-badge-indicator {
+  flex: 0 0 auto;
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: currentColor;
+}
+
+.status-badge--neutral {
+  border-color: #53606d;
+  background: #272d34;
+  color: #c7d0d9;
+}
+
+.status-badge--info {
+  border-color: #45666d;
+  background: #17373b;
+  color: #9ee7d7;
+}
+
+.status-badge--success {
+  border-color: #2d6f5e;
+  background: #12382d;
+  color: #9ee7d7;
+}
+
+.status-badge--warning {
+  border-color: #8a6823;
+  background: #3d3015;
+  color: #f2c14e;
+}
+
+.status-badge--critical {
+  border-color: #904247;
+  background: #452022;
+  color: #ffb4ab;
 }
 
 .metric-grid {
@@ -206,32 +250,6 @@ h2 {
   display: flex;
   flex-wrap: wrap;
   gap: 10px;
-}
-
-.heatmap-legend-item {
-  display: inline-flex;
-  align-items: center;
-  min-height: 34px;
-  gap: 8px;
-  padding: 6px 10px;
-  border: 1px solid #2b3138;
-  border-radius: 6px;
-  background: #1b2228;
-  color: #dbe6ee;
-  font-size: 0.85rem;
-}
-
-.heatmap-legend-item strong {
-  color: #ffffff;
-  font-size: 0.9rem;
-}
-
-.heatmap-legend-swatch {
-  width: 12px;
-  height: 12px;
-  border-radius: 3px;
-  border-width: 1px;
-  border-style: solid;
 }
 
 .heatmap-table-wrap {
@@ -393,11 +411,143 @@ h2 {
   color: #dbe6ee;
 }
 
-.empty-state {
-  padding: 24px;
+.startup-panel > .ui-state {
+  padding: 0;
+  border: 0;
+  background: transparent;
+}
+
+.ui-state {
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+  padding: 20px;
   border: 1px solid #2b3138;
   border-radius: 8px;
   background: #191f25;
+}
+
+.ui-state-copy {
+  display: grid;
+  gap: 8px;
+  min-width: 0;
+}
+
+.ui-state-copy h2 {
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.35;
+}
+
+.ui-state-copy p,
+.ui-state-copy small {
+  margin: 0;
+  color: #aeb9c5;
+  line-height: 1.5;
+}
+
+.ui-state-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 4px;
+}
+
+.ui-state-icon,
+.ui-state-spinner {
+  flex: 0 0 auto;
+  width: 34px;
+  height: 34px;
+  border: 1px solid #3b4652;
+  border-radius: 8px;
+  background: #151a1f;
+}
+
+.ui-state-icon {
+  position: relative;
+}
+
+.ui-state-icon::before,
+.ui-state-icon::after {
+  position: absolute;
+  content: "";
+}
+
+.ui-state-icon--empty::before {
+  inset: 10px 8px;
+  border-top: 2px solid #aeb9c5;
+  border-bottom: 2px solid #53606d;
+}
+
+.ui-state-icon--error {
+  border-color: #904247;
+  background: #452022;
+}
+
+.ui-state-icon--error::before,
+.ui-state-icon--error::after {
+  top: 15px;
+  left: 8px;
+  width: 16px;
+  height: 2px;
+  border-radius: 999px;
+  background: #ffb4ab;
+}
+
+.ui-state-icon--error::before {
+  transform: rotate(45deg);
+}
+
+.ui-state-icon--error::after {
+  transform: rotate(-45deg);
+}
+
+.ui-state-icon--success {
+  border-color: #2d6f5e;
+  background: #12382d;
+}
+
+.ui-state-icon--success::before {
+  top: 10px;
+  left: 9px;
+  width: 13px;
+  height: 7px;
+  border-bottom: 2px solid #9ee7d7;
+  border-left: 2px solid #9ee7d7;
+  transform: rotate(-45deg);
+}
+
+.ui-state-spinner {
+  border-color: #2b3138;
+  border-top-color: #9ee7d7;
+  border-radius: 999px;
+  animation: ui-state-spin 900ms linear infinite;
+}
+
+.ui-state--loading {
+  background: #151a1f;
+}
+
+.ui-state--error {
+  border-color: #904247;
+  background: #241b1f;
+}
+
+.ui-state--success {
+  border-color: #2d6f5e;
+  background: #14261f;
+}
+
+@keyframes ui-state-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ui-state-spinner {
+    animation: none;
+  }
 }
 
 @media (max-width: 760px) {

--- a/tests/Conductor.Blazor.Tests/SharedUiStateTests.cs
+++ b/tests/Conductor.Blazor.Tests/SharedUiStateTests.cs
@@ -1,0 +1,98 @@
+using Bunit;
+using Conductor.Host.Components.Shared;
+
+namespace Conductor.Blazor.Tests;
+
+public sealed class SharedUiStateTests
+{
+    [Fact]
+    public void StatusBadge_Renders_Text_Tone_Class_And_Accessible_Label()
+    {
+        using BunitContext context = new();
+
+        IRenderedComponent<StatusBadge> component = context.Render<StatusBadge>(parameters => parameters
+            .Add(badge => badge.Text, "Healthy")
+            .Add(badge => badge.Tone, StatusBadgeTone.Success));
+
+        Assert.Contains("Healthy", component.Markup, StringComparison.Ordinal);
+        Assert.Contains("status-badge--success", component.Markup, StringComparison.Ordinal);
+        Assert.Contains("Success status: Healthy", component.Markup, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void StatusBadge_Uses_Tone_Label_When_Text_Is_Empty()
+    {
+        using BunitContext context = new();
+
+        IRenderedComponent<StatusBadge> component = context.Render<StatusBadge>(parameters => parameters
+            .Add(badge => badge.Tone, StatusBadgeTone.Warning));
+
+        Assert.Contains(">Warning<", component.Markup, StringComparison.Ordinal);
+        Assert.Contains("status-badge--warning", component.Markup, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void LoadingState_Renders_Polite_Busy_Status()
+    {
+        using BunitContext context = new();
+
+        IRenderedComponent<LoadingState> component = context.Render<LoadingState>(parameters => parameters
+            .Add(state => state.Title, "Loading repositories")
+            .Add(state => state.Message, "Fetching dashboard projection data."));
+
+        Assert.Contains("role=\"status\"", component.Markup, StringComparison.Ordinal);
+        Assert.Contains("aria-busy=\"true\"", component.Markup, StringComparison.Ordinal);
+        Assert.Contains("Loading repositories", component.Markup, StringComparison.Ordinal);
+        Assert.Contains("Fetching dashboard projection data.", component.Markup, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void EmptyState_Renders_Action_Content()
+    {
+        using BunitContext context = new();
+
+        IRenderedComponent<EmptyState> component = context.Render<EmptyState>(parameters => parameters
+            .Add(state => state.Title, "No repositories yet")
+            .Add(state => state.Message, "Imported repositories will appear here.")
+            .AddChildContent("<button type=\"button\">Import repository</button>"));
+
+        Assert.Contains("No repositories yet", component.Markup, StringComparison.Ordinal);
+        Assert.Contains("Imported repositories will appear here.", component.Markup, StringComparison.Ordinal);
+        Assert.Contains("Import repository", component.Markup, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ErrorState_Renders_Alert_Detail_And_Action_Content()
+    {
+        using BunitContext context = new();
+
+        IRenderedComponent<ErrorState> component = context.Render<ErrorState>(parameters => parameters
+            .Add(state => state.Title, "Dashboard failed")
+            .Add(state => state.Message, "Projection data could not be loaded.")
+            .Add(state => state.Detail, "Correlation ID: abc123")
+            .AddChildContent("<button type=\"button\">Retry</button>"));
+
+        Assert.Contains("role=\"alert\"", component.Markup, StringComparison.Ordinal);
+        Assert.Contains("Dashboard failed", component.Markup, StringComparison.Ordinal);
+        Assert.Contains("Projection data could not be loaded.", component.Markup, StringComparison.Ordinal);
+        Assert.Contains("Correlation ID: abc123", component.Markup, StringComparison.Ordinal);
+        Assert.Contains("Retry", component.Markup, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SuccessState_Renders_Polite_Status_And_Action_Content()
+    {
+        using BunitContext context = new();
+
+        IRenderedComponent<SuccessState> component = context.Render<SuccessState>(parameters => parameters
+            .Add(state => state.Title, "Repository imported")
+            .Add(state => state.Message, "The repository is ready for orchestration.")
+            .AddChildContent("<a href=\"/repositories\">View repositories</a>"));
+
+        Assert.Contains("role=\"status\"", component.Markup, StringComparison.Ordinal);
+        Assert.Contains("aria-live=\"polite\"", component.Markup, StringComparison.Ordinal);
+        Assert.Contains("Repository imported", component.Markup, StringComparison.Ordinal);
+        Assert.Contains("The repository is ready for orchestration.", component.Markup, StringComparison.Ordinal);
+        Assert.Contains("View repositories", component.Markup, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## Summary
- Add reusable Blazor loading, empty, error, success, and status badge components under `Components/Shared`.
- Wire shared badges/states into the dashboard health summary, empty heatmap state, startup panel, and not-found route.
- Add focused bUnit coverage for the shared UI states and status badge rendering/accessibility behavior.
- Update README/testing docs to mention the shared UI component coverage.

## Validation
- `dotnet restore Conductor.slnx`: passed with no errors or warnings
- `dotnet build Conductor.slnx --no-restore --warnaserror`: passed with no errors or warnings
- `dotnet test Conductor.slnx --no-build`: passed with no errors or warnings
- `dotnet format Conductor.slnx --no-restore --verify-no-changes`: passed with no changes required
- `./scripts/validate-docs.ps1`: passed

Closes #27