### PR TITLE
Implement Symphony API client contracts

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,6 +10,7 @@
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.5" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.5" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.5" />
   </ItemGroup>
 
   <ItemGroup Label="Testing">

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,7 +1,21 @@
 # API Documentation
 
-Status: Planned
+Status: Draft
 
-This document will describe Conductor's public and internal HTTP APIs as endpoints become stable.
+This document describes Conductor's public and internal HTTP APIs as endpoints become stable.
 
-The current API direction is defined in [requirements.md](requirements.md) and [technical.md](technical.md). Endpoint-level request and response examples will be added when the Minimal API surface is implemented.
+The current API direction is defined in [requirements.md](requirements.md) and [technical.md](technical.md).
+
+## Symphony Runtime Client
+
+Conductor registers a named HTTP client called `SymphonyApi` for calls to existing Symphony runtimes. The typed client uses the Symphony instance base URL and appends these runtime endpoints:
+
+| Client method | Method | Endpoint | Notes |
+| --- | --- | --- | --- |
+| `GetHealthAsync` | `GET` | `/api/v1/health` | Uses a 3 second timeout, preserves raw JSON, and maps reported health to `InstanceHealthStatus`. Network failures are returned as `Offline` health probes. |
+| `GetRuntimeAsync` | `GET` | `/api/v1/runtime` | Uses a 10 second timeout and preserves the runtime JSON payload for snapshot ingestion. |
+| `GetWorkflowAsync` | `GET` | `/api/v1/workflow` | Reads workflow source from a `source`, `workflowSource`, `content`, or `workflow` JSON field, or treats the response body as raw source. Preserves the response ETag. |
+| `SaveWorkflowAsync` | `PUT` | `/api/v1/workflow` | Sends `{ "source": "..." }`, forwards the document ETag as `If-Match` when present, and uses a 15 second timeout. |
+| `GetStateAsync` | `GET` | `/api/v1/state` | Uses a 10 second timeout and preserves the state JSON payload for snapshot ingestion. |
+| `GetIssueAsync` | `GET` | `/api/v1/{issue_identifier}` | URL-encodes the issue identifier, returns `null` for `404`, and otherwise preserves issue detail JSON. |
+| `RequestRefreshAsync` | `POST` | `/api/v1/refresh` | Uses a 10 second timeout and returns whether Symphony accepted the best-effort refresh request. |

--- a/src/Conductor.Host/Conductor.Host.csproj
+++ b/src/Conductor.Host/Conductor.Host.csproj
@@ -3,6 +3,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Conductor.Core\Conductor.Core.csproj" />
     <ProjectReference Include="..\Conductor.Infrastructure.Persistence.Sqlite\Conductor.Infrastructure.Persistence.Sqlite.csproj" />
+    <ProjectReference Include="..\Conductor.Infrastructure.Symphony\Conductor.Infrastructure.Symphony.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Conductor.Host/Program.cs
+++ b/src/Conductor.Host/Program.cs
@@ -4,6 +4,7 @@ using Conductor.Host.Dashboard;
 using Conductor.Host.Endpoints;
 using Conductor.Host.Workers;
 using Conductor.Infrastructure.Persistence.Sqlite;
