### PR TITLE
Build live activity stream component

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ dotnet format Conductor.slnx --no-restore --verify-no-changes
 dotnet run --project src/Conductor.Host/Conductor.Host.csproj
 ```
 
-The root route (`/`) serves the dashboard baseline for local startup checks, including a reusable repository orchestration health heatmap populated with starter projection data. The same startup baseline also exposes `/health/live` and `/health/ready`.
+The root route (`/`) serves the dashboard baseline for local startup checks, including a reusable repository orchestration health heatmap and live activity stream populated with starter projection data. The same startup baseline also exposes `/health/live` and `/health/ready`.
 
 ## Persistence Configuration
 

--- a/src/Conductor.Core/Application/Dashboard/LiveActivityEvent.cs
+++ b/src/Conductor.Core/Application/Dashboard/LiveActivityEvent.cs
@@ -1,0 +1,40 @@
+using Conductor.Core.Common;
+using Conductor.Core.Domain;
+
+namespace Conductor.Core.Application.Dashboard;
+
+public sealed record LiveActivityEvent
+{
+    public LiveActivityEvent(
+        DateTimeOffset occurredAtUtc,
+        EventSeverity severity,
+        string eventType,
+        string sourceName,
+        int? issueNumber,
+        string message)
+    {
+        if (!Enum.IsDefined(severity))
+        {
+            throw new ArgumentOutOfRangeException(nameof(severity), severity, "A known event severity is required.");
+        }
+
+        OccurredAtUtc = occurredAtUtc;
+        Severity = severity;
+        EventType = Guard.NotWhiteSpace(eventType, nameof(eventType));
+        SourceName = Guard.NotWhiteSpace(sourceName, nameof(sourceName));
+        IssueNumber = issueNumber.HasValue ? Guard.Positive(issueNumber.Value, nameof(issueNumber)) : null;
+        Message = Guard.NotWhiteSpace(message, nameof(message));
+    }
+
+    public DateTimeOffset OccurredAtUtc { get; }
+
+    public EventSeverity Severity { get; }
+
+    public string EventType { get; }
+
+    public string SourceName { get; }
+
+    public int? IssueNumber { get; }
+
+    public string Message { get; }
+}

--- a/src/Conductor.Host/Components/Dashboard/LiveActivityStream.razor
+++ b/src/Conductor.Host/Components/Dashboard/LiveActivityStream.razor
@@ -1,0 +1,145 @@
+@using System.Globalization
+@using Conductor.Core.Application.Dashboard
+@using Conductor.Core.Domain
+
+<section class="live-activity-stream" aria-labelledby="@headingId">
+    <header class="live-activity-header">
+        <div>
+            <p class="eyebrow">Activity stream</p>
+            <h2 id="@headingId">@Title</h2>
+            @if (!string.IsNullOrWhiteSpace(Description))
+            {
+                <p>@Description</p>
+            }
+        </div>
+        <span class="live-activity-state">Live</span>
+    </header>
+
+    @if (orderedEvents.Length == 0)
+    {
+        <p class="empty-state">No operational activity has been recorded yet.</p>
+    }
+    else
+    {
+        <ol class="live-activity-list">
+            @foreach (LiveActivityEvent activity in orderedEvents)
+            {
+                <li class="@GetItemClass(activity.Severity)">
+                    <span class="@GetSeverityMarkerClass(activity.Severity)" aria-hidden="true">
+                        @GetSeverityInitial(activity.Severity)
+                    </span>
+                    <div class="live-activity-body">
+                        <div class="live-activity-meta">
+                            <time datetime="@FormatDateTime(activity.OccurredAtUtc)">
+                                @GetRelativeTime(activity.OccurredAtUtc)
+                            </time>
+                            <span>@GetSeverityLabel(activity.Severity)</span>
+                            <span>@activity.EventType</span>
+                        </div>
+                        <p>
+                            <strong>@activity.SourceName</strong>
+                            @if (activity.IssueNumber is int issueNumber)
+                            {
+                                <span class="activity-issue">#@issueNumber.ToString(CultureInfo.InvariantCulture)</span>
+                            }
+                            <span>@activity.Message</span>
+                        </p>
+                    </div>
+                </li>
+            }
+        </ol>
+    }
+</section>
+
+@code {
+    private readonly string headingId = $"live-activity-{Guid.NewGuid():N}";
+    private LiveActivityEvent[] orderedEvents = [];
+
+    [Parameter]
+    public string Title { get; set; } = "Live activity";
+
+    [Parameter]
+    public string? Description { get; set; } = "Recent operational events across repositories and Symphony instances.";
+
+    [Parameter]
+    public IReadOnlyList<LiveActivityEvent>? Events { get; set; }
+
+    [Parameter]
+    public DateTimeOffset? ReferenceTimeUtc { get; set; }
+
+    protected override void OnParametersSet()
+    {
+        orderedEvents = (Events ?? [])
+            .OrderByDescending(activity => activity.OccurredAtUtc)
+            .ThenBy(activity => activity.SourceName, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private DateTimeOffset CurrentReferenceTimeUtc => ReferenceTimeUtc?.ToUniversalTime() ?? DateTimeOffset.UtcNow;
+
+    private static string GetItemClass(EventSeverity severity) =>
+        $"live-activity-item live-activity-item--{GetSeverityCssName(severity)}";
+
+    private static string GetSeverityMarkerClass(EventSeverity severity) =>
+        $"live-activity-marker live-activity-marker--{GetSeverityCssName(severity)}";
+
+    private static string GetSeverityCssName(EventSeverity severity) =>
+        severity switch
+        {
+            EventSeverity.Information => "information",
+            EventSeverity.Warning => "warning",
+            EventSeverity.Error => "error",
+            EventSeverity.Critical => "critical",
+            _ => "unknown",
+        };
+
+    private static string GetSeverityInitial(EventSeverity severity) =>
+        severity switch
+        {
+            EventSeverity.Information => "i",
+            EventSeverity.Warning => "!",
+            EventSeverity.Error => "x",
+            EventSeverity.Critical => "!",
+            _ => "?",
+        };
+
+    private static string GetSeverityLabel(EventSeverity severity) =>
+        severity switch
+        {
+            EventSeverity.Information => "Info",
+            EventSeverity.Warning => "Warning",
+            EventSeverity.Error => "Error",
+            EventSeverity.Critical => "Critical",
+            _ => "Unknown",
+        };
+
+    private static string FormatDateTime(DateTimeOffset value) =>
+        value.ToUniversalTime().ToString("O", CultureInfo.InvariantCulture);
+
+    private string GetRelativeTime(DateTimeOffset occurredAtUtc)
+    {
+        TimeSpan elapsed = CurrentReferenceTimeUtc - occurredAtUtc.ToUniversalTime();
+
+        if (elapsed <= TimeSpan.Zero || elapsed < TimeSpan.FromMinutes(1))
+        {
+            return "Just now";
+        }
+
+        if (elapsed < TimeSpan.FromHours(1))
+        {
+            return FormatRelativeUnit((int)elapsed.TotalMinutes, "m");
+        }
+
+        if (elapsed < TimeSpan.FromDays(1))
+        {
+            return FormatRelativeUnit((int)elapsed.TotalHours, "h");
+        }
+
+        return FormatRelativeUnit((int)elapsed.TotalDays, "d");
+    }
+
+    private static string FormatRelativeUnit(int value, string unit) =>
+        string.Create(
+            CultureInfo.InvariantCulture,
+            $"{Math.Max(value, 1)}{unit} ago");
+}

--- a/src/Conductor.Host/Components/Pages/Home.razor
+++ b/src/Conductor.Host/Components/Pages/Home.razor
@@ -1,3 +1,6 @@
+@using Conductor.Core.Application.Dashboard
+@using Conductor.Core.Domain
+
 @page "/"
 
 <PageTitle>Conductor Dashboard</PageTitle>
@@ -24,18 +27,7 @@
 
     <HealthHeatmap Buckets="HealthBuckets" />
 
-    <section class="activity-panel">
-        <div>
-            <h2>Operational baseline</h2>
-            <p>The host is running with the initial project, persistence, dashboard, and test structure in place.</p>
-        </div>
-        <ul>
-            @foreach (string indicator in Indicators)
-            {
-                <li>@indicator</li>
-            }
-        </ul>
-    </section>
+    <LiveActivityStream Events="ActivityEvents" ReferenceTimeUtc="ReferenceTimeUtc" />
 
     <section class="startup-panel" aria-label="Startup verification">
         <div>
@@ -94,12 +86,38 @@
         new("Operations Docs", "18:00", HealthHeatmapStatus.Healthy, 95, "Stale branch warning cleared."),
     ];
 
-    private static readonly string[] Indicators =
+    private static readonly DateTimeOffset ReferenceTimeUtc = new(2026, 4, 29, 18, 20, 0, TimeSpan.Zero);
+
+    private static readonly LiveActivityEvent[] ActivityEvents =
     [
-        "Blazor Web App host",
-        "SQLite persistence registration",
-        "Health endpoints",
-        "Layered test projects",
+        new(
+            ReferenceTimeUtc.AddMinutes(-4),
+            EventSeverity.Information,
+            "Workspace prepared",
+            "acme-portal",
+            128,
+            "Workspace prepared for the next orchestration run."),
+        new(
+            ReferenceTimeUtc.AddMinutes(-8),
+            EventSeverity.Error,
+            "Continuation started",
+            "billing-api",
+            77,
+            "Tests failed and a continuation run started."),
+        new(
+            ReferenceTimeUtc.AddMinutes(-12),
+            EventSeverity.Warning,
+            "Instance offline",
+            "client-mobile",
+            null,
+            "Symphony instance health moved to offline."),
+        new(
+            ReferenceTimeUtc.AddMinutes(-15),
+            EventSeverity.Information,
+            "Run completed",
+            "data-pipeline",
+            102,
+            "Run completed successfully."),
     ];
 
     private static readonly (string Label, string Route, string State)[] StartupChecks =

--- a/src/Conductor.Host/wwwroot/app.css
+++ b/src/Conductor.Host/wwwroot/app.css
@@ -151,34 +151,134 @@ h2 {
   line-height: 1;
 }
 
-.activity-panel {
+.live-activity-stream {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(220px, 320px);
-  gap: 24px;
+  gap: 18px;
   padding: 24px;
   border: 1px solid #2b3138;
   border-radius: 8px;
   background: #191f25;
 }
 
-.activity-panel p {
+.live-activity-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.live-activity-header p:not(.eyebrow) {
   margin-bottom: 0;
   color: #aeb9c5;
 }
 
-.activity-panel ul {
+.live-activity-state {
+  flex: 0 0 auto;
+  padding: 6px 10px;
+  border: 1px solid #2d6f5e;
+  border-radius: 999px;
+  background: #12382d;
+  color: #9ee7d7;
+  font-size: 0.78rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.live-activity-list {
   display: grid;
-  gap: 10px;
+  gap: 0;
   margin: 0;
   padding: 0;
   list-style: none;
 }
 
-.activity-panel li {
-  padding: 10px 12px;
-  border-radius: 6px;
-  background: #232a31;
+.live-activity-item {
+  display: grid;
+  grid-template-columns: 34px minmax(0, 1fr);
+  gap: 12px;
+  padding: 14px 0;
+  border-top: 1px solid #2b3138;
+}
+
+.live-activity-item:first-child {
+  border-top: 0;
+  padding-top: 0;
+}
+
+.live-activity-item:last-child {
+  padding-bottom: 0;
+}
+
+.live-activity-marker {
+  display: inline-grid;
+  width: 30px;
+  height: 30px;
+  place-items: center;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 900;
+  line-height: 1;
+}
+
+.live-activity-marker--information {
+  border-color: #2f6ea5;
+  background: #143252;
+  color: #8ecbff;
+}
+
+.live-activity-marker--warning {
+  border-color: #8a6823;
+  background: #3d3015;
+  color: #f2c14e;
+}
+
+.live-activity-marker--error,
+.live-activity-marker--critical {
+  border-color: #904247;
+  background: #452022;
+  color: #ffb4ab;
+}
+
+.live-activity-body {
+  display: grid;
+  gap: 6px;
+  min-width: 0;
+}
+
+.live-activity-body p {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 0;
   color: #dbe6ee;
+}
+
+.live-activity-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  color: #aeb9c5;
+  font-size: 0.82rem;
+}
+
+.live-activity-meta span {
+  display: inline-flex;
+  align-items: center;
+}
+
+.live-activity-meta span:not(:first-of-type)::before {
+  content: "";
+  width: 4px;
+  height: 4px;
+  margin-right: 8px;
+  border-radius: 999px;
+  background: #53606d;
+}
+
+.activity-issue {
+  color: #9dbdff;
+  font-weight: 700;
 }
 
 .health-heatmap {
@@ -413,12 +513,16 @@ h2 {
 
   .side-nav nav,
   .metric-grid,
-  .activity-panel,
+  .live-activity-header,
   .startup-panel dl {
     grid-template-columns: 1fr;
   }
 
   .health-heatmap-header {
+    display: grid;
+  }
+
+  .live-activity-header {
     display: grid;
   }
 

--- a/tests/Conductor.Blazor.Tests/DashboardSmokeTests.cs
+++ b/tests/Conductor.Blazor.Tests/DashboardSmokeTests.cs
@@ -13,7 +13,8 @@ public sealed class DashboardSmokeTests
         IRenderedComponent<Home> dashboard = context.Render<Home>();
 
         Assert.Contains("Conductor Dashboard", dashboard.Markup, StringComparison.Ordinal);
-        Assert.Contains("SQLite persistence registration", dashboard.Markup, StringComparison.Ordinal);
+        Assert.Contains("Live activity", dashboard.Markup, StringComparison.Ordinal);
+        Assert.Contains("Tests failed and a continuation run started.", dashboard.Markup, StringComparison.Ordinal);
         Assert.Contains("Repository orchestration health", dashboard.Markup, StringComparison.Ordinal);
         Assert.Contains("Release Portal", dashboard.Markup, StringComparison.Ordinal);
         Assert.Contains("Startup verification", dashboard.Markup, StringComparison.Ordinal);

--- a/tests/Conductor.Blazor.Tests/LiveActivityStreamTests.cs
+++ b/tests/Conductor.Blazor.Tests/LiveActivityStreamTests.cs
@@ -1,0 +1,60 @@
+using Bunit;
+using Conductor.Core.Application.Dashboard;
+using Conductor.Core.Domain;
+using Conductor.Host.Components.Dashboard;
+
+namespace Conductor.Blazor.Tests;
+
+public sealed class LiveActivityStreamTests
+{
+    private static readonly DateTimeOffset ReferenceTime = new(2026, 4, 29, 18, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public void LiveActivityStream_Renders_Recent_Events_In_Descending_Time_Order()
+    {
+        using BunitContext context = new();
+        LiveActivityEvent[] events =
+        [
+            new(ReferenceTime.AddMinutes(-10), EventSeverity.Warning, "Instance offline", "client-mobile", null, "Symphony instance stopped responding."),
+            new(ReferenceTime.AddMinutes(-2), EventSeverity.Error, "Run failed", "billing-api", 77, "Tests failed and a continuation started."),
+            new(ReferenceTime.AddMinutes(-20), EventSeverity.Information, "Workspace prepared", "acme-portal", 128, "Workspace prepared for execution."),
+        ];
+
+        IRenderedComponent<LiveActivityStream> component = context.Render<LiveActivityStream>(parameters => parameters
+            .Add(component => component.Events, events)
+            .Add(component => component.ReferenceTimeUtc, ReferenceTime));
+
+        string markup = component.Markup;
+
+        Assert.Contains("Live activity", markup, StringComparison.Ordinal);
+        Assert.Contains("2m ago", markup, StringComparison.Ordinal);
+        Assert.Contains("10m ago", markup, StringComparison.Ordinal);
+        Assert.Contains("20m ago", markup, StringComparison.Ordinal);
+        Assert.Contains("billing-api", markup, StringComparison.Ordinal);
+        Assert.Contains("#77", markup, StringComparison.Ordinal);
+        Assert.Contains("Error", markup, StringComparison.Ordinal);
+        Assert.True(
+            markup.IndexOf("billing-api", StringComparison.Ordinal) < markup.IndexOf("client-mobile", StringComparison.Ordinal),
+            "Expected newest activity to render before older activity.");
+    }
+
+    [Fact]
+    public void LiveActivityStream_Renders_Empty_State_Without_Events()
+    {
+        using BunitContext context = new();
+
+        IRenderedComponent<LiveActivityStream> component = context.Render<LiveActivityStream>();
+
+        Assert.Contains("No operational activity has been recorded yet.", component.Markup, StringComparison.Ordinal);
+        Assert.DoesNotContain("<ol", component.Markup, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void LiveActivityEvent_Requires_Positive_Issue_Number()
+    {
+        ArgumentOutOfRangeException exception = Assert.Throws<ArgumentOutOfRangeException>(
+            () => new LiveActivityEvent(ReferenceTime, EventSeverity.Information, "Run queued", "billing-api", 0, "Queued."));
+
+        Assert.Equal("issueNumber", exception.ParamName);
+    }
+}

--- a/tests/Conductor.Host.Tests/HostSmokeTests.cs
+++ b/tests/Conductor.Host.Tests/HostSmokeTests.cs
@@ -23,15 +23,15 @@ public sealed class HostSmokeTests : IClassFixture<WebApplicationFactory<global:
     }
 
     [Fact]
-    public async Task HomePageServesPlaceholderDashboard()
+    public async Task HomePageServesDashboardWithLiveActivity()
     {
         using HttpClient client = CreateClient();
 
         string content = await client.GetStringAsync("/");
 
         Assert.Contains("Conductor Dashboard", content);
-        Assert.Contains("Operational baseline", content);
-        Assert.Contains("Health endpoints", content);
+        Assert.Contains("Live activity", content);
+        Assert.Contains("Tests failed and a continuation run started.", content);
         Assert.Contains("Startup verification", content);
         Assert.Contains("/health/ready", content);
     }


### PR DESCRIPTION
## Summary
- Added a typed `LiveActivityEvent` dashboard projection model for recent operational events.
- Added a reusable Blazor `LiveActivityStream` component with severity markers, relative timestamps, issue references, ordering, and empty state.
- Replaced the dashboard activity placeholder with starter live activity projection data and updated smoke/component coverage plus README dashboard notes.

## Validation
- `dotnet format Conductor.slnx --no-restore --verify-no-changes`: passed with no changes
- `git diff --check`: passed
- `dotnet build Conductor.slnx --no-restore --warnaserror`: passed with 0 warnings
- `dotnet test Conductor.slnx --no-build`: passed

Closes #26