### PR TITLE
Implement secret scope inheritance

### DIFF
--- a/docs/technical.md
+++ b/docs/technical.md
@@ -621,6 +621,7 @@ public interface ISecretStore
     Task<SecretDescriptor> CreateAsync(CreateSecretRequest request, CancellationToken ct);
     Task RotateAsync(SecretId secretId, RotateSecretRequest request, CancellationToken ct);
     Task<ResolvedSecret> ResolveAsync(SecretReference reference, CancellationToken ct);
+    Task<ResolvedSecret?> ResolveAsync(SecretResolutionRequest request, CancellationToken ct);
     Task<IReadOnlyList<SecretDescriptor>> ListAsync(SecretQuery query, CancellationToken ct);
     Task DeleteAsync(SecretId secretId, CancellationToken ct);
 }
@@ -847,6 +848,12 @@ Resolution precedence:
 2. Repository-scoped secret.
 3. Project-scoped secret.
 4. Global default.
+
+Credential modes:
+
+- `SpecificSecret` resolves the selected secret descriptor directly.
+- `InheritDefault` resolves scoped descriptors using the precedence order above.
+- `None` resolves no credential even when scoped defaults exist.
 
 Secret storage:
 

--- a/src/Conductor.Core/Abstractions/Secrets/ISecretStore.cs
+++ b/src/Conductor.Core/Abstractions/Secrets/ISecretStore.cs
@@ -17,6 +17,10 @@ public interface ISecretStore
         SecretReference reference,
         CancellationToken cancellationToken);
 
+    Task<ResolvedSecret?> ResolveAsync(
+        SecretResolutionRequest request,
+        CancellationToken cancellationToken);
+
     Task<IReadOnlyList<SecretDescriptor>> ListAsync(
         SecretQuery query,
         CancellationToken cancellationToken);

