### PR TITLE
[codex] Raise offline instance alerts

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,5 +4,6 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+- Added health polling alert evaluation for offline Symphony instances.
 - Added a documentation validation workflow for required files, trailing whitespace, local links, and fenced code blocks.
 - Added baseline placeholder documents for the planned documentation set.

--- a/docs/technical.md
+++ b/docs/technical.md
@@ -502,6 +502,11 @@ Initial alert rules:
 - Low GitHub rate limit.
 - Active issues with no running sessions.
 
+Offline instance evaluation records a health snapshot for each pollable registered
+Symphony instance. When an instance transitions to `Offline`, Conductor emits an
+`InstanceOffline` event and creates one unresolved critical in-app alert for that
+instance so repeated failed polls do not duplicate the same active alert.
+
 MVP alert delivery is in-app only. External delivery adapters are later sprints.
 
 ### 8.8 Reporting

--- a/src/Conductor.Host/Program.cs
+++ b/src/Conductor.Host/Program.cs
@@ -18,7 +18,7 @@ builder.Services.AddSingleton<IDashboardProjectionStore, JsonFileDashboardProjec
 builder.Services.AddHealthChecks();
 builder.Services.AddConductorPersistence(builder.Configuration);
 builder.Services.AddConductorSymphony();
-builder.Services.AddConductorWorkers();
+builder.Services.AddConductorWorkers(builder.Configuration);
 
 WebApplication app = builder.Build();
 

--- a/src/Conductor.Host/Workers/ConductorWorkerOptions.cs
+++ b/src/Conductor.Host/Workers/ConductorWorkerOptions.cs
@@ -1,0 +1,11 @@
+namespace Conductor.Host.Workers;
+
+public sealed class ConductorWorkerOptions
+{
+    public const string SectionName = "Conductor";
+
+    public int DefaultHealthPollSeconds { get; init; } = 10;
+
+    public TimeSpan HealthPollInterval =>
+        TimeSpan.FromSeconds(Math.Max(1, DefaultHealthPollSeconds));
+}

