### PR TITLE
Display Symphony instance health and runtime details

### DIFF
--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -13,6 +13,13 @@ Current metric tile keys:
 - `open-pull-requests`
 - `ai-spend-today`
 
+The same dashboard projection can include `instanceRuntimes` entries for the
+Symphony runtime panel. Each entry carries the instance key and display name,
+repository and base URL, `healthStatus`, `lifecycleStatus`, Symphony version,
+workflow owner/repository/source path metadata, the last health/snapshot/seen
+timestamps, and last snapshot counters for active issues, running sessions,
+retry queue, failed runs, and token totals.
+
 Run the dashboard slice checks with:
 
 ```powershell

--- a/src/Conductor.Core/Application/Dashboard/DashboardInstanceRuntime.cs
+++ b/src/Conductor.Core/Application/Dashboard/DashboardInstanceRuntime.cs
@@ -1,0 +1,42 @@
+using Conductor.Core.Domain;
+
+namespace Conductor.Core.Application.Dashboard;
+
+public sealed class DashboardInstanceRuntime
+{
+    public required string Key { get; init; }
+
+    public required string DisplayName { get; init; }
+
+    public string RepositoryFullName { get; init; } = string.Empty;
+
+    public Uri? BaseUrl { get; init; }
+
+    public InstanceHealthStatus HealthStatus { get; init; } = InstanceHealthStatus.Unknown;
+
+    public InstanceLifecycleStatus LifecycleStatus { get; init; } = InstanceLifecycleStatus.NotProvisioned;
+
+    public string? SymphonyVersion { get; init; }
+
+    public string? WorkflowOwner { get; init; }
+
+    public string? WorkflowRepository { get; init; }
+
+    public string? WorkflowSourcePath { get; init; }
+
+    public DateTimeOffset? LastHealthCheckAtUtc { get; init; }
+
+    public DateTimeOffset? LastSnapshotCapturedAtUtc { get; init; }
+
+    public DateTimeOffset? LastSeenAtUtc { get; init; }
+
+    public int ActiveIssueCount { get; init; }
+
+    public int RunningSessionCount { get; init; }
+
+    public int RetryQueueCount { get; init; }
+
+    public int FailedRunCount { get; init; }
+
+    public long TokenTotal { get; init; }
+}

--- a/src/Conductor.Core/Application/Dashboard/DashboardProjection.cs
+++ b/src/Conductor.Core/Application/Dashboard/DashboardProjection.cs
@@ -8,5 +8,7 @@ public sealed class DashboardProjection
 
     public IReadOnlyList<DashboardAttentionItem> AttentionItems { get; init; } = Array.Empty<DashboardAttentionItem>();
 
+    public IReadOnlyList<DashboardInstanceRuntime> InstanceRuntimes { get; init; } = Array.Empty<DashboardInstanceRuntime>();
+
     public static DashboardProjection Empty { get; } = new();
 }

--- a/src/Conductor.Core/Application/Queries/InstanceSummaryQueryService.cs
+++ b/src/Conductor.Core/Application/Queries/InstanceSummaryQueryService.cs
@@ -28,4 +28,14 @@ public sealed record InstanceSummaryProjection(
     InstanceHealthStatus HealthStatus,
     DateTimeOffset? LastHealthCheckAtUtc,
     DateTimeOffset? LastSeenAtUtc,
-    DateTimeOffset? LatestSnapshotCapturedAtUtc);
+    DateTimeOffset? LatestSnapshotCapturedAtUtc,
+    string? SymphonyVersion = null,
+    string? SymphonyReleaseTag = null,
+    string? WorkflowOwner = null,
+    string? WorkflowRepository = null,
+    string? WorkflowSourcePath = null,
+    int ActiveIssueCount = 0,
+    int RunningSessionCount = 0,
+    int RetryQueueCount = 0,
+    int FailedRunCount = 0,
+    long TokenTotal = 0);

--- a/src/Conductor.Host/Components/Dashboard/InstanceRuntimePanel.razor
+++ b/src/Conductor.Host/Components/Dashboard/InstanceRuntimePanel.razor
@@ -1,0 +1,220 @@
+@using System.Globalization
+@using Conductor.Core.Domain
+
+<section class="instance-runtime-panel" aria-labelledby="@headingId">
+    <header class="instance-runtime-header">
+        <div>
+            <p class="eyebrow">Symphony runtime</p>
+            <h2 id="@headingId">Instance health</h2>
+            <p>Registered instances reporting from the latest polling cycle.</p>
+        </div>
+    </header>
+
+    @if (instances.Length == 0)
+    {
+        <EmptyState
+            Title="No Symphony runtime data is available yet."
+            Message="Registered instance health and runtime snapshots will appear after polling starts." />
+    }
+    else
+    {
+        <div class="instance-runtime-table-wrap">
+            <table class="instance-runtime-table">
+                <caption class="sr-only">Symphony instance runtime details</caption>
+                <thead>
+                    <tr>
+                        <th scope="col">Instance</th>
+                        <th scope="col">Status</th>
+                        <th scope="col">Symphony</th>
+                        <th scope="col">Workflow</th>
+                        <th scope="col">Last poll</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (DashboardInstanceRuntime instance in instances)
+                    {
+                        <tr class="@GetRowClass(instance.HealthStatus)" data-instance-runtime="@instance.Key">
+                            <th scope="row">
+                                <span class="instance-runtime-name">@instance.DisplayName</span>
+                                @if (!string.IsNullOrWhiteSpace(instance.RepositoryFullName))
+                                {
+                                    <span class="instance-runtime-muted">@instance.RepositoryFullName</span>
+                                }
+                                @if (instance.BaseUrl is not null)
+                                {
+                                    <a href="@instance.BaseUrl" class="instance-runtime-link">@instance.BaseUrl</a>
+                                }
+                            </th>
+                            <td>
+                                <div class="instance-runtime-status">
+                                    <StatusBadge Text="@GetHealthLabel(instance.HealthStatus)" Tone="@GetHealthTone(instance.HealthStatus)" />
+                                    <span>@GetLifecycleLabel(instance.LifecycleStatus)</span>
+                                </div>
+                            </td>
+                            <td>
+                                <span class="instance-runtime-strong">@GetVersionText(instance)</span>
+                            </td>
+                            <td>
+                                <span class="instance-runtime-strong">@GetWorkflowLabel(instance)</span>
+                                <span class="instance-runtime-muted">@GetWorkflowPath(instance)</span>
+                            </td>
+                            <td>
+                                <dl class="instance-runtime-poll-grid" aria-label="@BuildPollLabel(instance)">
+                                    <div>
+                                        <dt>Health</dt>
+                                        <dd>@FormatInstant(instance.LastHealthCheckAtUtc)</dd>
+                                    </div>
+                                    <div>
+                                        <dt>Snapshot</dt>
+                                        <dd>@FormatInstant(instance.LastSnapshotCapturedAtUtc)</dd>
+                                    </div>
+                                    <div>
+                                        <dt>Last seen</dt>
+                                        <dd>@FormatInstant(instance.LastSeenAtUtc)</dd>
+                                    </div>
+                                    <div>
+                                        <dt>Active</dt>
+                                        <dd>@FormatCount(instance.ActiveIssueCount)</dd>
+                                    </div>
+                                    <div>
+                                        <dt>Running</dt>
+                                        <dd>@FormatCount(instance.RunningSessionCount)</dd>
+                                    </div>
+                                    <div>
+                                        <dt>Retry</dt>
+                                        <dd>@FormatCount(instance.RetryQueueCount)</dd>
+                                    </div>
+                                    <div>
+                                        <dt>Failed</dt>
+                                        <dd>@FormatCount(instance.FailedRunCount)</dd>
+                                    </div>
+                                    <div>
+                                        <dt>Tokens</dt>
+                                        <dd>@FormatLong(instance.TokenTotal)</dd>
+                                    </div>
+                                </dl>
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+    }
+</section>
+
+@code {
+    private readonly string headingId = $"instance-runtime-{Guid.NewGuid():N}";
+    private DashboardInstanceRuntime[] instances = [];
+
+    [Parameter]
+    public IReadOnlyList<DashboardInstanceRuntime>? Items { get; set; }
+
+    protected override void OnParametersSet()
+    {
+        instances = (Items ?? [])
+            .Where(instance => !string.IsNullOrWhiteSpace(instance.Key)
+                && !string.IsNullOrWhiteSpace(instance.DisplayName))
+            .OrderByDescending(instance => MapHealthSeverity(instance.HealthStatus))
+            .ThenBy(instance => instance.RepositoryFullName, StringComparer.Ordinal)
+            .ThenBy(instance => instance.DisplayName, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private static string GetRowClass(InstanceHealthStatus status) =>
+        $"instance-runtime-row instance-runtime-row--{GetHealthCssName(status)}";
+
+    private static StatusBadgeTone GetHealthTone(InstanceHealthStatus status) =>
+        status switch
+        {
+            InstanceHealthStatus.Healthy => StatusBadgeTone.Success,
+            InstanceHealthStatus.Warning => StatusBadgeTone.Warning,
+            InstanceHealthStatus.Critical => StatusBadgeTone.Critical,
+            InstanceHealthStatus.Offline => StatusBadgeTone.Neutral,
+            _ => StatusBadgeTone.Info,
+        };
+
+    private static string GetHealthLabel(InstanceHealthStatus status) =>
+        status switch
+        {
+            InstanceHealthStatus.Healthy => "Healthy",
+            InstanceHealthStatus.Warning => "Warning",
+            InstanceHealthStatus.Critical => "Critical",
+            InstanceHealthStatus.Offline => "Offline",
+            InstanceHealthStatus.Unknown => "Unknown",
+            _ => "Unknown",
+        };
+
+    private static string GetLifecycleLabel(InstanceLifecycleStatus status) =>
+        status switch
+        {
+            InstanceLifecycleStatus.NotProvisioned => "Not provisioned",
+            InstanceLifecycleStatus.Provisioned => "Provisioned",
+            InstanceLifecycleStatus.Starting => "Starting",
+            InstanceLifecycleStatus.Running => "Running",
+            InstanceLifecycleStatus.Stopping => "Stopping",
+            InstanceLifecycleStatus.Stopped => "Stopped",
+            InstanceLifecycleStatus.Failed => "Failed",
+            InstanceLifecycleStatus.Destroyed => "Destroyed",
+            _ => "Unknown",
+        };
+
+    private static string GetVersionText(DashboardInstanceRuntime instance) =>
+        string.IsNullOrWhiteSpace(instance.SymphonyVersion)
+            ? "Version unknown"
+            : instance.SymphonyVersion;
+
+    private static string GetWorkflowLabel(DashboardInstanceRuntime instance)
+    {
+        if (!string.IsNullOrWhiteSpace(instance.WorkflowOwner)
+            && !string.IsNullOrWhiteSpace(instance.WorkflowRepository))
+        {
+            return $"{instance.WorkflowOwner}/{instance.WorkflowRepository}";
+        }
+
+        return string.IsNullOrWhiteSpace(instance.RepositoryFullName)
+            ? "Workflow unknown"
+            : instance.RepositoryFullName;
+    }
+
+    private static string GetWorkflowPath(DashboardInstanceRuntime instance) =>
+        string.IsNullOrWhiteSpace(instance.WorkflowSourcePath)
+            ? "Workflow path unknown"
+            : instance.WorkflowSourcePath;
+
+    private static string FormatInstant(DateTimeOffset? value) =>
+        value.HasValue
+            ? value.Value
+                .ToUniversalTime()
+                .ToString("MMM d, HH:mm 'UTC'", CultureInfo.InvariantCulture)
+            : "Not polled";
+
+    private static string FormatCount(int value) =>
+        Math.Max(0, value).ToString(CultureInfo.InvariantCulture);
+
+    private static string FormatLong(long value) =>
+        Math.Max(0, value).ToString("N0", CultureInfo.InvariantCulture);
+
+    private static string BuildPollLabel(DashboardInstanceRuntime instance) =>
+        $"{instance.DisplayName} last health poll {FormatInstant(instance.LastHealthCheckAtUtc)}, latest snapshot {FormatInstant(instance.LastSnapshotCapturedAtUtc)}, last seen {FormatInstant(instance.LastSeenAtUtc)}.";
+
+    private static string GetHealthCssName(InstanceHealthStatus status) =>
+        status switch
+        {
+            InstanceHealthStatus.Healthy => "healthy",
+            InstanceHealthStatus.Warning => "warning",
+            InstanceHealthStatus.Critical => "critical",
+            InstanceHealthStatus.Offline => "offline",
+            _ => "unknown",
+        };
+
+    private static int MapHealthSeverity(InstanceHealthStatus status) =>
+        status switch
+        {
+            InstanceHealthStatus.Offline => 4,
+            InstanceHealthStatus.Critical => 3,
+            InstanceHealthStatus.Warning => 2,
+            InstanceHealthStatus.Unknown => 1,
+            InstanceHealthStatus.Healthy => 0,
+            _ => 1,
+        };
+}

--- a/src/Conductor.Host/Components/Pages/Home.razor
+++ b/src/Conductor.Host/Components/Pages/Home.razor
@@ -54,6 +54,7 @@
     <section class="dashboard-body">
         <div class="dashboard-stack">
             <HealthHeatmap Buckets="HealthBuckets" />
+            <InstanceRuntimePanel Items="InstanceRuntimes" />
 
             <section class="startup-panel" aria-label="Startup verification">
                 <SuccessState
@@ -87,6 +88,9 @@
 
     private IReadOnlyList<DashboardAttentionItem> AttentionItems =>
         projection?.AttentionItems ?? Array.Empty<DashboardAttentionItem>();
+
+    private IReadOnlyList<DashboardInstanceRuntime> InstanceRuntimes =>
+        projection?.InstanceRuntimes ?? Array.Empty<DashboardInstanceRuntime>();
 
     private static readonly HealthHeatmapBucket[] HealthBuckets =
     [

--- a/src/Conductor.Host/Data/dashboard-projection.json
+++ b/src/Conductor.Host/Data/dashboard-projection.json
@@ -80,5 +80,67 @@
       "createdAtUtc": "2026-04-29T01:45:00Z",
       "ageLabel": "15m ago"
     }
+  ],
+  "instanceRuntimes": [
+    {
+      "key": "billing-api-primary",
+      "displayName": "Billing API primary",
+      "repositoryFullName": "ReleasedGroup/billing-api",
+      "baseUrl": "http://localhost:5010/",
+      "healthStatus": "Healthy",
+      "lifecycleStatus": "Running",
+      "symphonyVersion": "1.2.3",
+      "workflowOwner": "ReleasedGroup",
+      "workflowRepository": "billing-api",
+      "workflowSourcePath": "/config/billing/WORKFLOW.md",
+      "lastHealthCheckAtUtc": "2026-04-29T01:58:00Z",
+      "lastSnapshotCapturedAtUtc": "2026-04-29T01:57:30Z",
+      "lastSeenAtUtc": "2026-04-29T01:58:00Z",
+      "activeIssueCount": 4,
+      "runningSessionCount": 2,
+      "retryQueueCount": 0,
+      "failedRunCount": 0,
+      "tokenTotal": 148200
+    },
+    {
+      "key": "client-mobile",
+      "displayName": "Client Mobile",
+      "repositoryFullName": "ReleasedGroup/client-mobile",
+      "baseUrl": "http://localhost:5020/",
+      "healthStatus": "Offline",
+      "lifecycleStatus": "Failed",
+      "symphonyVersion": "1.2.1",
+      "workflowOwner": "ReleasedGroup",
+      "workflowRepository": "client-mobile",
+      "workflowSourcePath": "/config/mobile/WORKFLOW.md",
+      "lastHealthCheckAtUtc": "2026-04-29T01:52:00Z",
+      "lastSnapshotCapturedAtUtc": "2026-04-29T01:41:30Z",
+      "lastSeenAtUtc": "2026-04-29T01:40:00Z",
+      "activeIssueCount": 1,
+      "runningSessionCount": 0,
+      "retryQueueCount": 3,
+      "failedRunCount": 1,
+      "tokenTotal": 38900
+    },
+    {
+      "key": "acme-portal",
+      "displayName": "Acme Portal",
+      "repositoryFullName": "ReleasedGroup/acme-portal",
+      "baseUrl": "http://localhost:5030/",
+      "healthStatus": "Warning",
+      "lifecycleStatus": "Running",
+      "symphonyVersion": "1.2.3",
+      "workflowOwner": "ReleasedGroup",
+      "workflowRepository": "acme-portal",
+      "workflowSourcePath": "/config/acme/WORKFLOW.md",
+      "lastHealthCheckAtUtc": "2026-04-29T01:55:00Z",
+      "lastSnapshotCapturedAtUtc": "2026-04-29T01:54:45Z",
+      "lastSeenAtUtc": "2026-04-29T01:55:00Z",
+      "activeIssueCount": 7,
+      "runningSessionCount": 1,
+      "retryQueueCount": 1,
+      "failedRunCount": 0,
+      "tokenTotal": 88200
+    }
   ]
 }

--- a/src/Conductor.Host/wwwroot/app.css
+++ b/src/Conductor.Host/wwwroot/app.css
@@ -578,6 +578,137 @@ h2 {
   color: #74808d;
 }
 
+.instance-runtime-panel {
+  display: grid;
+  gap: 18px;
+  padding: 24px;
+  border: 1px solid #2b3138;
+  border-radius: 8px;
+  background: #151a1f;
+}
+
+.instance-runtime-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.instance-runtime-header p:not(.eyebrow) {
+  margin-bottom: 0;
+  color: #aeb9c5;
+}
+
+.instance-runtime-table-wrap {
+  overflow-x: auto;
+}
+
+.instance-runtime-table {
+  width: 100%;
+  min-width: 860px;
+  border-collapse: collapse;
+}
+
+.instance-runtime-table th,
+.instance-runtime-table td {
+  padding: 16px 14px;
+  border-top: 1px solid #2b3138;
+  vertical-align: top;
+  text-align: left;
+}
+
+.instance-runtime-table thead th {
+  border-top: 0;
+  color: #aeb9c5;
+  font-size: 0.8rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.instance-runtime-table tbody th {
+  width: 24%;
+}
+
+.instance-runtime-name,
+.instance-runtime-strong {
+  display: block;
+  color: #ffffff;
+  font-weight: 800;
+  overflow-wrap: anywhere;
+}
+
+.instance-runtime-muted,
+.instance-runtime-link {
+  display: block;
+  margin-top: 6px;
+  color: #aeb9c5;
+  font-size: 0.84rem;
+  overflow-wrap: anywhere;
+}
+
+.instance-runtime-link {
+  color: #9cc2ff;
+}
+
+.instance-runtime-link:hover {
+  color: #ffffff;
+}
+
+.instance-runtime-status {
+  display: grid;
+  gap: 8px;
+  justify-items: start;
+}
+
+.instance-runtime-status > span:last-child {
+  color: #dbe6ee;
+  font-size: 0.86rem;
+  font-weight: 700;
+}
+
+.instance-runtime-poll-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+  margin: 0;
+}
+
+.instance-runtime-poll-grid div {
+  min-width: 0;
+}
+
+.instance-runtime-poll-grid dt {
+  color: #74808d;
+  font-size: 0.72rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.instance-runtime-poll-grid dd {
+  margin: 3px 0 0;
+  color: #dbe6ee;
+  font-size: 0.86rem;
+  font-weight: 700;
+  overflow-wrap: anywhere;
+}
+
+.instance-runtime-row--healthy {
+  box-shadow: inset 3px 0 0 #2d6f5e;
+}
+
+.instance-runtime-row--warning {
+  box-shadow: inset 3px 0 0 #8a6823;
+}
+
+.instance-runtime-row--critical {
+  box-shadow: inset 3px 0 0 #904247;
+}
+
+.instance-runtime-row--offline,
+.instance-runtime-row--unknown {
+  box-shadow: inset 3px 0 0 #53606d;
+}
+
 .dashboard-rail {
   display: grid;
   gap: 14px;
@@ -966,6 +1097,14 @@ h2 {
 
   .heatmap-grid {
     min-width: 640px;
+  }
+
+  .instance-runtime-header {
+    display: grid;
+  }
+
+  .instance-runtime-table {
+    min-width: 760px;
   }
 
   .metric-grid {

--- a/src/Conductor.Infrastructure.Persistence.Sqlite/Queries/SqliteProjectionQueryService.cs
+++ b/src/Conductor.Infrastructure.Persistence.Sqlite/Queries/SqliteProjectionQueryService.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Conductor.Core.Application.Queries;
 using Conductor.Core.Domain;
 using Conductor.Core.Domain.Ids;
@@ -174,7 +175,7 @@ public sealed class SqliteProjectionQueryService :
         Dictionary<ProjectId, Project> projectsById = await LoadProjectsAsync(
             repositoryRows.Select(repository => repository.ProjectId),
             cancellationToken);
-        Dictionary<SymphonyInstanceId, DateTimeOffset> latestSnapshotByInstanceId = await LoadLatestSnapshotsByInstanceAsync(
+        Dictionary<SymphonyInstanceId, LatestInstanceSnapshot> latestSnapshotByInstanceId = await LoadLatestSnapshotsByInstanceAsync(
             instanceRows.Select(instance => instance.Id),
             cancellationToken);
 
@@ -188,7 +189,7 @@ public sealed class SqliteProjectionQueryService :
                     projectsById.TryGetValue(repositoryProjectId, out project);
                 }
 
-                latestSnapshotByInstanceId.TryGetValue(instance.Id, out DateTimeOffset latestSnapshotAtUtc);
+                latestSnapshotByInstanceId.TryGetValue(instance.Id, out LatestInstanceSnapshot? latestSnapshot);
 
                 return new InstanceSummaryProjection(
                     instance.Id,
@@ -203,7 +204,17 @@ public sealed class SqliteProjectionQueryService :
                     instance.HealthStatus,
                     instance.LastHealthCheckAtUtc,
                     instance.LastSeenAtUtc,
-                    latestSnapshotAtUtc == default ? null : latestSnapshotAtUtc);
+                    latestSnapshot?.CapturedAtUtc,
+                    instance.SymphonyVersion ?? latestSnapshot?.RuntimeMetadata.Version,
+                    instance.SymphonyReleaseTag,
+                    latestSnapshot?.RuntimeMetadata.WorkflowOwner,
+                    latestSnapshot?.RuntimeMetadata.WorkflowRepository,
+                    latestSnapshot?.RuntimeMetadata.WorkflowSourcePath,
+                    latestSnapshot?.ActiveIssueCount ?? 0,
+                    latestSnapshot?.RunningSessionCount ?? 0,
+                    latestSnapshot?.RetryQueueCount ?? 0,
+                    latestSnapshot?.FailedRunCount ?? 0,
+                    latestSnapshot?.TokenTotal ?? 0);
             })
             .OrderBy(instance => instance.RepositoryFullName)
             .ThenBy(instance => instance.DisplayName)
@@ -270,7 +281,7 @@ public sealed class SqliteProjectionQueryService :
                 group => group.ToList());
     }
 
-    private async Task<Dictionary<SymphonyInstanceId, DateTimeOffset>> LoadLatestSnapshotsByInstanceAsync(
+    private async Task<Dictionary<SymphonyInstanceId, LatestInstanceSnapshot>> LoadLatestSnapshotsByInstanceAsync(
         IEnumerable<SymphonyInstanceId> instanceIds,
         CancellationToken cancellationToken)
     {
@@ -290,7 +301,99 @@ public sealed class SqliteProjectionQueryService :
             .GroupBy(snapshot => snapshot.SymphonyInstanceId)
             .ToDictionary(
                 group => group.Key,
-                group => group.Max(snapshot => snapshot.CapturedAtUtc));
+                group =>
+                {
+                    InstanceSnapshot snapshot = group
+                        .OrderByDescending(candidate => candidate.CapturedAtUtc)
+                        .First();
+
+                    return new LatestInstanceSnapshot(
+                        snapshot.CapturedAtUtc,
+                        TryReadRuntimeMetadata(snapshot.RuntimeJson),
+                        snapshot.ActiveIssueCount,
+                        snapshot.RunningSessionCount,
+                        snapshot.RetryQueueCount,
+                        snapshot.FailedRunCount,
+                        snapshot.TokenTotal);
+                });
+    }
+
+    private static RuntimeMetadata TryReadRuntimeMetadata(string? runtimeJson)
+    {
+        if (string.IsNullOrWhiteSpace(runtimeJson))
+        {
+            return RuntimeMetadata.Empty;
+        }
+
+        try
+        {
+            using JsonDocument document = JsonDocument.Parse(runtimeJson);
+
+            if (document.RootElement.ValueKind != JsonValueKind.Object)
+            {
+                return RuntimeMetadata.Empty;
+            }
+
+            JsonElement root = document.RootElement;
+            string? version = ReadStringProperty(root, "version");
+            string? workflowOwner = null;
+            string? workflowRepository = null;
+            string? workflowSourcePath = null;
+
+            if (TryGetObjectProperty(root, "workflow", out JsonElement workflow))
+            {
+                workflowOwner = ReadStringProperty(workflow, "owner");
+                workflowRepository = ReadStringProperty(workflow, "repository");
+                workflowSourcePath = ReadStringProperty(workflow, "sourcePath")
+                    ?? ReadStringProperty(workflow, "path");
+            }
+
+            return new RuntimeMetadata(
+                version,
+                workflowOwner,
+                workflowRepository,
+                workflowSourcePath);
+        }
+        catch (JsonException)
+        {
+            return RuntimeMetadata.Empty;
+        }
+    }
+
+    private static bool TryGetObjectProperty(
+        JsonElement element,
+        string propertyName,
+        out JsonElement propertyValue)
+    {
+        foreach (JsonProperty property in element.EnumerateObject())
+        {
+            if ((property.NameEquals(propertyName)
+                    || string.Equals(property.Name, propertyName, StringComparison.OrdinalIgnoreCase))
+                && property.Value.ValueKind == JsonValueKind.Object)
+            {
+                propertyValue = property.Value;
+                return true;
+            }
+        }
+
+        propertyValue = default;
+        return false;
+    }
+
+    private static string? ReadStringProperty(JsonElement element, string propertyName)
+    {
+        foreach (JsonProperty property in element.EnumerateObject())
+        {
+            if (property.NameEquals(propertyName)
+                || string.Equals(property.Name, propertyName, StringComparison.OrdinalIgnoreCase))
+            {
+                return property.Value.ValueKind == JsonValueKind.String
+                    ? property.Value.GetString()
+                    : null;
+            }
+        }
+
+        return null;
     }
 
     private static int MapHealthSeverity(InstanceHealthStatus status) => status switch
@@ -302,4 +405,22 @@ public sealed class SqliteProjectionQueryService :
         InstanceHealthStatus.Offline => 4,
         _ => 1,
     };
+
+    private sealed record LatestInstanceSnapshot(
+        DateTimeOffset CapturedAtUtc,
+        RuntimeMetadata RuntimeMetadata,
+        int ActiveIssueCount,
+        int RunningSessionCount,
+        int RetryQueueCount,
+        int FailedRunCount,
+        long TokenTotal);
+
+    private sealed record RuntimeMetadata(
+        string? Version,
+        string? WorkflowOwner,
+        string? WorkflowRepository,
+        string? WorkflowSourcePath)
+    {
+        public static RuntimeMetadata Empty { get; } = new(null, null, null, null);
+    }
 }

--- a/tests/Conductor.Blazor.Tests/Dashboard/JsonFileDashboardProjectionStoreTests.cs
+++ b/tests/Conductor.Blazor.Tests/Dashboard/JsonFileDashboardProjectionStoreTests.cs
@@ -1,4 +1,5 @@
 using Conductor.Core.Application.Dashboard;
+using Conductor.Core.Domain;
 using Conductor.Host.Dashboard;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting;
@@ -40,6 +41,28 @@ public sealed class JsonFileDashboardProjectionStoreTests
                       "createdAtUtc": "2026-04-29T01:58:00Z",
                       "ageLabel": "2m ago"
                     }
+                  ],
+                  "instanceRuntimes": [
+                    {
+                      "key": "billing-api-primary",
+                      "displayName": "Billing API primary",
+                      "repositoryFullName": "ReleasedGroup/billing-api",
+                      "baseUrl": "http://localhost:5010/",
+                      "healthStatus": "Healthy",
+                      "lifecycleStatus": "Running",
+                      "symphonyVersion": "1.2.3",
+                      "workflowOwner": "ReleasedGroup",
+                      "workflowRepository": "billing-api",
+                      "workflowSourcePath": "/config/billing-api/WORKFLOW.md",
+                      "lastHealthCheckAtUtc": "2026-04-29T01:58:00Z",
+                      "lastSnapshotCapturedAtUtc": "2026-04-29T01:57:30Z",
+                      "lastSeenAtUtc": "2026-04-29T01:58:00Z",
+                      "activeIssueCount": 4,
+                      "runningSessionCount": 2,
+                      "retryQueueCount": 0,
+                      "failedRunCount": 0,
+                      "tokenTotal": 140
+                    }
                   ]
                 }
                 """);
@@ -58,6 +81,14 @@ public sealed class JsonFileDashboardProjectionStoreTests
             DashboardAttentionItem attentionItem = Assert.Single(projection.AttentionItems);
             Assert.Equal("billing-api", attentionItem.SourceName);
             Assert.Equal("/repositories/billing-api", attentionItem.TargetHref);
+            DashboardInstanceRuntime instance = Assert.Single(projection.InstanceRuntimes);
+            Assert.Equal("Billing API primary", instance.DisplayName);
+            Assert.Equal(InstanceHealthStatus.Healthy, instance.HealthStatus);
+            Assert.Equal(InstanceLifecycleStatus.Running, instance.LifecycleStatus);
+            Assert.Equal("1.2.3", instance.SymphonyVersion);
+            Assert.Equal("ReleasedGroup", instance.WorkflowOwner);
+            Assert.Equal("billing-api", instance.WorkflowRepository);
+            Assert.Equal(DateTimeOffset.Parse("2026-04-29T01:58:00Z"), instance.LastHealthCheckAtUtc);
         }
         finally
         {

--- a/tests/Conductor.Blazor.Tests/DashboardSmokeTests.cs
+++ b/tests/Conductor.Blazor.Tests/DashboardSmokeTests.cs
@@ -39,6 +39,14 @@ public sealed class DashboardSmokeTests
                     "Symphony instance is offline",
                     "/instances/client-mobile",
                     "instance")
+            ],
+            InstanceRuntimes =
+            [
+                InstanceRuntime(
+                    "billing-api-primary",
+                    "Billing API primary",
+                    InstanceHealthStatus.Healthy,
+                    InstanceLifecycleStatus.Running)
             ]
         }));
 
@@ -55,6 +63,11 @@ public sealed class DashboardSmokeTests
         Assert.Contains("Tests failed and a continuation run started.", dashboard.Markup, StringComparison.Ordinal);
         Assert.Contains("Repository orchestration health", dashboard.Markup, StringComparison.Ordinal);
         Assert.Contains("Release Portal", dashboard.Markup, StringComparison.Ordinal);
+        Assert.Contains("Symphony runtime", dashboard.Markup, StringComparison.Ordinal);
+        Assert.Contains("Billing API primary", dashboard.Markup, StringComparison.Ordinal);
+        Assert.Contains("ReleasedGroup/billing-api", dashboard.Markup, StringComparison.Ordinal);
+        Assert.Contains("1.2.3", dashboard.Markup, StringComparison.Ordinal);
+        Assert.Contains("/config/billing-api/WORKFLOW.md", dashboard.Markup, StringComparison.Ordinal);
         Assert.Contains("Needs attention", dashboard.Markup, StringComparison.Ordinal);
         Assert.Contains("billing-api", dashboard.Markup, StringComparison.Ordinal);
         Assert.Contains("Critical", dashboard.Markup, StringComparison.Ordinal);
@@ -230,6 +243,35 @@ public sealed class DashboardSmokeTests
             TargetKind = targetKind,
             CreatedAtUtc = DateTimeOffset.Parse("2026-04-29T01:58:00Z"),
             AgeLabel = "2m ago"
+        };
+    }
+
+    private static DashboardInstanceRuntime InstanceRuntime(
+        string key,
+        string displayName,
+        InstanceHealthStatus healthStatus,
+        InstanceLifecycleStatus lifecycleStatus)
+    {
+        return new DashboardInstanceRuntime
+        {
+            Key = key,
+            DisplayName = displayName,
+            RepositoryFullName = "ReleasedGroup/billing-api",
+            BaseUrl = new Uri("http://localhost:5010/"),
+            HealthStatus = healthStatus,
+            LifecycleStatus = lifecycleStatus,
+            SymphonyVersion = "1.2.3",
+            WorkflowOwner = "ReleasedGroup",
+            WorkflowRepository = "billing-api",
+            WorkflowSourcePath = "/config/billing-api/WORKFLOW.md",
+            LastHealthCheckAtUtc = DateTimeOffset.Parse("2026-04-29T01:58:00Z"),
+            LastSnapshotCapturedAtUtc = DateTimeOffset.Parse("2026-04-29T01:57:30Z"),
+            LastSeenAtUtc = DateTimeOffset.Parse("2026-04-29T01:58:00Z"),
+            ActiveIssueCount = 4,
+            RunningSessionCount = 2,
+            RetryQueueCount = 0,
+            FailedRunCount = 0,
+            TokenTotal = 140
         };
     }
 

--- a/tests/Conductor.Blazor.Tests/InstanceRuntimePanelTests.cs
+++ b/tests/Conductor.Blazor.Tests/InstanceRuntimePanelTests.cs
@@ -1,0 +1,119 @@
+using AngleSharp.Dom;
+using Bunit;
+using Conductor.Core.Application.Dashboard;
+using Conductor.Core.Domain;
+using Conductor.Host.Components.Dashboard;
+
+namespace Conductor.Blazor.Tests;
+
+public sealed class InstanceRuntimePanelTests
+{
+    [Fact]
+    public void InstanceRuntimePanel_Renders_Status_Workflow_Version_And_Poll_Data()
+    {
+        using BunitContext context = new();
+        DashboardInstanceRuntime[] instances =
+        [
+            Instance(
+                "api-primary",
+                "API primary",
+                InstanceHealthStatus.Healthy,
+                InstanceLifecycleStatus.Running),
+            Instance(
+                "mobile-offline",
+                "Mobile offline",
+                InstanceHealthStatus.Offline,
+                InstanceLifecycleStatus.Failed)
+        ];
+
+        IRenderedComponent<InstanceRuntimePanel> component = context.Render<InstanceRuntimePanel>(
+            parameters => parameters.Add(panel => panel.Items, instances));
+
+        Assert.Contains("Instance health", component.Markup, StringComparison.Ordinal);
+        Assert.Contains("API primary", component.Markup, StringComparison.Ordinal);
+        Assert.Contains("ReleasedGroup/api-service", component.Markup, StringComparison.Ordinal);
+        Assert.Contains("http://localhost:5010/", component.Markup, StringComparison.Ordinal);
+        Assert.Contains("Healthy", component.Markup, StringComparison.Ordinal);
+        Assert.Contains("Running", component.Markup, StringComparison.Ordinal);
+        Assert.Contains("1.2.3", component.Markup, StringComparison.Ordinal);
+        Assert.Contains("ReleasedGroup/api-service", component.Markup, StringComparison.Ordinal);
+        Assert.Contains("/config/api-service/WORKFLOW.md", component.Markup, StringComparison.Ordinal);
+        Assert.Contains("Apr 29, 01:58 UTC", component.Markup, StringComparison.Ordinal);
+        Assert.Contains("Snapshot", component.Markup, StringComparison.Ordinal);
+        Assert.Contains("Active", component.Markup, StringComparison.Ordinal);
+        Assert.Contains("Retry", component.Markup, StringComparison.Ordinal);
+        Assert.Contains("Failed", component.Markup, StringComparison.Ordinal);
+        Assert.Contains("Tokens", component.Markup, StringComparison.Ordinal);
+        Assert.Contains("140", component.Markup, StringComparison.Ordinal);
+
+        IReadOnlyList<IElement> rows = component.FindAll("[data-instance-runtime]");
+        Assert.Equal("mobile-offline", rows[0].GetAttribute("data-instance-runtime"));
+        Assert.Contains("instance-runtime-row--offline", rows[0].GetAttribute("class") ?? string.Empty, StringComparison.Ordinal);
+        Assert.Contains("status-badge--neutral", rows[0].InnerHtml, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void InstanceRuntimePanel_Renders_Empty_State_Without_Runtime_Data()
+    {
+        using BunitContext context = new();
+
+        IRenderedComponent<InstanceRuntimePanel> component = context.Render<InstanceRuntimePanel>();
+
+        Assert.Contains("No Symphony runtime data is available yet.", component.Markup, StringComparison.Ordinal);
+        Assert.DoesNotContain("<table", component.Markup, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void InstanceRuntimePanel_Falls_Back_For_Missing_Runtime_Metadata()
+    {
+        using BunitContext context = new();
+        DashboardInstanceRuntime[] instances =
+        [
+            new()
+            {
+                Key = "unknown",
+                DisplayName = "Unknown runtime",
+                HealthStatus = InstanceHealthStatus.Unknown,
+                LifecycleStatus = InstanceLifecycleStatus.Provisioned
+            }
+        ];
+
+        IRenderedComponent<InstanceRuntimePanel> component = context.Render<InstanceRuntimePanel>(
+            parameters => parameters.Add(panel => panel.Items, instances));
+
+        Assert.Contains("Version unknown", component.Markup, StringComparison.Ordinal);
+        Assert.Contains("Workflow unknown", component.Markup, StringComparison.Ordinal);
+        Assert.Contains("Workflow path unknown", component.Markup, StringComparison.Ordinal);
+        Assert.Contains("Not polled", component.Markup, StringComparison.Ordinal);
+        Assert.Contains("status-badge--info", component.Markup, StringComparison.Ordinal);
+    }
+
+    private static DashboardInstanceRuntime Instance(
+        string key,
+        string displayName,
+        InstanceHealthStatus healthStatus,
+        InstanceLifecycleStatus lifecycleStatus)
+    {
+        return new DashboardInstanceRuntime
+        {
+            Key = key,
+            DisplayName = displayName,
+            RepositoryFullName = "ReleasedGroup/api-service",
+            BaseUrl = new Uri("http://localhost:5010/"),
+            HealthStatus = healthStatus,
+            LifecycleStatus = lifecycleStatus,
+            SymphonyVersion = "1.2.3",
+            WorkflowOwner = "ReleasedGroup",
+            WorkflowRepository = "api-service",
+            WorkflowSourcePath = "/config/api-service/WORKFLOW.md",
+            LastHealthCheckAtUtc = DateTimeOffset.Parse("2026-04-29T01:58:00Z"),
+            LastSnapshotCapturedAtUtc = DateTimeOffset.Parse("2026-04-29T01:57:30Z"),
+            LastSeenAtUtc = DateTimeOffset.Parse("2026-04-29T01:58:00Z"),
+            ActiveIssueCount = 4,
+            RunningSessionCount = 2,
+            RetryQueueCount = 1,
+            FailedRunCount = 0,
+            TokenTotal = 140
+        };
+    }
+}

--- a/tests/Conductor.Persistence.Tests/SqliteProjectionQueryServiceTests.cs
+++ b/tests/Conductor.Persistence.Tests/SqliteProjectionQueryServiceTests.cs
@@ -58,6 +58,14 @@ public sealed class SqliteProjectionQueryServiceTests
         Assert.Equal("Alpha", runningInstance.ProjectName);
         Assert.Equal(InstanceLifecycleStatus.Running, runningInstance.LifecycleStatus);
         Assert.Equal(fixture.LatestSnapshotAtUtc, runningInstance.LatestSnapshotCapturedAtUtc);
+        Assert.Equal("1.2.3", runningInstance.SymphonyVersion);
+        Assert.Equal("ReleasedGroup", runningInstance.WorkflowOwner);
+        Assert.Equal("api-service", runningInstance.WorkflowRepository);
+        Assert.Equal("/config/api-service/WORKFLOW.md", runningInstance.WorkflowSourcePath);
+        Assert.Equal(1, runningInstance.ActiveIssueCount);
+        Assert.Equal(1, runningInstance.RunningSessionCount);
+        Assert.Equal(0, runningInstance.RetryQueueCount);
+        Assert.Equal(140, runningInstance.TokenTotal);
 
         Assert.DoesNotContain(instances, instance => instance.Id == fixture.DestroyedInstanceId);
     }
@@ -337,7 +345,17 @@ public sealed class SqliteProjectionQueryServiceTests
             capturedAtUtc,
             InstanceHealthStatus.Healthy,
             """{"status":"healthy"}""",
-            "{}",
+            """
+            {
+              "applicationName": "Symphony",
+              "version": "1.2.3",
+              "workflow": {
+                "owner": "ReleasedGroup",
+                "repository": "api-service",
+                "sourcePath": "/config/api-service/WORKFLOW.md"
+              }
+            }
+            """,
             "{}",
             activeIssueCount: 1,
             runningSessionCount: 1,


### PR DESCRIPTION
## Summary
- Add a dashboard runtime panel that shows each Symphony instance's health, lifecycle status, version, workflow metadata, and latest poll counters.
- Extend the dashboard JSON projection and SQLite instance summary projection with runtime metadata parsed from latest snapshots.
- Add Blazor and persistence coverage plus dashboard projection documentation.

## Validation
- `dotnet restore Conductor.slnx`: passed with no errors or warnings
- `dotnet build Conductor.slnx --no-restore --warnaserror`: passed with no errors or warnings
- `dotnet test Conductor.slnx --no-build`: passed with no errors or warnings
- `dotnet format Conductor.slnx --no-restore --verify-no-changes`: passed with no errors or warnings
- `./scripts/validate-docs.ps1`: passed with no errors or warnings
- `git diff --check`: passed

Closes #34