+using Conductor.Infrastructure.Symphony;
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
@@ -16,6 +17,7 @@ builder.Services.Configure<DashboardProjectionOptions>(
 builder.Services.AddSingleton<IDashboardProjectionStore, JsonFileDashboardProjectionStore>();
 builder.Services.AddHealthChecks();
 builder.Services.AddConductorPersistence(builder.Configuration);
+builder.Services.AddConductorSymphony();
 builder.Services.AddConductorWorkers();
 
 WebApplication app = builder.Build();

--- a/src/Conductor.Infrastructure.Symphony/Conductor.Infrastructure.Symphony.csproj
+++ b/src/Conductor.Infrastructure.Symphony/Conductor.Infrastructure.Symphony.csproj
@@ -1,6 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Http" />
+
     <ProjectReference Include="..\Conductor.Core\Conductor.Core.csproj" />
   </ItemGroup>
 

--- a/src/Conductor.Infrastructure.Symphony/SymphonyApiClient.cs
+++ b/src/Conductor.Infrastructure.Symphony/SymphonyApiClient.cs
@@ -1,0 +1,412 @@
+using System.Diagnostics;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using Conductor.Core.Abstractions.Symphony;
+using Conductor.Core.Domain;
+
+namespace Conductor.Infrastructure.Symphony;
+
+public sealed class SymphonyApiClient(HttpClient httpClient) : ISymphonyApiClient
+{
+    public const string HttpClientName = "SymphonyApi";
+
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+    private static readonly TimeSpan HealthTimeout = TimeSpan.FromSeconds(3);
+    private static readonly TimeSpan ReadTimeout = TimeSpan.FromSeconds(10);
+    private static readonly TimeSpan WorkflowSaveTimeout = TimeSpan.FromSeconds(15);
+
+    public async Task<SymphonyHealthResponse> GetHealthAsync(
+        Uri baseUri,
+        CancellationToken cancellationToken)
+    {
+        Stopwatch stopwatch = Stopwatch.StartNew();
+
+        try
+        {
+            using HttpResponseMessage response = await SendAsync(
+                HttpMethod.Get,
+                baseUri,
+                "api/v1/health",
+                HealthTimeout,
+                cancellationToken);
+
+            string rawJson = NormalizeRawJson(await ReadBodyAsync(response, cancellationToken));
+
+            return new SymphonyHealthResponse(
+                MapHealthStatus(response, rawJson),
+                (int)response.StatusCode,
+                stopwatch.Elapsed,
+                rawJson);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            return new SymphonyHealthResponse(
+                InstanceHealthStatus.Offline,
+                null,
+                stopwatch.Elapsed,
+                JsonSerializer.Serialize(
+                    new HealthFailure("timeout", "Symphony health request timed out."),
+                    JsonOptions));
+        }
+        catch (HttpRequestException exception)
+        {
+            return new SymphonyHealthResponse(
+                InstanceHealthStatus.Offline,
+                null,
+                stopwatch.Elapsed,
+                JsonSerializer.Serialize(
+                    new HealthFailure("request_failed", exception.Message),
+                    JsonOptions));
+        }
+    }
+
+    public async Task<SymphonyRuntimeResponse> GetRuntimeAsync(
+        Uri baseUri,
+        CancellationToken cancellationToken)
+    {
+        const string endpoint = "api/v1/runtime";
+
+        using HttpResponseMessage response = await SendAsync(
+            HttpMethod.Get,
+            baseUri,
+            endpoint,
+            ReadTimeout,
+            cancellationToken);
+
+        string rawJson = await ReadBodyAsync(response, cancellationToken);
+        EnsureSuccess(response, endpoint);
+
+        return new SymphonyRuntimeResponse(rawJson);
+    }
+
+    public async Task<SymphonyWorkflowDocument> GetWorkflowAsync(
+        Uri baseUri,
+        CancellationToken cancellationToken)
+    {
+        const string endpoint = "api/v1/workflow";
+
+        using HttpResponseMessage response = await SendAsync(
+            HttpMethod.Get,
+            baseUri,
+            endpoint,
+            ReadTimeout,
+            cancellationToken);
+
+        string body = await ReadBodyAsync(response, cancellationToken);
+        EnsureSuccess(response, endpoint);
+
+        return ToWorkflowDocument(body, response, fallback: null);
+    }
+
+    public async Task<SymphonyWorkflowDocument> SaveWorkflowAsync(
+        Uri baseUri,
+        SymphonyWorkflowDocument document,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(document);
+
+        const string endpoint = "api/v1/workflow";
+        string payload = JsonSerializer.Serialize(new WorkflowPayload(document.Source), JsonOptions);
+
+        using HttpResponseMessage response = await SendAsync(
+            HttpMethod.Put,
+            baseUri,
+            endpoint,
+            WorkflowSaveTimeout,
+            cancellationToken,
+            payload,
+            request =>
+            {
+                if (!string.IsNullOrWhiteSpace(document.ETag))
+                {
+                    request.Headers.TryAddWithoutValidation("If-Match", document.ETag);
+                }
+            });
+
+        string body = await ReadBodyAsync(response, cancellationToken);
+        EnsureSuccess(response, endpoint);
+
+        return ToWorkflowDocument(body, response, document);
+    }
+
+    public async Task<SymphonyStateResponse> GetStateAsync(
+        Uri baseUri,
+        CancellationToken cancellationToken)
+    {
+        const string endpoint = "api/v1/state";
+
+        using HttpResponseMessage response = await SendAsync(
+            HttpMethod.Get,
+            baseUri,
+            endpoint,
+            ReadTimeout,
+            cancellationToken);
+
+        string rawJson = await ReadBodyAsync(response, cancellationToken);
+        EnsureSuccess(response, endpoint);
+
+        return new SymphonyStateResponse(rawJson);
+    }
+
+    public async Task<SymphonyIssueResponse?> GetIssueAsync(
+        Uri baseUri,
+        string issueIdentifier,
+        CancellationToken cancellationToken)
+    {
+        string normalizedIdentifier = RequireNonEmpty(issueIdentifier, nameof(issueIdentifier));
+        string endpoint = $"api/v1/{Uri.EscapeDataString(normalizedIdentifier)}";
+
+        using HttpResponseMessage response = await SendAsync(
+            HttpMethod.Get,
+            baseUri,
+            endpoint,
+            ReadTimeout,
+            cancellationToken);
+
+        string rawJson = await ReadBodyAsync(response, cancellationToken);
+
+        if (response.StatusCode == HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+
+        EnsureSuccess(response, endpoint);
+
+        return new SymphonyIssueResponse(normalizedIdentifier, rawJson);
+    }
+
+    public async Task<SymphonyRefreshResponse> RequestRefreshAsync(
+        Uri baseUri,
+        CancellationToken cancellationToken)
+    {
+        const string endpoint = "api/v1/refresh";
+
+        using HttpResponseMessage response = await SendAsync(
+            HttpMethod.Post,
+            baseUri,
+            endpoint,
+            ReadTimeout,
+            cancellationToken);
+
+        string rawJson = NormalizeRawJson(await ReadBodyAsync(response, cancellationToken));
+        EnsureSuccess(response, endpoint);
+
+        return new SymphonyRefreshResponse(
+            response.StatusCode == HttpStatusCode.Accepted || response.IsSuccessStatusCode,
+            rawJson);
+    }
+
+    private async Task<HttpResponseMessage> SendAsync(
+        HttpMethod method,
+        Uri baseUri,
+        string endpoint,
+        TimeSpan timeout,
+        CancellationToken cancellationToken,
+        string? jsonContent = null,
+        Action<HttpRequestMessage>? configureRequest = null)
+    {
+        using CancellationTokenSource timeoutSource =
+            CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutSource.CancelAfter(timeout);
+
+        using HttpRequestMessage request = new(method, BuildEndpointUri(baseUri, endpoint));
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+
+        if (jsonContent is not null)
+        {
+            request.Content = new StringContent(jsonContent, Encoding.UTF8, "application/json");
+        }
+
+        configureRequest?.Invoke(request);
+
+        return await httpClient.SendAsync(
+            request,
+            HttpCompletionOption.ResponseContentRead,
+            timeoutSource.Token);
+    }
+
+    private static Uri BuildEndpointUri(Uri baseUri, string endpoint)
+    {
+        ArgumentNullException.ThrowIfNull(baseUri);
+
+        if (!baseUri.IsAbsoluteUri)
+        {
+            throw new ArgumentException("Symphony base URI must be absolute.", nameof(baseUri));
+        }
+
+        UriBuilder builder = new(baseUri)
+        {
+            Fragment = string.Empty,
+            Query = string.Empty,
+        };
+
+        if (!builder.Path.EndsWith("/", StringComparison.Ordinal))
+        {
+            builder.Path += "/";
+        }
+
+        return new Uri(builder.Uri, endpoint);
+    }
+
+    private static async Task<string> ReadBodyAsync(
+        HttpResponseMessage response,
+        CancellationToken cancellationToken) =>
+        response.Content is null
+            ? string.Empty
+            : await response.Content.ReadAsStringAsync(cancellationToken);
+
+    private static void EnsureSuccess(HttpResponseMessage response, string endpoint)
+    {
+        if (response.IsSuccessStatusCode)
+        {
+            return;
+        }
+
+        throw new HttpRequestException(
+            $"Symphony endpoint '{endpoint}' returned HTTP {(int)response.StatusCode} ({response.ReasonPhrase}).",
+            inner: null,
+            response.StatusCode);
+    }
+
+    private static string NormalizeRawJson(string rawJson) =>
+        rawJson.Length == 0 ? "{}" : rawJson;
+
+    private static InstanceHealthStatus MapHealthStatus(
+        HttpResponseMessage response,
+        string rawJson)
+    {
+        InstanceHealthStatus? reportedStatus = TryReadHealthStatus(rawJson);
+
+        if (reportedStatus.HasValue)
+        {
+            return reportedStatus.Value;
+        }
+
+        if (response.IsSuccessStatusCode)
+        {
+            return InstanceHealthStatus.Healthy;
+        }
+
+        return (int)response.StatusCode >= 500
+            ? InstanceHealthStatus.Critical
+            : InstanceHealthStatus.Warning;
+    }
+
+    private static InstanceHealthStatus? TryReadHealthStatus(string rawJson)
+    {
+        if (string.IsNullOrWhiteSpace(rawJson))
+        {
+            return null;
+        }
+
+        try
+        {
+            using JsonDocument document = JsonDocument.Parse(rawJson);
+
+            if (document.RootElement.ValueKind != JsonValueKind.Object)
+            {
+                return null;
+            }
+
+            string? status = ReadStringProperty(document.RootElement, "status")
+                ?? ReadStringProperty(document.RootElement, "healthStatus")
+                ?? ReadStringProperty(document.RootElement, "health");
+
+            return status is null ? null : ParseHealthStatus(status);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static InstanceHealthStatus? ParseHealthStatus(string status) =>
+        status.Trim().ToLowerInvariant() switch
+        {
+            "healthy" or "ok" or "up" => InstanceHealthStatus.Healthy,
+            "warning" or "warn" or "degraded" => InstanceHealthStatus.Warning,
+            "critical" or "unhealthy" or "failed" => InstanceHealthStatus.Critical,
+            "offline" or "down" or "unreachable" => InstanceHealthStatus.Offline,
+            "unknown" => InstanceHealthStatus.Unknown,
+            _ => Enum.TryParse(status, ignoreCase: true, out InstanceHealthStatus parsed)
+                ? parsed
+                : null,
+        };
+
+    private static SymphonyWorkflowDocument ToWorkflowDocument(
+        string body,
+        HttpResponseMessage response,
+        SymphonyWorkflowDocument? fallback)
+    {
+        string? etag = response.Headers.ETag?.Tag ?? fallback?.ETag;
+
+        if (body.Length == 0)
+        {
+            return fallback is null
+                ? new SymphonyWorkflowDocument(string.Empty, etag)
+                : fallback with { ETag = etag };
+        }
+
+        return new SymphonyWorkflowDocument(ExtractWorkflowSource(body), etag);
+    }
+
+    private static string ExtractWorkflowSource(string body)
+    {
+        try
+        {
+            using JsonDocument document = JsonDocument.Parse(body);
+
+            if (document.RootElement.ValueKind == JsonValueKind.String)
+            {
+                return document.RootElement.GetString() ?? string.Empty;
+            }
+
+            if (document.RootElement.ValueKind != JsonValueKind.Object)
+            {
+                return body;
+            }
+
+            return ReadStringProperty(document.RootElement, "source")
+                ?? ReadStringProperty(document.RootElement, "workflowSource")
+                ?? ReadStringProperty(document.RootElement, "content")
+                ?? ReadStringProperty(document.RootElement, "workflow")
+                ?? body;
+        }
+        catch (JsonException)
+        {
+            return body;
+        }
+    }
+
+    private static string? ReadStringProperty(JsonElement element, string propertyName)
+    {
+        foreach (JsonProperty property in element.EnumerateObject())
+        {
+            if (property.NameEquals(propertyName)
+                || string.Equals(property.Name, propertyName, StringComparison.OrdinalIgnoreCase))
+            {
+                return property.Value.ValueKind == JsonValueKind.String
+                    ? property.Value.GetString()
+                    : null;
+            }
+        }
+
+        return null;
+    }
+
+    private static string RequireNonEmpty(string value, string parameterName)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new ArgumentException("Value cannot be empty.", parameterName);
+        }
+
+        return value.Trim();
+    }
+
+    private sealed record WorkflowPayload(string Source);
+
+    private sealed record HealthFailure(string Kind, string Message);
+}

--- a/src/Conductor.Infrastructure.Symphony/SymphonyServiceCollectionExtensions.cs
+++ b/src/Conductor.Infrastructure.Symphony/SymphonyServiceCollectionExtensions.cs
@@ -1,0 +1,18 @@
+using Conductor.Core.Abstractions.Symphony;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Conductor.Infrastructure.Symphony;
+
+public static class SymphonyServiceCollectionExtensions
+{
+    public static IServiceCollection AddConductorSymphony(this IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        services.AddHttpClient<ISymphonyApiClient, SymphonyApiClient>(
+            SymphonyApiClient.HttpClientName,
+            client => client.Timeout = TimeSpan.FromSeconds(15));
+
+        return services;
+    }
+}

--- a/tests/Conductor.Blazor.Tests/HealthHeatmapTests.cs
+++ b/tests/Conductor.Blazor.Tests/HealthHeatmapTests.cs
@@ -66,14 +66,14 @@ public sealed class HealthHeatmapTests
         IRenderedComponent<HealthHeatmap> component = context.Render<HealthHeatmap>(parameters => parameters
             .Add(component => component.Buckets, buckets));
 
-        IReadOnlyList<IElement> summaries = component.FindAll(".heatmap-legend-item");
+        IReadOnlyList<IElement> summaries = component.FindAll(".status-badge");
 
         Assert.Collection(
             summaries,
-            summary => AssertLegendItem(summary, "Healthy", "2", "heatmap-cell--healthy"),
-            summary => AssertLegendItem(summary, "Warning", "1", "heatmap-cell--warning"),
-            summary => AssertLegendItem(summary, "Critical", "1", "heatmap-cell--critical"),
-            summary => AssertLegendItem(summary, "Offline", "1", "heatmap-cell--offline"));
+            summary => AssertSummaryBadge(summary, "Healthy 2", "status-badge--success"),
+            summary => AssertSummaryBadge(summary, "Warning 1", "status-badge--warning"),
+            summary => AssertSummaryBadge(summary, "Critical 1", "status-badge--critical"),
+            summary => AssertSummaryBadge(summary, "Offline 1", "status-badge--neutral"));
     }
 
     [Fact]