--- a/src/Conductor.Host/Workers/InstanceHealthMonitor.cs
+++ b/src/Conductor.Host/Workers/InstanceHealthMonitor.cs
@@ -1,0 +1,221 @@
+using System.Text.Json;
+using Conductor.Core.Abstractions.Symphony;
+using Conductor.Core.Domain;
+using Conductor.Core.Domain.Alerts;
+using Conductor.Core.Domain.Ids;
+using Conductor.Core.Domain.Snapshots;
+using Conductor.Core.Domain.Symphony;
+using Conductor.Infrastructure.Persistence.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using DomainEvent = Conductor.Core.Domain.Events.Event;
+using DomainEventId = Conductor.Core.Domain.Ids.EventId;
+
+namespace Conductor.Host.Workers;
+
+public sealed class InstanceHealthMonitor(
+    ConductorDbContext dbContext,
+    ISymphonyApiClient symphonyApiClient,
+    TimeProvider timeProvider,
+    ILogger<InstanceHealthMonitor> logger)
+{
+    public const string OfflineAlertSource = "symphony-instance-health";
+    public const string OfflineEventType = "InstanceOffline";
+
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
+    public async Task<int> PollOnceAsync(CancellationToken cancellationToken = default)
+    {
+        List<SymphonyInstanceId> instanceIds = await dbContext.SymphonyInstances
+            .AsNoTracking()
+            .Where(instance =>
+                instance.LifecycleStatus != InstanceLifecycleStatus.Destroyed &&
+                instance.LifecycleStatus != InstanceLifecycleStatus.Stopped &&
+                instance.LifecycleStatus != InstanceLifecycleStatus.Stopping)
+            .OrderBy(instance => instance.DisplayName)
+            .Select(instance => instance.Id)
+            .ToListAsync(cancellationToken);
+
+        int polledCount = 0;
+
+        foreach (SymphonyInstanceId instanceId in instanceIds)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            try
+            {
+                if (await PollInstanceAsync(instanceId, cancellationToken))
+                {
+                    polledCount++;
+                }
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception exception)
+            {
+                logger.LogError(
+                    exception,
+                    "Failed to poll Symphony instance {SymphonyInstanceId}.",
+                    instanceId);
+            }
+            finally
+            {
+                dbContext.ChangeTracker.Clear();
+            }
+        }
+
+        return polledCount;
+    }
+
+    private async Task<bool> PollInstanceAsync(
+        SymphonyInstanceId instanceId,
+        CancellationToken cancellationToken)
+    {
+        SymphonyInstance? instance = await dbContext.SymphonyInstances
+            .SingleOrDefaultAsync(candidate => candidate.Id == instanceId, cancellationToken);
+
+        if (instance is null || !CanPoll(instance.LifecycleStatus))
+        {
+            return false;
+        }
+
+        InstanceHealthStatus previousHealthStatus = instance.HealthStatus;
+        SymphonyHealthResponse health = await GetHealthSafelyAsync(instance, cancellationToken);
+        DateTimeOffset observedAtUtc = timeProvider.GetUtcNow();
+
+        instance.RecordHealth(health.Status, observedAtUtc);
+        dbContext.InstanceSnapshots.Add(new InstanceSnapshot(
+            InstanceSnapshotId.New(),
+            instance.Id,
+            observedAtUtc,
+            health.Status,
+            health.RawJson,
+            runtimeJson: null,
+            stateJson: null,
+            activeIssueCount: 0,
+            runningSessionCount: 0,
+            retryQueueCount: 0,
+            failedRunCount: 0,
+            tokenInputTotal: 0,
+            tokenOutputTotal: 0));
+
+        if (ShouldRaiseOfflineAlert(previousHealthStatus, health.Status) &&
+            !await HasUnresolvedOfflineAlertAsync(instance.Id, cancellationToken))
+        {
+            AddOfflineEventAndAlert(instance, health, observedAtUtc);
+        }
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        return true;
+    }
+
+    private async Task<SymphonyHealthResponse> GetHealthSafelyAsync(
+        SymphonyInstance instance,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await symphonyApiClient.GetHealthAsync(instance.BaseUrl, cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            logger.LogWarning(
+                exception,
+                "Symphony health request failed for instance {SymphonyInstanceId}.",
+                instance.Id);
+
+            return new SymphonyHealthResponse(
+                InstanceHealthStatus.Offline,
+                HttpStatusCode: null,
+                Latency: TimeSpan.Zero,
+                CreateFailureJson(exception));
+        }
+    }
+
+    private async Task<bool> HasUnresolvedOfflineAlertAsync(
+        SymphonyInstanceId instanceId,
+        CancellationToken cancellationToken) =>
+        await dbContext.Alerts.AnyAsync(
+            alert =>
+                alert.SymphonyInstanceId != null &&
+                alert.SymphonyInstanceId == instanceId &&
+                alert.Source == OfflineAlertSource &&
+                alert.Status != AlertStatus.Resolved,
+            cancellationToken);
+
+    private void AddOfflineEventAndAlert(
+        SymphonyInstance instance,
+        SymphonyHealthResponse health,
+        DateTimeOffset observedAtUtc)
+    {
+        string summary = $"Symphony instance '{instance.DisplayName}' is offline";
+        string recommendedAction =
+            "Check the instance process or container, network connectivity, and configured base URL.";
+
+        dbContext.Events.Add(new DomainEvent(
+            DomainEventId.New(),
+            instance.Id,
+            instance.RepositoryId,
+            issueNumber: null,
+            EventSeverity.Critical,
+            OfflineEventType,
+            $"Symphony instance '{instance.DisplayName}' became unreachable.",
+            CreateOfflinePayload(instance, health),
+            observedAtUtc));
+
+        dbContext.Alerts.Add(new Alert(
+            AlertId.New(),
+            AlertSeverity.Critical,
+            OfflineAlertSource,
+            summary,
+            recommendedAction,
+            observedAtUtc,
+            instance.Id,
+            instance.RepositoryId));
+    }
+
+    private static bool CanPoll(InstanceLifecycleStatus lifecycleStatus) =>
+        lifecycleStatus is not InstanceLifecycleStatus.Destroyed
+            and not InstanceLifecycleStatus.Stopped
+            and not InstanceLifecycleStatus.Stopping;
+
+    private static bool ShouldRaiseOfflineAlert(
+        InstanceHealthStatus previousHealthStatus,
+        InstanceHealthStatus currentHealthStatus) =>
+        currentHealthStatus == InstanceHealthStatus.Offline &&
+        previousHealthStatus != InstanceHealthStatus.Offline;
+
+    private static string CreateOfflinePayload(
+        SymphonyInstance instance,
+        SymphonyHealthResponse health) =>
+        JsonSerializer.Serialize(
+            new OfflineEventPayload(
+                instance.Id.ToString(),
+                instance.DisplayName,
+                instance.BaseUrl.ToString(),
+                health.HttpStatusCode,
+                health.Latency.TotalMilliseconds,
+                health.RawJson),
+            JsonOptions);
+
+    private static string CreateFailureJson(Exception exception) =>
+        JsonSerializer.Serialize(
+            new HealthPollFailure("poll_failed", exception.Message),
+            JsonOptions);
+
+    private sealed record OfflineEventPayload(
+        string SymphonyInstanceId,
+        string DisplayName,
+        string BaseUrl,
+        int? HttpStatusCode,
+        double LatencyMilliseconds,
+        string HealthRawJson);
+
+    private sealed record HealthPollFailure(string Kind, string Message);
+}

