### PR TITLE
Add masked OpenAI secret descriptors

### DIFF
--- a/docs/feature_guides.md
+++ b/docs/feature_guides.md
@@ -5,3 +5,7 @@ Status: Planned
 Feature guides will provide task-focused documentation for major Conductor capabilities.
 
 Planned guides include repository onboarding, workflow profile management, Symphony instance operations, secret handling, alert review, and report generation.
+
+## Secret Handling
+
+The secret descriptor list supports GitHub PAT and OpenAI API key credentials as separate types. Descriptor rows show the credential name, scope, target environment variable, and a masked value only. OpenAI API key descriptors map to `OPENAI_API_KEY`; GitHub PAT descriptors map to `GITHUB_TOKEN`.

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -9,3 +9,7 @@ Initial user workflows will cover dashboard review, repository import, instance 
 ## Dashboard Review
 
 The dashboard includes a needs-attention panel for active critical and warning items. Each row shows the affected repository or Symphony instance, the current severity, the reason it needs attention, and a link to the source area for follow-up.
+
+## Secret Review
+
+The Secrets page lists saved credential descriptors for orchestration. GitHub PAT and OpenAI API key descriptors are shown independently, and saved values are rendered only as masked placeholders.

--- a/src/Conductor.Core/Application/Secrets/ISecretDescriptorQueryService.cs
+++ b/src/Conductor.Core/Application/Secrets/ISecretDescriptorQueryService.cs
@@ -1,0 +1,10 @@
+using Conductor.Core.Abstractions.Secrets;
+
+namespace Conductor.Core.Application.Secrets;
+
+public interface ISecretDescriptorQueryService
+{
+    Task<IReadOnlyList<SecretDescriptorView>> ListAsync(
+        SecretQuery query,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Conductor.Core/Application/Secrets/SecretDescriptorView.cs
+++ b/src/Conductor.Core/Application/Secrets/SecretDescriptorView.cs
@@ -1,0 +1,50 @@
+using Conductor.Core.Domain.Ids;
+using Conductor.Core.Domain.Secrets;
+
+namespace Conductor.Core.Application.Secrets;
+
+public sealed record SecretDescriptorView(
+    SecretId Id,
+    string Name,
+    SecretType SecretType,
+    string SecretTypeLabel,
+    string EnvironmentVariableName,
+    SecretScopeType ScopeType,
+    string ScopeLabel,
+    string? ScopeId,
+    string MaskedValue,
+    DateTimeOffset CreatedAtUtc,
+    DateTimeOffset? RotatedAtUtc)
+{
+    public static SecretDescriptorView FromDescriptor(SecretDescriptor descriptor)
+    {
+        ArgumentNullException.ThrowIfNull(descriptor);
+
+        SecretTypeDisplay secretType = SecretTypeMetadata.Get(descriptor.SecretType);
+
+        return new SecretDescriptorView(
+            descriptor.Id,
+            descriptor.Name,
+            descriptor.SecretType,
+            secretType.Label,
+            secretType.EnvironmentVariableName,
+            descriptor.ScopeType,
+            FormatScope(descriptor.ScopeType, descriptor.ScopeId),
+            descriptor.ScopeId,
+            secretType.MaskedDisplayValue,
+            descriptor.CreatedAtUtc,
+            descriptor.RotatedAtUtc);
+    }
+
+    private static string FormatScope(SecretScopeType scopeType, string? scopeId)
+    {
+        return scopeType switch
+        {
+            SecretScopeType.Global => "Global",
+            SecretScopeType.Project => $"Project {scopeId}",
+            SecretScopeType.Repository => $"Repository {scopeId}",
+            SecretScopeType.SymphonyInstance => $"Symphony instance {scopeId}",
+            _ => throw new ArgumentOutOfRangeException(nameof(scopeType), scopeType, "Unsupported secret scope type."),
+        };
+    }
+}

--- a/src/Conductor.Core/Domain/Secrets/SecretTypeMetadata.cs
+++ b/src/Conductor.Core/Domain/Secrets/SecretTypeMetadata.cs
@@ -1,0 +1,46 @@
+namespace Conductor.Core.Domain.Secrets;
+
+public sealed record SecretTypeDisplay(
+    SecretType SecretType,
+    string Label,
+    string EnvironmentVariableName,
+    string MaskedDisplayValue);
+
+public static class SecretTypeMetadata
+{
+    public const string MaskedDisplayValue = "************";
+
+    public static IReadOnlyList<SecretTypeDisplay> CredentialTypes { get; } =
+    [
+        Get(SecretType.GitHubToken),
+        Get(SecretType.OpenAiApiKey),
+    ];
+
+    public static SecretTypeDisplay Get(SecretType secretType)
+    {
+        return secretType switch
+        {
+            SecretType.GitHubToken => new SecretTypeDisplay(
+                secretType,
+                "GitHub PAT",
+                "GITHUB_TOKEN",
+                MaskedDisplayValue),
+            SecretType.OpenAiApiKey => new SecretTypeDisplay(
+                secretType,
+                "OpenAI API key",
+                "OPENAI_API_KEY",
+                MaskedDisplayValue),
+            SecretType.CodexHome => new SecretTypeDisplay(
+                secretType,
+                "Codex home",
+                "CODEX_HOME",
+                MaskedDisplayValue),
+            SecretType.Other => new SecretTypeDisplay(
+                secretType,
+                "Other secret",
+                "Custom",
+                MaskedDisplayValue),
+            _ => throw new ArgumentOutOfRangeException(nameof(secretType), secretType, "Unsupported secret type."),
+        };
+    }
+}

--- a/src/Conductor.Host/Components/Layout/MainLayout.razor
+++ b/src/Conductor.Host/Components/Layout/MainLayout.razor
@@ -7,11 +7,12 @@
             <span>Conductor</span>
         </a>
         <nav>
-            <a href="/" aria-current="page">Dashboard</a>
-            <a href="/projects">Projects</a>
-            <a href="/repositories">Repositories</a>
-            <a href="/instances">Instances</a>
-            <a href="/reports">Reports</a>
+            <NavLink href="/" Match="NavLinkMatch.All">Dashboard</NavLink>
+            <NavLink href="/projects">Projects</NavLink>
+            <NavLink href="/repositories">Repositories</NavLink>
+            <NavLink href="/instances">Instances</NavLink>
+            <NavLink href="/settings/secrets">Secrets</NavLink>
+            <NavLink href="/reports">Reports</NavLink>
         </nav>
     </aside>
 

--- a/src/Conductor.Host/Components/Pages/Secrets.razor
+++ b/src/Conductor.Host/Components/Pages/Secrets.razor
@@ -1,0 +1,138 @@
+@page "/settings/secrets"
+@using System.Data.Common
+@using Conductor.Core.Abstractions.Secrets
+@using Conductor.Core.Application.Secrets
+@using Conductor.Core.Domain.Secrets
+@inject ISecretDescriptorQueryService SecretDescriptorQueryService
+
+<PageTitle>Secrets - Conductor</PageTitle>
+
+<section class="secrets-page">
+    <header class="secrets-header">
+        <div>
+            <p class="eyebrow">Credential vault</p>
+            <h1>Secrets</h1>
+            <p class="secrets-summary">GitHub and OpenAI credentials available to repository orchestration.</p>
+        </div>
+        <div class="dashboard-meta">
+            <StatusBadge Text="Masked values" Tone="@StatusBadgeTone.Success" />
+            @if (descriptors is not null)
+            {
+                <span class="projection-stamp">@descriptors.Count descriptors</span>
+            }
+        </div>
+    </header>
+
+    <section class="secret-type-grid" aria-label="Supported credential types">
+        @foreach (SecretTypeDisplay secretType in SecretTypeMetadata.CredentialTypes)
+        {
+            <article class="secret-type-card" data-secret-type-card="@secretType.SecretType">
+                <span class="secret-type-label">@secretType.Label</span>
+                <code>@secretType.EnvironmentVariableName</code>
+            </article>
+        }
+    </section>
+
+    @if (loadError is not null)
+    {
+        <ErrorState
+            Title="Secret descriptors could not be loaded."
+            Message="Check the persistence store and try again."
+            Detail="@loadError" />
+    }
+    else if (descriptors is null)
+    {
+        <LoadingState
+            Title="Loading secret descriptors"
+            Message="Fetching saved credential metadata." />
+    }
+    else if (descriptors.Count == 0)
+    {
+        <EmptyState
+            Title="No secret descriptors yet."
+            Message="Saved GitHub PAT and OpenAI API key descriptors will appear here." />
+    }
+    else
+    {
+        <div class="secret-table-wrap">
+            <table class="secret-table" aria-label="Secret descriptors">
+                <thead>
+                    <tr>
+                        <th scope="col">Name</th>
+                        <th scope="col">Type</th>
+                        <th scope="col">Scope</th>
+                        <th scope="col">Value</th>
+                        <th scope="col">Created</th>
+                        <th scope="col">Rotated</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (SecretDescriptorView descriptor in descriptors)
+                    {
+                        <tr data-secret-type="@descriptor.SecretType">
+                            <th scope="row">
+                                <span class="secret-name">@descriptor.Name</span>
+                                <span class="secret-muted">@descriptor.EnvironmentVariableName</span>
+                            </th>
+                            <td>
+                                <span class="@GetSecretTypeClass(descriptor.SecretType)">@descriptor.SecretTypeLabel</span>
+                            </td>
+                            <td>
+                                <span>@descriptor.ScopeLabel</span>
+                            </td>
+                            <td>
+                                <code class="secret-mask" aria-label="@($"{descriptor.SecretTypeLabel} value masked")">
+                                    @descriptor.MaskedValue
+                                </code>
+                            </td>
+                            <td>
+                                <time datetime="@descriptor.CreatedAtUtc.ToString("O")">
+                                    @descriptor.CreatedAtUtc.ToLocalTime().ToString("MMM d, yyyy")
+                                </time>
+                            </td>
+                            <td>
+                                @if (descriptor.RotatedAtUtc is { } rotatedAtUtc)
+                                {
+                                    <time datetime="@rotatedAtUtc.ToString("O")">
+                                        @rotatedAtUtc.ToLocalTime().ToString("MMM d, yyyy")
+                                    </time>
+                                }
+                                else
+                                {
+                                    <span class="secret-muted">Not rotated</span>
+                                }
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+    }
+</section>
+
+@code {
+    private IReadOnlyList<SecretDescriptorView>? descriptors;
+    private string? loadError;
+
+    protected override async Task OnInitializedAsync()
+    {
+        try
+        {
+            descriptors = await SecretDescriptorQueryService.ListAsync(new SecretQuery());
+        }
+        catch (Exception ex) when (ex is DbException or InvalidOperationException or IOException or UnauthorizedAccessException)
+        {
+            loadError = ex.Message;
+        }
+    }
+
+    private static string GetSecretTypeClass(SecretType secretType)
+    {
+        return secretType switch
+        {
+            SecretType.GitHubToken => "secret-type-pill secret-type-pill--github",
+            SecretType.OpenAiApiKey => "secret-type-pill secret-type-pill--openai",
+            _ => "secret-type-pill",
+        };
+    }
+}

--- a/src/Conductor.Host/wwwroot/app.css
+++ b/src/Conductor.Host/wwwroot/app.css
@@ -79,7 +79,8 @@ a {
 }
 
 .side-nav nav a:hover,
-.side-nav nav a[aria-current="page"] {
+.side-nav nav a[aria-current="page"],
+.side-nav nav a.active {
   background: #232a31;
   color: #ffffff;
 }
@@ -930,6 +931,128 @@ h2 {
   background: transparent;
 }
 
+.secrets-page {
+  display: grid;
+  gap: 24px;
+  max-width: 1180px;
+}
+
+.secrets-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.secrets-summary {
+  margin: 8px 0 0;
+  color: #aeb9c5;
+}
+
+.secret-type-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.secret-type-card {
+  display: grid;
+  gap: 10px;
+  min-height: 106px;
+  padding: 18px;
+  border: 1px solid #2b3138;
+  border-radius: 8px;
+  background: #191f25;
+}
+
+.secret-type-label {
+  color: #ffffff;
+  font-size: 1rem;
+  font-weight: 800;
+}
+
+.secret-type-card code,
+.secret-mask {
+  width: fit-content;
+  max-width: 100%;
+  padding: 4px 7px;
+  border-radius: 4px;
+  background: #232a31;
+  color: #f2c14e;
+  overflow-wrap: anywhere;
+}
+
+.secret-table-wrap {
+  overflow-x: auto;
+  border: 1px solid #2b3138;
+  border-radius: 8px;
+  background: #151a1f;
+}
+
+.secret-table {
+  width: 100%;
+  min-width: 860px;
+  border-collapse: collapse;
+}
+
+.secret-table th,
+.secret-table td {
+  padding: 16px 14px;
+  border-top: 1px solid #2b3138;
+  vertical-align: top;
+  text-align: left;
+}
+
+.secret-table thead th {
+  border-top: 0;
+  color: #aeb9c5;
+  font-size: 0.8rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.secret-name,
+.secret-muted {
+  display: block;
+  overflow-wrap: anywhere;
+}
+
+.secret-name {
+  color: #ffffff;
+  font-weight: 800;
+}
+
+.secret-muted {
+  margin-top: 5px;
+  color: #aeb9c5;
+  font-size: 0.84rem;
+}
+
+.secret-type-pill {
+  display: inline-flex;
+  align-items: center;
+  min-height: 30px;
+  padding: 5px 9px;
+  border: 1px solid #53606d;
+  border-radius: 999px;
+  background: #272d34;
+  color: #c7d0d9;
+  font-size: 0.82rem;
+  font-weight: 800;
+}
+
+.secret-type-pill--github {
+  border-color: #45666d;
+  background: #17373b;
+  color: #9ee7d7;
+}
+
+.secret-type-pill--openai {
+  border-color: #8a6823;
+  background: #3d3015;
+  color: #f2c14e;
+}
+
 .ui-state {
   display: flex;
   align-items: flex-start;
@@ -1113,6 +1236,12 @@ h2 {
 
   .dashboard-header {
     display: grid;
+  }
+
+  .secrets-header,
+  .secret-type-grid {
+    display: grid;
+    grid-template-columns: 1fr;
   }
 
   .dashboard-meta {

--- a/src/Conductor.Infrastructure.Persistence.Sqlite/Queries/SqliteSecretDescriptorQueryService.cs
+++ b/src/Conductor.Infrastructure.Persistence.Sqlite/Queries/SqliteSecretDescriptorQueryService.cs
@@ -1,0 +1,35 @@
+using Conductor.Core.Abstractions.Secrets;
+using Conductor.Core.Application.Secrets;
+using Conductor.Core.Domain.Secrets;
+using Microsoft.EntityFrameworkCore;
+
+namespace Conductor.Infrastructure.Persistence.Sqlite.Queries;
+
+internal sealed class SqliteSecretDescriptorQueryService(ConductorDbContext dbContext) : ISecretDescriptorQueryService
+{
+    public async Task<IReadOnlyList<SecretDescriptorView>> ListAsync(
+        SecretQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        IQueryable<SecretDescriptor> descriptors = dbContext.SecretDescriptors.AsNoTracking();
+
+        if (query.SecretType is { } secretType)
+        {
+            descriptors = descriptors.Where(descriptor => descriptor.SecretType == secretType);
+        }
+
+        if (query.ScopeType is { } scopeType)
+        {
+            descriptors = descriptors.Where(descriptor => descriptor.ScopeType == scopeType);
+        }
+
+        List<SecretDescriptor> results = await descriptors
+            .OrderBy(descriptor => descriptor.SecretType)
+            .ThenBy(descriptor => descriptor.Name)
+            .ToListAsync(cancellationToken);
+
+        return results
+            .Select(SecretDescriptorView.FromDescriptor)
+            .ToArray();
+    }
+}

--- a/src/Conductor.Infrastructure.Persistence.Sqlite/SqlitePersistenceServiceCollectionExtensions.cs
+++ b/src/Conductor.Infrastructure.Persistence.Sqlite/SqlitePersistenceServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using Conductor.Core.Application.Queries;
+using Conductor.Core.Application.Secrets;
 using Conductor.Core.Application.Snapshots;
 using Conductor.Infrastructure.Persistence.Sqlite.Queries;
 using Conductor.Infrastructure.Persistence.Sqlite.Snapshots;
@@ -33,6 +34,7 @@ public static class SqlitePersistenceServiceCollectionExtensions
             provider.GetRequiredService<SqliteProjectionQueryService>());
         services.AddScoped<IInstanceSummaryQueryService>(provider =>
             provider.GetRequiredService<SqliteProjectionQueryService>());
+        services.AddScoped<ISecretDescriptorQueryService, SqliteSecretDescriptorQueryService>();
         services.AddScoped<IInstanceSnapshotStore, SqliteInstanceSnapshotStore>();
 
         return services;

--- a/tests/Conductor.Blazor.Tests/SecretManagementPageTests.cs
+++ b/tests/Conductor.Blazor.Tests/SecretManagementPageTests.cs
@@ -1,0 +1,63 @@
+using Bunit;
+using Conductor.Core.Abstractions.Secrets;
+using Conductor.Core.Application.Secrets;
+using Conductor.Core.Domain.Ids;
+using Conductor.Core.Domain.Secrets;
+using Conductor.Host.Components.Pages;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Conductor.Blazor.Tests;
+
+public sealed class SecretManagementPageTests
+{
+    [Fact]
+    public void Secrets_Renders_OpenAi_Key_Descriptor_With_Masked_Value()
+    {
+        using BunitContext context = new();
+        DateTimeOffset createdAtUtc = DateTimeOffset.Parse("2026-04-29T00:10:00Z");
+        SecretDescriptor descriptor = new(
+            SecretId.New(),
+            "Production OpenAI key",
+            SecretType.OpenAiApiKey,
+            SecretScopeType.Global,
+            scopeId: null,
+            createdAtUtc);
+
+        context.Services.AddSingleton<ISecretDescriptorQueryService>(
+            new StaticSecretDescriptorQueryService([SecretDescriptorView.FromDescriptor(descriptor)]));
+
+        IRenderedComponent<Secrets> page = context.Render<Secrets>();
+
+        Assert.Contains("Secrets", page.Markup, StringComparison.Ordinal);
+        Assert.Contains("Production OpenAI key", page.Markup, StringComparison.Ordinal);
+        Assert.Contains("OpenAI API key", page.Markup, StringComparison.Ordinal);
+        Assert.Contains("OPENAI_API_KEY", page.Markup, StringComparison.Ordinal);
+        Assert.Contains(SecretTypeMetadata.MaskedDisplayValue, page.Markup, StringComparison.Ordinal);
+        Assert.DoesNotContain("sk-", page.Markup, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Secrets_Renders_Empty_State_When_No_Descriptors_Exist()
+    {
+        using BunitContext context = new();
+        context.Services.AddSingleton<ISecretDescriptorQueryService>(
+            new StaticSecretDescriptorQueryService([]));
+
+        IRenderedComponent<Secrets> page = context.Render<Secrets>();
+
+        Assert.Contains("No secret descriptors yet.", page.Markup, StringComparison.Ordinal);
+        Assert.Contains("GitHub PAT", page.Markup, StringComparison.Ordinal);
+        Assert.Contains("OpenAI API key", page.Markup, StringComparison.Ordinal);
+    }
+
+    private sealed class StaticSecretDescriptorQueryService(IReadOnlyList<SecretDescriptorView> descriptors)
+        : ISecretDescriptorQueryService
+    {
+        public Task<IReadOnlyList<SecretDescriptorView>> ListAsync(
+            SecretQuery query,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(descriptors);
+        }
+    }
+}

--- a/tests/Conductor.Core.Tests/Issue13DomainEntityTests.cs
+++ b/tests/Conductor.Core.Tests/Issue13DomainEntityTests.cs
@@ -97,4 +97,19 @@ public sealed class Issue13DomainEntityTests
 
         Assert.Equal("scopeId", error.ParamName);
     }
+
+    [Fact]
+    public void SecretTypeMetadata_Labels_OpenAi_Api_Key_For_Masked_Display()
+    {
+        SecretTypeDisplay metadata = SecretTypeMetadata.Get(SecretType.OpenAiApiKey);
+
+        Assert.Equal(SecretType.OpenAiApiKey, metadata.SecretType);
+        Assert.Equal("OpenAI API key", metadata.Label);
+        Assert.Equal("OPENAI_API_KEY", metadata.EnvironmentVariableName);
+        Assert.Equal(SecretTypeMetadata.MaskedDisplayValue, metadata.MaskedDisplayValue);
+        Assert.DoesNotContain("sk-", metadata.MaskedDisplayValue, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains(
+            SecretTypeMetadata.CredentialTypes,
+            secretType => secretType.SecretType == SecretType.OpenAiApiKey);
+    }
 }

--- a/tests/Conductor.Persistence.Tests/SqlitePersistenceSmokeTests.cs
+++ b/tests/Conductor.Persistence.Tests/SqlitePersistenceSmokeTests.cs
@@ -1,5 +1,7 @@
 using System.Data.Common;
 using System.Globalization;
+using Conductor.Core.Abstractions.Secrets;
+using Conductor.Core.Application.Secrets;
 using Conductor.Core.Application.Snapshots;
 using Conductor.Core.Domain;
 using Conductor.Core.Domain.Alerts;
@@ -563,12 +565,61 @@ public sealed class SqlitePersistenceSmokeTests
         await using AsyncServiceScope scope = provider.CreateAsyncScope();
         ConductorDbContext dbContext = scope.ServiceProvider.GetRequiredService<ConductorDbContext>();
         IInstanceSnapshotStore snapshotStore = scope.ServiceProvider.GetRequiredService<IInstanceSnapshotStore>();
+        ISecretDescriptorQueryService secretDescriptorQueryService =
+            scope.ServiceProvider.GetRequiredService<ISecretDescriptorQueryService>();
 
         await dbContext.Database.OpenConnectionAsync();
 
         Assert.True(await dbContext.Database.CanConnectAsync());
         Assert.IsType<SqliteInstanceSnapshotStore>(snapshotStore);
+        Assert.NotNull(secretDescriptorQueryService);
         Assert.True(Directory.Exists(Path.GetDirectoryName(databasePath)));
+    }
+
+    [Fact]
+    public async Task Secret_Descriptor_Query_Returns_OpenAi_Descriptors_With_Masked_Display()
+    {
+        string databasePath = CreateTemporaryDatabasePath();
+        IConfiguration configuration = BuildConfiguration(databasePath);
+        ServiceCollection services = new();
+
+        services.AddConductorPersistence(configuration);
+
+        await using ServiceProvider provider = services.BuildServiceProvider(validateScopes: true);
+        await using AsyncServiceScope scope = provider.CreateAsyncScope();
+        ConductorDbContext dbContext = scope.ServiceProvider.GetRequiredService<ConductorDbContext>();
+        ISecretDescriptorQueryService queryService =
+            scope.ServiceProvider.GetRequiredService<ISecretDescriptorQueryService>();
+        DateTimeOffset createdAtUtc = DateTimeOffset.Parse("2026-04-29T00:10:00Z");
+
+        await dbContext.Database.EnsureCreatedAsync();
+        dbContext.SecretDescriptors.AddRange(
+            new SecretDescriptor(
+                SecretId.New(),
+                "Default GitHub PAT",
+                SecretType.GitHubToken,
+                SecretScopeType.Global,
+                scopeId: null,
+                createdAtUtc),
+            new SecretDescriptor(
+                SecretId.New(),
+                "Production OpenAI key",
+                SecretType.OpenAiApiKey,
+                SecretScopeType.Global,
+                scopeId: null,
+                createdAtUtc));
+        await dbContext.SaveChangesAsync();
+        dbContext.ChangeTracker.Clear();
+
+        IReadOnlyList<SecretDescriptorView> openAiDescriptors =
+            await queryService.ListAsync(new SecretQuery(SecretType.OpenAiApiKey));
+        SecretDescriptorView openAiDescriptor = Assert.Single(openAiDescriptors);
+
+        Assert.Equal("Production OpenAI key", openAiDescriptor.Name);
+        Assert.Equal(SecretType.OpenAiApiKey, openAiDescriptor.SecretType);
+        Assert.Equal("OpenAI API key", openAiDescriptor.SecretTypeLabel);
+        Assert.Equal("OPENAI_API_KEY", openAiDescriptor.EnvironmentVariableName);
+        Assert.Equal(SecretTypeMetadata.MaskedDisplayValue, openAiDescriptor.MaskedValue);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Add shared secret type metadata for GitHub PAT and OpenAI API key descriptors, including masked display values and target environment variables.
- Add a SQLite-backed secret descriptor query service and a /settings/secrets page that renders saved descriptor metadata without secret values.
- Add focused core, persistence, and Blazor coverage for OpenAI API key masked display.

Closes #40

## Validation
- dotnet restore Conductor.slnx: passed
- dotnet build Conductor.slnx --no-restore --warnaserror: passed with 0 warnings
- dotnet test Conductor.slnx --no-build: passed
- dotnet format Conductor.slnx --no-restore --verify-no-changes: passed
- git diff --check: passed