--- a/src/Conductor.Core/Domain/Secrets/SecretResolutionPolicy.cs
+++ b/src/Conductor.Core/Domain/Secrets/SecretResolutionPolicy.cs
@@ -1,0 +1,157 @@
+using Conductor.Core.Common;
+using Conductor.Core.Domain.Ids;
+
+namespace Conductor.Core.Domain.Secrets;
+
+public sealed class SecretResolutionRequest
+{
+    public SecretResolutionRequest(
+        SecretType secretType,
+        SymphonyInstanceId symphonyInstanceId,
+        RepositoryId repositoryId,
+        ProjectId? projectId,
+        CredentialInheritanceMode inheritanceMode,
+        SecretId? specificSecretId = null)
+    {
+        if (!Enum.IsDefined(inheritanceMode))
+        {
+            throw new ArgumentOutOfRangeException(nameof(inheritanceMode), inheritanceMode, "Credential inheritance mode is not supported.");
+        }
+
+        SecretType = secretType;
+        SymphonyInstanceId = new SymphonyInstanceId(Guard.NotEmpty(symphonyInstanceId.Value, nameof(symphonyInstanceId)));
+        RepositoryId = new RepositoryId(Guard.NotEmpty(repositoryId.Value, nameof(repositoryId)));
+        ProjectId = projectId is null
+            ? null
+            : new ProjectId(Guard.NotEmpty(projectId.Value.Value, nameof(projectId)));
+        InheritanceMode = inheritanceMode;
+        SpecificSecretId = ValidateSpecificSecretId(specificSecretId, inheritanceMode);
+    }
+
+    public SecretType SecretType { get; }
+
+    public SymphonyInstanceId SymphonyInstanceId { get; }
+
+    public RepositoryId RepositoryId { get; }
+
+    public ProjectId? ProjectId { get; }
+
+    public CredentialInheritanceMode InheritanceMode { get; }
+
+    public SecretId? SpecificSecretId { get; }
+
+    private static SecretId? ValidateSpecificSecretId(
+        SecretId? secretId,
+        CredentialInheritanceMode inheritanceMode)
+    {
+        if (inheritanceMode == CredentialInheritanceMode.SpecificSecret)
+        {
+            if (secretId is null)
+            {
+                throw new ArgumentException("A specific secret resolution request requires a secret id.", nameof(secretId));
+            }
+
+            return new SecretId(Guard.NotEmpty(secretId.Value.Value, nameof(secretId)));
+        }
+
+        if (secretId is not null)
+        {
+            throw new ArgumentException("A secret id can only be supplied for specific secret resolution.", nameof(secretId));
+        }
+
+        return null;
+    }
+}
+
+public sealed record SecretResolutionCandidate(SecretScopeType ScopeType, string? ScopeId);
+
+public static class SecretResolutionPolicy
+{
+    public static SecretDescriptor? Resolve(
+        SecretResolutionRequest request,
+        IEnumerable<SecretDescriptor> descriptors)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        ArgumentNullException.ThrowIfNull(descriptors);
+
+        SecretDescriptor[] matchingTypeDescriptors = descriptors
+            .Where(descriptor => descriptor.SecretType == request.SecretType)
+            .ToArray();
+
+        return request.InheritanceMode switch
+        {
+            CredentialInheritanceMode.None => null,
+            CredentialInheritanceMode.SpecificSecret => ResolveSpecificSecret(request, matchingTypeDescriptors),
+            CredentialInheritanceMode.InheritDefault => ResolveInheritedSecret(request, matchingTypeDescriptors),
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(request),
+                request.InheritanceMode,
+                "Credential inheritance mode is not supported."),
+        };
+    }
+
+    public static IReadOnlyList<SecretResolutionCandidate> GetInheritanceCandidates(
+        SecretResolutionRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (request.InheritanceMode != CredentialInheritanceMode.InheritDefault)
+        {
+            return [];
+        }
+
+        List<SecretResolutionCandidate> candidates =
+        [
+            new(SecretScopeType.SymphonyInstance, request.SymphonyInstanceId.ToString()),
+            new(SecretScopeType.Repository, request.RepositoryId.ToString()),
+        ];
+
+        if (request.ProjectId is { } projectId)
+        {
+            candidates.Add(new SecretResolutionCandidate(SecretScopeType.Project, projectId.ToString()));
+        }
+
+        candidates.Add(new SecretResolutionCandidate(SecretScopeType.Global, null));
+
+        return candidates;
+    }
+
+    private static SecretDescriptor? ResolveSpecificSecret(
+        SecretResolutionRequest request,
+        IEnumerable<SecretDescriptor> descriptors)
+    {
+        SecretId specificSecretId = request.SpecificSecretId!.Value;
+
+        return descriptors.FirstOrDefault(descriptor => descriptor.Id == specificSecretId);
+    }
+
+    private static SecretDescriptor? ResolveInheritedSecret(
+        SecretResolutionRequest request,
+        IReadOnlyList<SecretDescriptor> descriptors)
+    {
+        foreach (SecretResolutionCandidate candidate in GetInheritanceCandidates(request))
+        {
+            SecretDescriptor? resolved = descriptors
+                .Where(descriptor => MatchesCandidate(descriptor, candidate))
+                .OrderByDescending(descriptor => descriptor.RotatedAtUtc ?? descriptor.CreatedAtUtc)
+                .ThenByDescending(descriptor => descriptor.CreatedAtUtc)
+                .ThenByDescending(descriptor => descriptor.Id.Value)
+                .FirstOrDefault();
+
+            if (resolved is not null)
+            {
+                return resolved;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool MatchesCandidate(
+        SecretDescriptor descriptor,
+        SecretResolutionCandidate candidate)
+    {
+        return descriptor.ScopeType == candidate.ScopeType &&
+            string.Equals(descriptor.ScopeId, candidate.ScopeId, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/tests/Conductor.Core.Tests/SecretResolutionPolicyTests.cs
+++ b/tests/Conductor.Core.Tests/SecretResolutionPolicyTests.cs
@@ -1,0 +1,235 @@
+using Conductor.Core.Domain;
+using Conductor.Core.Domain.Ids;
+using Conductor.Core.Domain.Secrets;
+
+namespace Conductor.Core.Tests;
+
+public sealed class SecretResolutionPolicyTests
+{
+    private static readonly DateTimeOffset CreatedAtUtc = DateTimeOffset.Parse("2026-04-29T00:00:00Z");
+    private static readonly ProjectId ProjectId = new(Guid.Parse("11111111-1111-1111-1111-111111111111"));
+    private static readonly RepositoryId RepositoryId = new(Guid.Parse("22222222-2222-2222-2222-222222222222"));
+    private static readonly SymphonyInstanceId InstanceId = new(Guid.Parse("33333333-3333-3333-3333-333333333333"));
+
+    [Fact]
+    public void Resolve_Inherited_Secret_Prefers_Instance_Scope()
+    {
+        SecretDescriptor globalSecret = Descriptor(
+            new SecretId(Guid.Parse("10000000-0000-0000-0000-000000000001")),
+            SecretScopeType.Global,
+            scopeId: null);
+        SecretDescriptor projectSecret = Descriptor(
+            new SecretId(Guid.Parse("10000000-0000-0000-0000-000000000002")),
+            SecretScopeType.Project,
+            ProjectId.ToString());
+        SecretDescriptor repositorySecret = Descriptor(
+            new SecretId(Guid.Parse("10000000-0000-0000-0000-000000000003")),
+            SecretScopeType.Repository,
+            RepositoryId.ToString());
+        SecretDescriptor instanceSecret = Descriptor(
+            new SecretId(Guid.Parse("10000000-0000-0000-0000-000000000004")),
+            SecretScopeType.SymphonyInstance,
+            InstanceId.ToString());
+
+        SecretDescriptor? resolved = SecretResolutionPolicy.Resolve(
+            InheritedRequest(SecretType.GitHubToken),
+            [globalSecret, projectSecret, repositorySecret, instanceSecret]);
+
+        Assert.Equal(instanceSecret.Id, resolved?.Id);
+    }
+
+    [Fact]
+    public void Resolve_Inherited_Secret_Falls_Back_From_Repository_To_Project_Then_Global()
+    {
+        SecretDescriptor globalSecret = Descriptor(
+            new SecretId(Guid.Parse("20000000-0000-0000-0000-000000000001")),
+            SecretScopeType.Global,
+            scopeId: null);
+        SecretDescriptor projectSecret = Descriptor(
+            new SecretId(Guid.Parse("20000000-0000-0000-0000-000000000002")),
+            SecretScopeType.Project,
+            ProjectId.ToString());
+        SecretDescriptor repositorySecret = Descriptor(
+            new SecretId(Guid.Parse("20000000-0000-0000-0000-000000000003")),
+            SecretScopeType.Repository,
+            RepositoryId.ToString());
+
+        Assert.Equal(
+            repositorySecret.Id,
+            SecretResolutionPolicy.Resolve(
+                InheritedRequest(SecretType.GitHubToken),
+                [globalSecret, projectSecret, repositorySecret])?.Id);
+        Assert.Equal(
+            projectSecret.Id,
+            SecretResolutionPolicy.Resolve(
+                InheritedRequest(SecretType.GitHubToken),
+                [globalSecret, projectSecret])?.Id);
+        Assert.Equal(
+            globalSecret.Id,
+            SecretResolutionPolicy.Resolve(
+                InheritedRequest(SecretType.GitHubToken),
+                [globalSecret])?.Id);
+    }
+
+    [Fact]
+    public void Resolve_Inherited_Secret_Does_Not_Cross_Secret_Types()
+    {
+        SecretDescriptor openAiSecret = Descriptor(
+            new SecretId(Guid.Parse("30000000-0000-0000-0000-000000000001")),
+            SecretScopeType.SymphonyInstance,
+            InstanceId.ToString(),
+            SecretType.OpenAiApiKey);
+        SecretDescriptor gitHubSecret = Descriptor(
+            new SecretId(Guid.Parse("30000000-0000-0000-0000-000000000002")),
+            SecretScopeType.Global,
+            scopeId: null,
+            SecretType.GitHubToken);
+
+        SecretDescriptor? resolved = SecretResolutionPolicy.Resolve(
+            InheritedRequest(SecretType.GitHubToken),
+            [openAiSecret, gitHubSecret]);
+
+        Assert.Equal(gitHubSecret.Id, resolved?.Id);
+    }
+
+    [Fact]
+    public void Resolve_Returns_Null_When_Credential_Mode_Is_None()
+    {
+        SecretDescriptor instanceSecret = Descriptor(
+            new SecretId(Guid.Parse("40000000-0000-0000-0000-000000000001")),
+            SecretScopeType.SymphonyInstance,
+            InstanceId.ToString());
+        SecretResolutionRequest request = new(
+            SecretType.GitHubToken,
+            InstanceId,
+            RepositoryId,
+            ProjectId,
+            CredentialInheritanceMode.None);
+
+        SecretDescriptor? resolved = SecretResolutionPolicy.Resolve(request, [instanceSecret]);
+
+        Assert.Null(resolved);
+    }
+
+    [Fact]
+    public void Resolve_Specific_Secret_Uses_Selected_Descriptor()
+    {
+        SecretDescriptor instanceSecret = Descriptor(
+            new SecretId(Guid.Parse("50000000-0000-0000-0000-000000000001")),
+            SecretScopeType.SymphonyInstance,
+            InstanceId.ToString());
+        SecretDescriptor selectedRepositorySecret = Descriptor(
+            new SecretId(Guid.Parse("50000000-0000-0000-0000-000000000002")),
+            SecretScopeType.Repository,
+            RepositoryId.ToString());
+        SecretResolutionRequest request = new(
+            SecretType.GitHubToken,
+            InstanceId,
+            RepositoryId,
+            ProjectId,
+            CredentialInheritanceMode.SpecificSecret,
+            selectedRepositorySecret.Id);
+
+        SecretDescriptor? resolved = SecretResolutionPolicy.Resolve(
+            request,
+            [instanceSecret, selectedRepositorySecret]);
+
+        Assert.Equal(selectedRepositorySecret.Id, resolved?.Id);
+    }
+
+    [Fact]
+    public void Resolve_Inherited_Secret_Uses_Most_Recently_Rotated_Match_Within_A_Scope()
+    {
+        SecretDescriptor olderSecret = Descriptor(
+            new SecretId(Guid.Parse("60000000-0000-0000-0000-000000000001")),
+            SecretScopeType.Repository,
+            RepositoryId.ToString());
+        SecretDescriptor rotatedSecret = Descriptor(
+            new SecretId(Guid.Parse("60000000-0000-0000-0000-000000000002")),
+            SecretScopeType.Repository,
+            RepositoryId.ToString());
+
+        rotatedSecret.MarkRotated(CreatedAtUtc.AddMinutes(10));
+
+        SecretDescriptor? resolved = SecretResolutionPolicy.Resolve(
+            InheritedRequest(SecretType.GitHubToken),
+            [olderSecret, rotatedSecret]);
+
+        Assert.Equal(rotatedSecret.Id, resolved?.Id);
+    }
+
+    [Fact]
+    public void GetInheritanceCandidates_Uses_Documented_Precedence_And_Omits_Missing_Project()
+    {
+        SecretResolutionRequest request = new(
+            SecretType.OpenAiApiKey,
+            InstanceId,
+            RepositoryId,
+            projectId: null,
+            CredentialInheritanceMode.InheritDefault);
+
+        IReadOnlyList<SecretResolutionCandidate> candidates = SecretResolutionPolicy.GetInheritanceCandidates(request);
+
+        Assert.Collection(
+            candidates,
+            candidate =>
+            {
+                Assert.Equal(SecretScopeType.SymphonyInstance, candidate.ScopeType);
+                Assert.Equal(InstanceId.ToString(), candidate.ScopeId);
+            },
+            candidate =>
+            {
+                Assert.Equal(SecretScopeType.Repository, candidate.ScopeType);
+                Assert.Equal(RepositoryId.ToString(), candidate.ScopeId);
+            },
+            candidate =>
+            {
+                Assert.Equal(SecretScopeType.Global, candidate.ScopeType);
+                Assert.Null(candidate.ScopeId);
+            });
+    }
+
+    [Fact]
+    public void SecretResolutionRequest_Requires_Specific_Secret_Id_Only_For_Specific_Mode()
+    {
+        var missingSecretError = Assert.Throws<ArgumentException>(() => new SecretResolutionRequest(
+            SecretType.GitHubToken,
+            InstanceId,
+            RepositoryId,
+            ProjectId,
+            CredentialInheritanceMode.SpecificSecret));
+        var inheritedSecretError = Assert.Throws<ArgumentException>(() => new SecretResolutionRequest(
+            SecretType.GitHubToken,
+            InstanceId,
+            RepositoryId,
+            ProjectId,
+            CredentialInheritanceMode.InheritDefault,
+            SecretId.New()));
+
+        Assert.Equal("secretId", missingSecretError.ParamName);
+        Assert.Equal("secretId", inheritedSecretError.ParamName);
+    }
+
+    private static SecretResolutionRequest InheritedRequest(SecretType secretType) =>
+        new(
+            secretType,
+            InstanceId,
+            RepositoryId,
+            ProjectId,
+            CredentialInheritanceMode.InheritDefault);
+
+    private static SecretDescriptor Descriptor(
+        SecretId id,
+        SecretScopeType scopeType,
+        string? scopeId,
+        SecretType secretType = SecretType.GitHubToken)
+    {
+        return new SecretDescriptor(
+            id,
+            $"{scopeType} {secretType}",
+            secretType,
+            scopeType,
+            scopeId,
+            CreatedAtUtc);
+    }
+}


### PR DESCRIPTION
## Summary
- Add a core `SecretResolutionPolicy` and `SecretResolutionRequest` for credential resolution.
- Resolve inherited descriptors by secret type using instance, repository, project, then global precedence.
- Preserve `SpecificSecret` and `None` credential modes, extend the secret store contract, and document the behavior.
- Add focused unit tests for precedence, fallback, type isolation, specific selection, no-credential mode, and candidate ordering.

Closes #41

## Validation
- `dotnet restore Conductor.slnx`: passed
- `dotnet build Conductor.slnx --no-restore --warnaserror`: passed with 0 warnings
- `dotnet test Conductor.slnx --no-build`: passed
- `dotnet format Conductor.slnx --no-restore --verify-no-changes`: passed
- `./scripts/validate-docs.ps1`: passed