--- a/src/Conductor.Host/Workers/InstanceHealthMonitorWorker.cs
+++ b/src/Conductor.Host/Workers/InstanceHealthMonitorWorker.cs
@@ -1,0 +1,44 @@
+using Microsoft.Extensions.Options;
+
+namespace Conductor.Host.Workers;
+
+public sealed class InstanceHealthMonitorWorker(
+    IServiceScopeFactory serviceScopeFactory,
+    IOptions<ConductorWorkerOptions> options,
+    ILogger<InstanceHealthMonitorWorker> logger) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        using PeriodicTimer timer = new(options.Value.HealthPollInterval);
+
+        try
+        {
+            while (await timer.WaitForNextTickAsync(stoppingToken))
+            {
+                await PollInstancesAsync(stoppingToken);
+            }
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+        }
+    }
+
+    private async Task PollInstancesAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            using IServiceScope scope = serviceScopeFactory.CreateScope();
+            InstanceHealthMonitor monitor = scope.ServiceProvider.GetRequiredService<InstanceHealthMonitor>();
+
+            await monitor.PollOnceAsync(cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            logger.LogError(exception, "Symphony instance health polling failed.");
+        }
+    }
+}

--- a/src/Conductor.Host/Workers/WorkerRegistrationExtensions.cs
+++ b/src/Conductor.Host/Workers/WorkerRegistrationExtensions.cs
@@ -2,8 +2,16 @@ namespace Conductor.Host.Workers;
 
 public static class WorkerRegistrationExtensions
 {
-    public static IServiceCollection AddConductorWorkers(this IServiceCollection services)
+    public static IServiceCollection AddConductorWorkers(
+        this IServiceCollection services,
+        IConfiguration configuration)
     {
+        services.Configure<ConductorWorkerOptions>(
+            configuration.GetSection(ConductorWorkerOptions.SectionName));
+        services.AddSingleton(TimeProvider.System);
+        services.AddScoped<InstanceHealthMonitor>();
+        services.AddHostedService<InstanceHealthMonitorWorker>();
+
         return services;
     }
 }