@@ -164,11 +164,10 @@ public sealed class HealthHeatmapTests
         Assert.Equal("Mon", periods[0].TextContent);
     }
 
-    private static void AssertLegendItem(IElement summary, string label, string count, string expectedClass)
+    private static void AssertSummaryBadge(IElement summary, string label, string expectedClass)
     {
-        Assert.Contains(label, summary.TextContent, StringComparison.Ordinal);
-        Assert.Equal(count, summary.QuerySelector("strong")?.TextContent);
-        AssertClassContains(summary.QuerySelector(".heatmap-legend-swatch"), expectedClass);
+        Assert.Equal(label, summary.TextContent.Trim());
+        AssertClassContains(summary, expectedClass);
     }
 
     private static void AssertHeatmapCell(

--- a/tests/Conductor.Integration.Tests/Conductor.Integration.Tests.csproj
+++ b/tests/Conductor.Integration.Tests/Conductor.Integration.Tests.csproj
@@ -18,6 +18,15 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\Conductor.Core\Conductor.Core.csproj" />
+    <ProjectReference Include="..\..\src\Conductor.Infrastructure.Symphony\Conductor.Infrastructure.Symphony.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="Fixtures\Symphony\*.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Using Include="Xunit" />
   </ItemGroup>
 

--- a/tests/Conductor.Integration.Tests/Fixtures/Symphony/health-ok.json
+++ b/tests/Conductor.Integration.Tests/Fixtures/Symphony/health-ok.json
@@ -1,0 +1,5 @@
+{
+  "status": "healthy",
+  "version": "1.2.3",
+  "checkedAtUtc": "2026-04-29T00:00:00Z"
+}

--- a/tests/Conductor.Integration.Tests/Fixtures/Symphony/issue-detail.json
+++ b/tests/Conductor.Integration.Tests/Fixtures/Symphony/issue-detail.json
@@ -1,0 +1,13 @@
+{
+  "issueIdentifier": "issue-42",
+  "status": "running",
+  "branchName": "symphony/42",
+  "latestActivityUtc": "2026-04-29T00:00:00Z",
+  "timeline": [
+    {
+      "kind": "session_started",
+      "message": "Session started.",
+      "occurredAtUtc": "2026-04-29T00:00:00Z"
+    }
+  ]
+}

--- a/tests/Conductor.Integration.Tests/Fixtures/Symphony/runtime-basic.json
+++ b/tests/Conductor.Integration.Tests/Fixtures/Symphony/runtime-basic.json
@@ -1,0 +1,13 @@
+{
+  "applicationName": "Symphony",
+  "version": "1.2.3",
+  "instanceId": "symphony-local-1",
+  "workflow": {
+    "owner": "ReleasedGroup",
+    "repository": "TheConductor",
+    "sourcePath": "/config/WORKFLOW.md"
+  },
+  "persistence": {
+    "provider": "sqlite"
+  }
+}

--- a/tests/Conductor.Integration.Tests/Fixtures/Symphony/state-running.json
+++ b/tests/Conductor.Integration.Tests/Fixtures/Symphony/state-running.json
@@ -1,0 +1,20 @@
+{
+  "runningSessions": [
+    {
+      "issueIdentifier": "issue-42",
+      "sessionId": "session-1",
+      "turnCount": 3,
+      "lastActivityUtc": "2026-04-29T00:00:00Z"
+    }
+  ],
+  "retryQueue": [],
+  "trackedIssueDistribution": {
+    "running": 1,
+    "queued": 2,
+    "blocked": 0
+  },
+  "tokens": {
+    "input": 1200,
+    "output": 340
+  }
+}

--- a/tests/Conductor.Integration.Tests/SymphonyApiClientTests.cs
+++ b/tests/Conductor.Integration.Tests/SymphonyApiClientTests.cs
@@ -1,0 +1,185 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using Conductor.Core.Abstractions.Symphony;
+using Conductor.Core.Domain;
+using Conductor.Infrastructure.Symphony;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Conductor.Integration.Tests;
+
+public sealed class SymphonyApiClientTests
+{
+    private static readonly Uri BaseUri = new("http://symphony.local/root/");
+
+    [Fact]
+    public async Task Client_Calls_Read_Endpoints_And_Preserves_Raw_Json()
+    {
+        string healthJson = Fixture("health-ok.json");
+        string runtimeJson = Fixture("runtime-basic.json");
+        string stateJson = Fixture("state-running.json");
+        string issueJson = Fixture("issue-detail.json");
+        string refreshJson = """{"accepted":true}""";
+        var handler = new QueueHandler(
+            _ => JsonResponse(HttpStatusCode.OK, healthJson),
+            _ => JsonResponse(HttpStatusCode.OK, runtimeJson),
+            _ => JsonResponse(HttpStatusCode.OK, stateJson),
+            _ => JsonResponse(HttpStatusCode.OK, issueJson),
+            _ => JsonResponse(HttpStatusCode.Accepted, refreshJson));
+        using HttpClient httpClient = new(handler);
+        var client = new SymphonyApiClient(httpClient);
+
+        SymphonyHealthResponse health = await client.GetHealthAsync(BaseUri, CancellationToken.None);
+        SymphonyRuntimeResponse runtime = await client.GetRuntimeAsync(BaseUri, CancellationToken.None);
+        SymphonyStateResponse state = await client.GetStateAsync(BaseUri, CancellationToken.None);
+        SymphonyIssueResponse? issue = await client.GetIssueAsync(BaseUri, "issue-42", CancellationToken.None);
+        SymphonyRefreshResponse refresh = await client.RequestRefreshAsync(BaseUri, CancellationToken.None);
+
+        Assert.Equal(InstanceHealthStatus.Healthy, health.Status);
+        Assert.Equal(200, health.HttpStatusCode);
+        Assert.Equal(healthJson, health.RawJson);
+        Assert.Equal(runtimeJson, runtime.RawJson);
+        Assert.Equal(stateJson, state.RawJson);
+        Assert.NotNull(issue);
+        Assert.Equal("issue-42", issue.IssueIdentifier);
+        Assert.Equal(issueJson, issue.RawJson);
+        Assert.True(refresh.Accepted);
+        Assert.Equal(refreshJson, refresh.RawJson);
+        Assert.Equal(
+            [
+                "GET /root/api/v1/health",
+                "GET /root/api/v1/runtime",
+                "GET /root/api/v1/state",
+                "GET /root/api/v1/issue-42",
+                "POST /root/api/v1/refresh",
+            ],
+            handler.Requests.Select(request => $"{request.Method} {request.Uri.AbsolutePath}"));
+    }
+
+    [Fact]
+    public async Task Workflow_Methods_Read_And_Save_Source_With_ETags()
+    {
+        var handler = new QueueHandler(
+            _ => JsonResponse(
+                HttpStatusCode.OK,
+                """{"source":"# Workflow\nsteps: []"}""",
+                "\"workflow-1\""),
+            _ => EmptyResponse(HttpStatusCode.NoContent, "\"workflow-2\""));
+        using HttpClient httpClient = new(handler);
+        var client = new SymphonyApiClient(httpClient);
+
+        SymphonyWorkflowDocument workflow = await client.GetWorkflowAsync(BaseUri, CancellationToken.None);
+        SymphonyWorkflowDocument saved = await client.SaveWorkflowAsync(
+            BaseUri,
+            workflow with { Source = "# Updated workflow" },
+            CancellationToken.None);
+
+        Assert.Equal("# Workflow\nsteps: []", workflow.Source);
+        Assert.Equal("\"workflow-1\"", workflow.ETag);
+        Assert.Equal("# Updated workflow", saved.Source);
+        Assert.Equal("\"workflow-2\"", saved.ETag);
+        Assert.Equal("GET /root/api/v1/workflow", Format(handler.Requests[0]));
+        Assert.Equal("PUT /root/api/v1/workflow", Format(handler.Requests[1]));
+        Assert.Equal("\"workflow-1\"", handler.Requests[1].IfMatch);
+
+        using JsonDocument payload = JsonDocument.Parse(handler.Requests[1].Content!);
+        Assert.Equal("# Updated workflow", payload.RootElement.GetProperty("source").GetString());
+    }
+
+    [Fact]
+    public async Task Issue_Returns_Null_For_NotFound_Response()
+    {
+        var handler = new QueueHandler(_ => JsonResponse(HttpStatusCode.NotFound, """{"error":"missing"}"""));
+        using HttpClient httpClient = new(handler);
+        var client = new SymphonyApiClient(httpClient);
+
+        SymphonyIssueResponse? issue = await client.GetIssueAsync(BaseUri, "issue-404", CancellationToken.None);
+
+        Assert.Null(issue);
+    }
+
+    [Fact]
+    public async Task Health_Returns_Offline_For_Request_Failure()
+    {
+        var handler = new QueueHandler(_ => throw new HttpRequestException("connection refused"));
+        using HttpClient httpClient = new(handler);
+        var client = new SymphonyApiClient(httpClient);
+
+        SymphonyHealthResponse health = await client.GetHealthAsync(BaseUri, CancellationToken.None);
+
+        Assert.Equal(InstanceHealthStatus.Offline, health.Status);
+        Assert.Null(health.HttpStatusCode);
+        Assert.Contains("request_failed", health.RawJson, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AddConductorSymphony_Registers_Api_Client()
+    {
+        ServiceCollection services = [];
+
+        services.AddConductorSymphony();
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        Assert.IsType<SymphonyApiClient>(provider.GetRequiredService<ISymphonyApiClient>());
+    }
+
+    private static string Fixture(string fileName) =>
+        File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "Fixtures", "Symphony", fileName));
+
+    private static string Format(RecordedRequest request) =>
+        $"{request.Method} {request.Uri.AbsolutePath}";
+
+    private static HttpResponseMessage JsonResponse(
+        HttpStatusCode statusCode,
+        string json,
+        string? etag = null)
+    {
+        HttpResponseMessage response = EmptyResponse(statusCode, etag);
+        response.Content = new StringContent(json, Encoding.UTF8, "application/json");
+        return response;
+    }
+
+    private static HttpResponseMessage EmptyResponse(HttpStatusCode statusCode, string? etag = null)
+    {
+        HttpResponseMessage response = new(statusCode);
+
+        if (etag is not null)
+        {
+            response.Headers.ETag = new EntityTagHeaderValue(etag);
+        }
+
+        return response;
+    }
+
+    private sealed class QueueHandler(
+        params Func<RecordedRequest, HttpResponseMessage>[] responses) : HttpMessageHandler
+    {
+        private readonly Queue<Func<RecordedRequest, HttpResponseMessage>> responses = new(responses);
+
+        public List<RecordedRequest> Requests { get; } = [];
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            string? content = request.Content is null
+                ? null
+                : await request.Content.ReadAsStringAsync(cancellationToken);
+            string? ifMatch = request.Headers.TryGetValues("If-Match", out IEnumerable<string>? values)
+                ? values.SingleOrDefault()
+                : null;
+            var recordedRequest = new RecordedRequest(
+                request.Method.Method,
+                request.RequestUri ?? throw new InvalidOperationException("Request URI was not set."),
+                content,
+                ifMatch);
+
+            Requests.Add(recordedRequest);
+
+            return responses.Dequeue()(recordedRequest);
+        }
+    }
+
+    private sealed record RecordedRequest(string Method, Uri Uri, string? Content, string? IfMatch);
+}


### PR DESCRIPTION
## Summary
- Implements the concrete `ISymphonyApiClient` for Symphony health, runtime, workflow, state, issue detail, and refresh endpoints.
- Registers the named `SymphonyApi` HTTP client in host composition.
- Adds fixture-backed integration tests covering endpoint paths, raw JSON preservation, workflow ETag handling, 404 issue behavior, and health request failures.
- Documents the Symphony runtime client endpoint mapping in `docs/api.md`.

Closes #29

## Validation
- `dotnet restore Conductor.slnx`: passed
- `dotnet build Conductor.slnx --no-restore --warnaserror`: passed with 0 warnings
- `dotnet test Conductor.slnx --no-build`: passed
- `dotnet format Conductor.slnx --no-restore --verify-no-changes`: passed
- `./scripts/validate-docs.ps1`: passed

## Notes
- `GetHealthAsync` returns `Offline` for network/timeout failures so polling can persist a health probe instead of crashing the collection cycle.