--- a/tests/Conductor.Host.Tests/Workers/InstanceHealthMonitorTests.cs
+++ b/tests/Conductor.Host.Tests/Workers/InstanceHealthMonitorTests.cs
@@ -1,0 +1,268 @@
+using Conductor.Core.Abstractions.Symphony;
+using Conductor.Core.Domain;
+using Conductor.Core.Domain.Alerts;
+using Conductor.Core.Domain.Ids;
+using Conductor.Core.Domain.Repositories;
+using Conductor.Core.Domain.Symphony;
+using Conductor.Host.Workers;
+using Conductor.Infrastructure.Persistence.Sqlite;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using DomainEvent = Conductor.Core.Domain.Events.Event;
+
+namespace Conductor.Host.Tests.Workers;
+
+public sealed class InstanceHealthMonitorTests
+{
+    private static readonly DateTimeOffset CreatedAtUtc = DateTimeOffset.Parse("2026-04-29T01:00:00Z");
+    private static readonly DateTimeOffset PolledAtUtc = DateTimeOffset.Parse("2026-04-29T01:05:00Z");
+
+    [Fact]
+    public async Task PollOnce_Creates_Offline_Event_And_Alert_When_Instance_Becomes_Unreachable()
+    {
+        await using SqliteConnection connection = await OpenConnectionAsync();
+        DbContextOptions<ConductorDbContext> options = CreateOptions(connection);
+        await using ConductorDbContext dbContext = await CreateDbContextAsync(options);
+
+        SymphonyInstanceId instanceId = await SeedInstanceAsync(
+            dbContext,
+            InstanceLifecycleStatus.Running,
+            InstanceHealthStatus.Healthy);
+        var apiClient = new FakeSymphonyApiClient(
+            new SymphonyHealthResponse(
+                InstanceHealthStatus.Offline,
+                HttpStatusCode: null,
+                TimeSpan.FromMilliseconds(120),
+                """{"kind":"request_failed"}"""));
+        InstanceHealthMonitor monitor = CreateMonitor(dbContext, apiClient);
+
+        int polledCount = await monitor.PollOnceAsync();
+
+        SymphonyInstance savedInstance = await dbContext.SymphonyInstances.SingleAsync();
+        DomainEvent recordedEvent = await dbContext.Events.SingleAsync();
+        Alert alert = await dbContext.Alerts.SingleAsync();
+
+        Assert.Equal(1, polledCount);
+        Assert.Equal(instanceId, savedInstance.Id);
+        Assert.Equal(InstanceHealthStatus.Offline, savedInstance.HealthStatus);
+        Assert.Equal(PolledAtUtc, savedInstance.LastHealthCheckAtUtc);
+        Assert.Null(savedInstance.LastSeenAtUtc);
+        Assert.Equal(InstanceHealthStatus.Offline, await dbContext.InstanceSnapshots
+            .Select(snapshot => snapshot.HealthStatus)
+            .SingleAsync());
+        Assert.Equal(InstanceHealthMonitor.OfflineEventType, recordedEvent.EventType);
+        Assert.Equal(EventSeverity.Critical, recordedEvent.Severity);
+        Assert.Contains("became unreachable", recordedEvent.Message, StringComparison.Ordinal);
+        Assert.Equal(InstanceHealthMonitor.OfflineAlertSource, alert.Source);
+        Assert.Equal(AlertSeverity.Critical, alert.Severity);
+        Assert.Equal(AlertStatus.Active, alert.Status);
+        Assert.Equal(instanceId, alert.SymphonyInstanceId);
+    }
+
+    [Fact]
+    public async Task PollOnce_Does_Not_Duplicate_Unresolved_Offline_Alert()
+    {
+        await using SqliteConnection connection = await OpenConnectionAsync();
+        DbContextOptions<ConductorDbContext> options = CreateOptions(connection);
+        await using ConductorDbContext dbContext = await CreateDbContextAsync(options);
+
+        await SeedInstanceAsync(
+            dbContext,
+            InstanceLifecycleStatus.Running,
+            InstanceHealthStatus.Healthy);
+        var apiClient = new FakeSymphonyApiClient(
+            new SymphonyHealthResponse(
+                InstanceHealthStatus.Offline,
+                HttpStatusCode: null,
+                TimeSpan.FromMilliseconds(120),
+                """{"kind":"request_failed"}"""),
+            new SymphonyHealthResponse(
+                InstanceHealthStatus.Offline,
+                HttpStatusCode: null,
+                TimeSpan.FromMilliseconds(90),
+                """{"kind":"request_failed"}"""));
+        InstanceHealthMonitor monitor = CreateMonitor(dbContext, apiClient);
+
+        await monitor.PollOnceAsync();
+        await monitor.PollOnceAsync();
+
+        Assert.Equal(2, await dbContext.InstanceSnapshots.CountAsync());
+        Assert.Equal(1, await dbContext.Events.CountAsync());
+        Assert.Equal(1, await dbContext.Alerts.CountAsync());
+    }
+
+    [Fact]
+    public async Task PollOnce_Continues_When_One_Instance_Health_Request_Fails()
+    {
+        await using SqliteConnection connection = await OpenConnectionAsync();
+        DbContextOptions<ConductorDbContext> options = CreateOptions(connection);
+        await using ConductorDbContext dbContext = await CreateDbContextAsync(options);
+
+        SymphonyInstanceId unreachableInstanceId = await SeedInstanceAsync(
+            dbContext,
+            InstanceLifecycleStatus.Running,
+            InstanceHealthStatus.Healthy,
+            displayName: "A Unreachable instance",
+            repositoryOwner: "ReleasedGroup",
+            repositoryName: "Unreachable");
+        SymphonyInstanceId healthyInstanceId = await SeedInstanceAsync(
+            dbContext,
+            InstanceLifecycleStatus.Running,
+            InstanceHealthStatus.Unknown,
+            displayName: "B Healthy instance",
+            repositoryOwner: "ReleasedGroup",
+            repositoryName: "Healthy");
+        var apiClient = new FakeSymphonyApiClient(
+            new HttpRequestException("connection refused"),
+            new SymphonyHealthResponse(
+                InstanceHealthStatus.Healthy,
+                200,
+                TimeSpan.FromMilliseconds(18),
+                """{"status":"healthy"}"""));
+        InstanceHealthMonitor monitor = CreateMonitor(dbContext, apiClient);
+
+        int polledCount = await monitor.PollOnceAsync();
+
+        Dictionary<SymphonyInstanceId, InstanceHealthStatus> statuses = await dbContext.SymphonyInstances
+            .ToDictionaryAsync(instance => instance.Id, instance => instance.HealthStatus);
+
+        Assert.Equal(2, polledCount);
+        Assert.Equal(InstanceHealthStatus.Offline, statuses[unreachableInstanceId]);
+        Assert.Equal(InstanceHealthStatus.Healthy, statuses[healthyInstanceId]);
+        Assert.Equal(2, await dbContext.InstanceSnapshots.CountAsync());
+        Assert.Equal(1, await dbContext.Events.CountAsync());
+        Assert.Equal(1, await dbContext.Alerts.CountAsync());
+    }
+
+    private static async Task<SqliteConnection> OpenConnectionAsync()
+    {
+        var connection = new SqliteConnection("Data Source=:memory:");
+        await connection.OpenAsync();
+        return connection;
+    }
+
+    private static DbContextOptions<ConductorDbContext> CreateOptions(SqliteConnection connection) =>
+        new DbContextOptionsBuilder<ConductorDbContext>()
+            .UseSqlite(connection)
+            .Options;
+
+    private static async Task<ConductorDbContext> CreateDbContextAsync(
+        DbContextOptions<ConductorDbContext> options)
+    {
+        var dbContext = new ConductorDbContext(options);
+        await dbContext.Database.EnsureCreatedAsync();
+        return dbContext;
+    }
+
+    private static InstanceHealthMonitor CreateMonitor(
+        ConductorDbContext dbContext,
+        ISymphonyApiClient apiClient) =>
+        new(
+            dbContext,
+            apiClient,
+            new FixedTimeProvider(PolledAtUtc),
+            NullLogger<InstanceHealthMonitor>.Instance);
+
+    private static async Task<SymphonyInstanceId> SeedInstanceAsync(
+        ConductorDbContext dbContext,
+        InstanceLifecycleStatus lifecycleStatus,
+        InstanceHealthStatus healthStatus,
+        string displayName = "TheConductor main",
+        string repositoryOwner = "ReleasedGroup",
+        string repositoryName = "TheConductor")
+    {
+        RepositoryId repositoryId = RepositoryId.New();
+        SymphonyInstanceId instanceId = SymphonyInstanceId.New();
+
+        dbContext.Repositories.Add(new Repository(
+            repositoryId,
+            RepositoryProvider.GitHub,
+            repositoryOwner,
+            repositoryName,
+            "main",
+            new Uri($"https://github.com/{repositoryOwner}/{repositoryName}.git"),
+            new Uri($"https://github.com/{repositoryOwner}/{repositoryName}"),
+            RepositoryVisibility.Public,
+            isArchived: false,
+            projectId: null,
+            lastSyncedAtUtc: CreatedAtUtc,
+            RepositoryOrchestrationStatus.Eligible,
+            orchestrationStatusReason: null));
+        dbContext.SymphonyInstances.Add(new SymphonyInstance(
+            instanceId,
+            repositoryId,
+            displayName,
+            ExecutionMode.Docker,
+            new Uri($"http://localhost:{Random.Shared.Next(10000, 20000)}"),
+            CreatedAtUtc,
+            lifecycleStatus,
+            healthStatus));
+
+        await dbContext.SaveChangesAsync();
+        dbContext.ChangeTracker.Clear();
+
+        return instanceId;
+    }
+
+    private sealed class FixedTimeProvider(DateTimeOffset utcNow) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => utcNow;
+    }
+
+    private sealed class FakeSymphonyApiClient : ISymphonyApiClient
+    {
+        private readonly Queue<object> healthResults;
+
+        public FakeSymphonyApiClient(params object[] healthResults)
+        {
+            this.healthResults = new Queue<object>(healthResults);
+        }
+
+        public Task<SymphonyHealthResponse> GetHealthAsync(
+            Uri baseUri,
+            CancellationToken cancellationToken)
+        {
+            object result = healthResults.Dequeue();
+
+            if (result is Exception exception)
+            {
+                throw exception;
+            }
+
+            return Task.FromResult((SymphonyHealthResponse)result);
+        }
+
+        public Task<SymphonyRuntimeResponse> GetRuntimeAsync(
+            Uri baseUri,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task<SymphonyWorkflowDocument> GetWorkflowAsync(
+            Uri baseUri,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task<SymphonyWorkflowDocument> SaveWorkflowAsync(
+            Uri baseUri,
+            SymphonyWorkflowDocument document,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task<SymphonyStateResponse> GetStateAsync(
+            Uri baseUri,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task<SymphonyIssueResponse?> GetIssueAsync(
+            Uri baseUri,
+            string issueIdentifier,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task<SymphonyRefreshResponse> RequestRefreshAsync(
+            Uri baseUri,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+    }
+}


### PR DESCRIPTION
## Summary
- add a hosted Symphony instance health monitor that records health snapshots
- create a deduplicated critical alert and InstanceOffline event when a registered instance transitions offline
- cover offline alert creation, duplicate suppression, and per-instance failure isolation in host tests
- document the offline alert evaluation behavior

## Validation
- dotnet test Conductor.slnx
- dotnet build Conductor.slnx --no-restore
- ./scripts/validate-docs.ps1

Closes #35