### PR TITLE
[codex] Implement encrypted secret store

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup Label="Application">
+    <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="10.0.7" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.5" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.5" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.5" />

--- a/docs/technical.md
+++ b/docs/technical.md
@@ -329,6 +329,7 @@ Initial migration should create:
 - `Alerts`
 - `Reports`
 - `SecretDescriptors`
+- `EncryptedSecretValues`
 - `AuditEvents`
 - `BackgroundOperations`
 
@@ -590,7 +591,7 @@ public interface ISecretStore
 }
 ```
 
-Secret values must only be returned to runner/provisioning code paths that need to inject them. UI and ordinary API responses must receive descriptors only.
+Secret values must be protected with ASP.NET Core Data Protection before persistence. `SecretDescriptor` rows contain only metadata; encrypted payloads are stored separately and must only be returned to runner/provisioning code paths that need to inject them. UI and ordinary API responses must receive descriptors only.
 
 ### 9.4 Release Resolver
 
@@ -815,7 +816,7 @@ Resolution precedence:
 Secret storage:
 
 - Store encrypted values using ASP.NET Core Data Protection for MVP.
-- Store secret descriptors separately from encrypted payloads.
+- Store secret descriptors separately from encrypted payloads in `SecretDescriptors` and `EncryptedSecretValues`.
 - Never return secret values through ordinary APIs.
 - Never persist resolved secret values in operation logs.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -9,7 +9,7 @@ The solution includes the Sprint 0 test skeletons from `docs/technical.md`:
 | Project | Purpose |
 | --- | --- |
 | `tests/Conductor.Core.Tests` | Unit tests for domain rules, application services, workflow generation, release selection, secret behavior, and alert logic. |
-| `tests/Conductor.Persistence.Tests` | SQLite persistence tests for migrations, repositories, query projections, retention, and audit writes. |
+| `tests/Conductor.Persistence.Tests` | SQLite persistence tests for migrations, repositories, query projections, retention, secret value storage, and audit writes. |
 | `tests/Conductor.Api.Tests` | Minimal API tests using `WebApplicationFactory` for endpoint behavior, authorization, and validation responses. |
 | `tests/Conductor.Blazor.Tests` | bUnit component tests for dashboard UI, shared loading/empty/error/success states, status badges, forms, and secret-safe rendering. |
 | `tests/Conductor.Integration.Tests` | Fixture-backed integration tests for clients, runners, and cross-project workflows that do not require external credentials by default. |

--- a/src/Conductor.Core/Abstractions/Secrets/ISecretStore.cs
+++ b/src/Conductor.Core/Abstractions/Secrets/ISecretStore.cs
@@ -29,14 +29,24 @@ public sealed record CreateSecretRequest(
     SecretType SecretType,
     SecretScopeType ScopeType,
     string? ScopeId,
-    string Value);
+    string Value)
+{
+    public override string ToString() =>
+        $"{nameof(CreateSecretRequest)} {{ {nameof(Name)} = {Name}, {nameof(SecretType)} = {SecretType}, {nameof(ScopeType)} = {ScopeType}, {nameof(ScopeId)} = {ScopeId}, {nameof(Value)} = ******** }}";
+}
 
-public sealed record RotateSecretRequest(string Value);
+public sealed record RotateSecretRequest(string Value)
+{
+    public override string ToString() => $"{nameof(RotateSecretRequest)} {{ {nameof(Value)} = ******** }}";
+}
 
 public sealed record SecretReference(
     SecretId SecretId,
     CredentialInheritanceMode InheritanceMode);
 
-public sealed record ResolvedSecret(SecretId SecretId, string Value);
+public sealed record ResolvedSecret(SecretId SecretId, string Value)
+{
+    public override string ToString() => $"{nameof(ResolvedSecret)} {{ {nameof(SecretId)} = {SecretId}, {nameof(Value)} = ******** }}";
+}
 
 public sealed record SecretQuery(SecretType? SecretType = null, SecretScopeType? ScopeType = null);

--- a/src/Conductor.Core/Domain/Secrets/EncryptedSecretValue.cs
+++ b/src/Conductor.Core/Domain/Secrets/EncryptedSecretValue.cs
@@ -1,0 +1,33 @@
+using Conductor.Core.Common;
+using Conductor.Core.Domain.Ids;
+
+namespace Conductor.Core.Domain.Secrets;
+
+public sealed class EncryptedSecretValue
+{
+    public EncryptedSecretValue(
+        SecretId secretId,
+        string protectedValue,
+        DateTimeOffset createdAtUtc,
+        DateTimeOffset? rotatedAtUtc = null)
+    {
+        SecretId = secretId;
+        ProtectedValue = Guard.NotWhiteSpace(protectedValue, nameof(protectedValue));
+        CreatedAtUtc = createdAtUtc;
+        RotatedAtUtc = rotatedAtUtc;
+    }
+
+    public SecretId SecretId { get; }
+
+    public string ProtectedValue { get; private set; }
+
+    public DateTimeOffset CreatedAtUtc { get; }
+
+    public DateTimeOffset? RotatedAtUtc { get; private set; }
+
+    public void Rotate(string protectedValue, DateTimeOffset rotatedAtUtc)
+    {
+        ProtectedValue = Guard.NotWhiteSpace(protectedValue, nameof(protectedValue));
+        RotatedAtUtc = rotatedAtUtc;
+    }
+}

--- a/src/Conductor.Host/Conductor.Host.csproj
+++ b/src/Conductor.Host/Conductor.Host.csproj
@@ -3,6 +3,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Conductor.Core\Conductor.Core.csproj" />
     <ProjectReference Include="..\Conductor.Infrastructure.Persistence.Sqlite\Conductor.Infrastructure.Persistence.Sqlite.csproj" />
+    <ProjectReference Include="..\Conductor.Infrastructure.Secrets\Conductor.Infrastructure.Secrets.csproj" />
     <ProjectReference Include="..\Conductor.Infrastructure.Symphony\Conductor.Infrastructure.Symphony.csproj" />
   </ItemGroup>
 

--- a/src/Conductor.Host/Program.cs
+++ b/src/Conductor.Host/Program.cs
@@ -4,6 +4,7 @@ using Conductor.Host.Dashboard;
 using Conductor.Host.Endpoints;
 using Conductor.Host.Workers;
 using Conductor.Infrastructure.Persistence.Sqlite;
+using Conductor.Infrastructure.Secrets;
 using Conductor.Infrastructure.Symphony;
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
@@ -17,6 +18,7 @@ builder.Services.Configure<DashboardProjectionOptions>(
 builder.Services.AddSingleton<IDashboardProjectionStore, JsonFileDashboardProjectionStore>();
 builder.Services.AddHealthChecks();
 builder.Services.AddConductorPersistence(builder.Configuration);
+builder.Services.AddConductorSecrets();
 builder.Services.AddConductorSymphony();
 builder.Services.AddConductorWorkers();
 

--- a/src/Conductor.Infrastructure.Persistence.Sqlite/ConductorDbContext.cs
+++ b/src/Conductor.Infrastructure.Persistence.Sqlite/ConductorDbContext.cs
@@ -48,6 +48,8 @@ public sealed class ConductorDbContext(DbContextOptions<ConductorDbContext> opti
 
     public DbSet<SecretDescriptor> SecretDescriptors => Set<SecretDescriptor>();
 
+    public DbSet<EncryptedSecretValue> EncryptedSecretValues => Set<EncryptedSecretValue>();
+
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
         modelBuilder.HasAnnotation("Relational:MaxIdentifierLength", 64);

--- a/src/Conductor.Infrastructure.Persistence.Sqlite/Configurations/EncryptedSecretValueConfiguration.cs
+++ b/src/Conductor.Infrastructure.Persistence.Sqlite/Configurations/EncryptedSecretValueConfiguration.cs
@@ -1,0 +1,32 @@
+using Conductor.Core.Domain.Secrets;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Conductor.Infrastructure.Persistence.Sqlite.Configurations;
+
+internal sealed class EncryptedSecretValueConfiguration : IEntityTypeConfiguration<EncryptedSecretValue>
+{
+    public void Configure(EntityTypeBuilder<EncryptedSecretValue> builder)
+    {
+        builder.ToTable("EncryptedSecretValues");
+
+        builder.HasKey(secret => secret.SecretId);
+
+        builder.Property(secret => secret.SecretId)
+            .HasConversion(StronglyTypedIdValueConverters.SecretId)
+            .ValueGeneratedNever();
+
+        builder.Property(secret => secret.ProtectedValue)
+            .IsRequired();
+
+        builder.Property(secret => secret.CreatedAtUtc)
+            .IsRequired();
+
+        builder.Property(secret => secret.RotatedAtUtc);
+
+        builder.HasOne<SecretDescriptor>()
+            .WithOne()
+            .HasForeignKey<EncryptedSecretValue>(secret => secret.SecretId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/src/Conductor.Infrastructure.Persistence.Sqlite/Migrations/20260429033219_AddEncryptedSecretValues.Designer.cs
+++ b/src/Conductor.Infrastructure.Persistence.Sqlite/Migrations/20260429033219_AddEncryptedSecretValues.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Conductor.Infrastructure.Persistence.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Conductor.Infrastructure.Persistence.Sqlite.Migrations
 {
     [DbContext(typeof(ConductorDbContext))]
-    partial class ConductorDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260429033219_AddEncryptedSecretValues")]
+    partial class AddEncryptedSecretValues
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Conductor.Infrastructure.Persistence.Sqlite/Migrations/20260429033219_AddEncryptedSecretValues.cs
+++ b/src/Conductor.Infrastructure.Persistence.Sqlite/Migrations/20260429033219_AddEncryptedSecretValues.cs
@@ -1,0 +1,42 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Conductor.Infrastructure.Persistence.Sqlite.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddEncryptedSecretValues : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "EncryptedSecretValues",
+                columns: table => new
+                {
+                    SecretId = table.Column<Guid>(type: "TEXT", nullable: false),
+                    ProtectedValue = table.Column<string>(type: "TEXT", nullable: false),
+                    CreatedAtUtc = table.Column<DateTimeOffset>(type: "TEXT", nullable: false),
+                    RotatedAtUtc = table.Column<DateTimeOffset>(type: "TEXT", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_EncryptedSecretValues", x => x.SecretId);
+                    table.ForeignKey(
+                        name: "FK_EncryptedSecretValues_SecretDescriptors_SecretId",
+                        column: x => x.SecretId,
+                        principalTable: "SecretDescriptors",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "EncryptedSecretValues");
+        }
+    }
+}

--- a/src/Conductor.Infrastructure.Secrets/Conductor.Infrastructure.Secrets.csproj
+++ b/src/Conductor.Infrastructure.Secrets/Conductor.Infrastructure.Secrets.csproj
@@ -1,7 +1,12 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection" />
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Conductor.Core\Conductor.Core.csproj" />
+    <ProjectReference Include="..\Conductor.Infrastructure.Persistence.Sqlite\Conductor.Infrastructure.Persistence.Sqlite.csproj" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/Conductor.Infrastructure.Secrets/DataProtectionSecretProtector.cs
+++ b/src/Conductor.Infrastructure.Secrets/DataProtectionSecretProtector.cs
@@ -1,0 +1,37 @@
+using Microsoft.AspNetCore.DataProtection;
+
+namespace Conductor.Infrastructure.Secrets;
+
+public sealed class DataProtectionSecretProtector
+{
+    private const string Purpose = "Conductor.Infrastructure.Secrets.SecretStore.v1";
+
+    private readonly IDataProtector protector;
+
+    public DataProtectionSecretProtector(IDataProtectionProvider dataProtectionProvider)
+    {
+        ArgumentNullException.ThrowIfNull(dataProtectionProvider);
+
+        protector = dataProtectionProvider.CreateProtector(Purpose);
+    }
+
+    public string Protect(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new ArgumentException("A secret value is required.", nameof(value));
+        }
+
+        return protector.Protect(value);
+    }
+
+    public string Unprotect(string protectedValue)
+    {
+        if (string.IsNullOrWhiteSpace(protectedValue))
+        {
+            throw new ArgumentException("A protected secret value is required.", nameof(protectedValue));
+        }
+
+        return protector.Unprotect(protectedValue);
+    }
+}

--- a/src/Conductor.Infrastructure.Secrets/DataProtectionSecretStore.cs
+++ b/src/Conductor.Infrastructure.Secrets/DataProtectionSecretStore.cs
@@ -1,0 +1,131 @@
+using Conductor.Core.Abstractions.Secrets;
+using Conductor.Core.Domain;
+using Conductor.Core.Domain.Ids;
+using Conductor.Core.Domain.Secrets;
+using Conductor.Infrastructure.Persistence.Sqlite;
+using Microsoft.EntityFrameworkCore;
+
+namespace Conductor.Infrastructure.Secrets;
+
+public sealed class DataProtectionSecretStore(
+    ConductorDbContext dbContext,
+    DataProtectionSecretProtector secretProtector,
+    TimeProvider timeProvider) : ISecretStore
+{
+    public async Task<SecretDescriptor> CreateAsync(
+        CreateSecretRequest request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        string protectedValue = secretProtector.Protect(request.Value);
+        DateTimeOffset now = timeProvider.GetUtcNow();
+        var descriptor = new SecretDescriptor(
+            SecretId.New(),
+            request.Name,
+            request.SecretType,
+            request.ScopeType,
+            request.ScopeId,
+            now);
+        var encryptedValue = new EncryptedSecretValue(descriptor.Id, protectedValue, now);
+
+        dbContext.SecretDescriptors.Add(descriptor);
+        dbContext.EncryptedSecretValues.Add(encryptedValue);
+        await dbContext.SaveChangesAsync(cancellationToken);
+
+        return descriptor;
+    }
+
+    public async Task RotateAsync(
+        SecretId secretId,
+        RotateSecretRequest request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        SecretDescriptor descriptor = await FindDescriptorAsync(secretId, cancellationToken);
+        EncryptedSecretValue encryptedValue = await FindEncryptedValueAsync(secretId, cancellationToken);
+
+        DateTimeOffset now = timeProvider.GetUtcNow();
+        encryptedValue.Rotate(secretProtector.Protect(request.Value), now);
+        descriptor.MarkRotated(now);
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task<ResolvedSecret> ResolveAsync(
+        SecretReference reference,
+        CancellationToken cancellationToken)
+    {
+        if (reference.InheritanceMode is not CredentialInheritanceMode.SpecificSecret)
+        {
+            throw new InvalidOperationException("Only specific secret references can be resolved directly.");
+        }
+
+        EncryptedSecretValue encryptedValue = await dbContext.EncryptedSecretValues
+            .AsNoTracking()
+            .SingleOrDefaultAsync(secret => secret.SecretId == reference.SecretId, cancellationToken)
+            ?? throw new KeyNotFoundException($"Secret '{reference.SecretId}' was not found.");
+
+        return new ResolvedSecret(
+            reference.SecretId,
+            secretProtector.Unprotect(encryptedValue.ProtectedValue));
+    }
+
+    public async Task<IReadOnlyList<SecretDescriptor>> ListAsync(
+        SecretQuery query,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        IQueryable<SecretDescriptor> descriptors = dbContext.SecretDescriptors.AsNoTracking();
+
+        if (query.SecretType is { } secretType)
+        {
+            descriptors = descriptors.Where(secret => secret.SecretType == secretType);
+        }
+
+        if (query.ScopeType is { } scopeType)
+        {
+            descriptors = descriptors.Where(secret => secret.ScopeType == scopeType);
+        }
+
+        return await descriptors
+            .OrderBy(secret => secret.Name)
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task DeleteAsync(SecretId secretId, CancellationToken cancellationToken)
+    {
+        SecretDescriptor? descriptor = await dbContext.SecretDescriptors.FindAsync([secretId], cancellationToken);
+
+        if (descriptor is null)
+        {
+            return;
+        }
+
+        EncryptedSecretValue? encryptedValue = await dbContext.EncryptedSecretValues.FindAsync(
+            [secretId],
+            cancellationToken);
+
+        if (encryptedValue is not null)
+        {
+            dbContext.EncryptedSecretValues.Remove(encryptedValue);
+        }
+
+        dbContext.SecretDescriptors.Remove(descriptor);
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    private async Task<SecretDescriptor> FindDescriptorAsync(
+        SecretId secretId,
+        CancellationToken cancellationToken) =>
+        await dbContext.SecretDescriptors.FindAsync([secretId], cancellationToken)
+            ?? throw new KeyNotFoundException($"Secret '{secretId}' was not found.");
+
+    private async Task<EncryptedSecretValue> FindEncryptedValueAsync(
+        SecretId secretId,
+        CancellationToken cancellationToken) =>
+        await dbContext.EncryptedSecretValues.FindAsync([secretId], cancellationToken)
+            ?? throw new KeyNotFoundException($"Encrypted value for secret '{secretId}' was not found.");
+}

--- a/src/Conductor.Infrastructure.Secrets/SecretsServiceCollectionExtensions.cs
+++ b/src/Conductor.Infrastructure.Secrets/SecretsServiceCollectionExtensions.cs
@@ -1,0 +1,18 @@
+using Conductor.Core.Abstractions.Secrets;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Conductor.Infrastructure.Secrets;
+
+public static class SecretsServiceCollectionExtensions
+{
+    public static IServiceCollection AddConductorSecrets(this IServiceCollection services)
+    {
+        services.AddDataProtection();
+        services.TryAddSingleton(TimeProvider.System);
+        services.AddSingleton<DataProtectionSecretProtector>();
+        services.AddScoped<ISecretStore, DataProtectionSecretStore>();
+
+        return services;
+    }
+}

--- a/tests/Conductor.Persistence.Tests/Conductor.Persistence.Tests.csproj
+++ b/tests/Conductor.Persistence.Tests/Conductor.Persistence.Tests.csproj
@@ -25,6 +25,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Conductor.Infrastructure.Persistence.Sqlite\Conductor.Infrastructure.Persistence.Sqlite.csproj" />
+    <ProjectReference Include="..\..\src\Conductor.Infrastructure.Secrets\Conductor.Infrastructure.Secrets.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Conductor.Persistence.Tests/SqlitePersistenceSmokeTests.cs
+++ b/tests/Conductor.Persistence.Tests/SqlitePersistenceSmokeTests.cs
@@ -41,6 +41,7 @@ public sealed class SqlitePersistenceSmokeTests
         "Alerts",
         "Reports",
         "SecretDescriptors",
+        "EncryptedSecretValues",
         "AuditEvents",
         "BackgroundOperations",
     ];

--- a/tests/Conductor.Persistence.Tests/SqliteSecretStoreTests.cs
+++ b/tests/Conductor.Persistence.Tests/SqliteSecretStoreTests.cs
@@ -1,0 +1,185 @@
+using Conductor.Core.Abstractions.Secrets;
+using Conductor.Core.Domain;
+using Conductor.Core.Domain.Secrets;
+using Conductor.Infrastructure.Persistence.Sqlite;
+using Conductor.Infrastructure.Secrets;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.DataProtection.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+
+namespace Conductor.Persistence.Tests;
+
+public sealed class SqliteSecretStoreTests
+{
+    [Fact]
+    public async Task CreateAsync_Stores_Descriptor_And_Encrypted_Value_Separately()
+    {
+        await using ConductorDbContext dbContext = await CreateDbContextAsync();
+        DataProtectionSecretStore store = CreateStore(dbContext);
+
+        SecretDescriptor descriptor = await store.CreateAsync(
+            new CreateSecretRequest(
+                "Repository GitHub token",
+                SecretType.GitHubToken,
+                SecretScopeType.Repository,
+                "repo-123",
+                "ghp_test_secret_value"),
+            CancellationToken.None);
+
+        SecretDescriptor savedDescriptor = await dbContext.SecretDescriptors.SingleAsync();
+        EncryptedSecretValue encryptedValue = await dbContext.EncryptedSecretValues.SingleAsync();
+
+        Assert.Equal(descriptor.Id, savedDescriptor.Id);
+        Assert.Equal("Repository GitHub token", savedDescriptor.Name);
+        Assert.Equal(descriptor.Id, encryptedValue.SecretId);
+        Assert.NotEqual("ghp_test_secret_value", encryptedValue.ProtectedValue);
+        Assert.DoesNotContain("ghp_test_secret_value", encryptedValue.ProtectedValue, StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            typeof(SecretDescriptor).GetProperties(),
+            property => property.Name.Contains("Value", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task ResolveAsync_Returns_Plaintext_Only_For_Specific_Secret_References()
+    {
+        await using ConductorDbContext dbContext = await CreateDbContextAsync();
+        DataProtectionSecretStore store = CreateStore(dbContext);
+        SecretDescriptor descriptor = await store.CreateAsync(
+            new CreateSecretRequest(
+                "OpenAI API key",
+                SecretType.OpenAiApiKey,
+                SecretScopeType.Global,
+                ScopeId: null,
+                "sk-test-secret"),
+            CancellationToken.None);
+
+        ResolvedSecret resolved = await store.ResolveAsync(
+            new SecretReference(descriptor.Id, CredentialInheritanceMode.SpecificSecret),
+            CancellationToken.None);
+
+        Assert.Equal(descriptor.Id, resolved.SecretId);
+        Assert.Equal("sk-test-secret", resolved.Value);
+        Assert.DoesNotContain("sk-test-secret", resolved.ToString(), StringComparison.Ordinal);
+        await Assert.ThrowsAsync<InvalidOperationException>(() => store.ResolveAsync(
+            new SecretReference(descriptor.Id, CredentialInheritanceMode.InheritDefault),
+            CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task RotateAsync_Updates_Metadata_And_Replaces_Encrypted_Value()
+    {
+        await using ConductorDbContext dbContext = await CreateDbContextAsync();
+        DataProtectionSecretStore store = CreateStore(dbContext);
+        SecretDescriptor descriptor = await store.CreateAsync(
+            new CreateSecretRequest(
+                "Repository GitHub token",
+                SecretType.GitHubToken,
+                SecretScopeType.Repository,
+                "repo-123",
+                "old-secret"),
+            CancellationToken.None);
+        string originalProtectedValue = await dbContext.EncryptedSecretValues
+            .Where(secret => secret.SecretId == descriptor.Id)
+            .Select(secret => secret.ProtectedValue)
+            .SingleAsync();
+
+        await store.RotateAsync(descriptor.Id, new RotateSecretRequest("new-secret"), CancellationToken.None);
+
+        SecretDescriptor rotatedDescriptor = await dbContext.SecretDescriptors.SingleAsync();
+        EncryptedSecretValue rotatedValue = await dbContext.EncryptedSecretValues.SingleAsync();
+        ResolvedSecret resolved = await store.ResolveAsync(
+            new SecretReference(descriptor.Id, CredentialInheritanceMode.SpecificSecret),
+            CancellationToken.None);
+
+        Assert.NotNull(rotatedDescriptor.RotatedAtUtc);
+        Assert.NotNull(rotatedValue.RotatedAtUtc);
+        Assert.NotEqual(originalProtectedValue, rotatedValue.ProtectedValue);
+        Assert.Equal("new-secret", resolved.Value);
+    }
+
+    [Fact]
+    public async Task ListAsync_Returns_Descriptors_Without_Resolving_Values()
+    {
+        await using ConductorDbContext dbContext = await CreateDbContextAsync();
+        DataProtectionSecretStore store = CreateStore(dbContext);
+        await store.CreateAsync(
+            new CreateSecretRequest(
+                "Repository GitHub token",
+                SecretType.GitHubToken,
+                SecretScopeType.Repository,
+                "repo-123",
+                "github-secret"),
+            CancellationToken.None);
+        await store.CreateAsync(
+            new CreateSecretRequest(
+                "Global OpenAI API key",
+                SecretType.OpenAiApiKey,
+                SecretScopeType.Global,
+                ScopeId: null,
+                "openai-secret"),
+            CancellationToken.None);
+
+        IReadOnlyList<SecretDescriptor> descriptors = await store.ListAsync(
+            new SecretQuery(SecretType.GitHubToken),
+            CancellationToken.None);
+
+        Assert.Single(descriptors);
+        Assert.Equal(SecretType.GitHubToken, descriptors[0].SecretType);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_Removes_Descriptor_And_Encrypted_Value()
+    {
+        await using ConductorDbContext dbContext = await CreateDbContextAsync();
+        DataProtectionSecretStore store = CreateStore(dbContext);
+        SecretDescriptor descriptor = await store.CreateAsync(
+            new CreateSecretRequest(
+                "Repository GitHub token",
+                SecretType.GitHubToken,
+                SecretScopeType.Repository,
+                "repo-123",
+                "secret"),
+            CancellationToken.None);
+
+        await store.DeleteAsync(descriptor.Id, CancellationToken.None);
+
+        Assert.Empty(await dbContext.SecretDescriptors.ToListAsync());
+        Assert.Empty(await dbContext.EncryptedSecretValues.ToListAsync());
+    }
+
+    [Fact]
+    public void Secret_Request_ToString_Masks_Values()
+    {
+        var createRequest = new CreateSecretRequest(
+            "Repository GitHub token",
+            SecretType.GitHubToken,
+            SecretScopeType.Repository,
+            "repo-123",
+            "secret-value");
+        var rotateRequest = new RotateSecretRequest("rotated-secret-value");
+
+        Assert.DoesNotContain("secret-value", createRequest.ToString(), StringComparison.Ordinal);
+        Assert.DoesNotContain("rotated-secret-value", rotateRequest.ToString(), StringComparison.Ordinal);
+    }
+
+    private static async Task<ConductorDbContext> CreateDbContextAsync()
+    {
+        DbContextOptions<ConductorDbContext> options = new DbContextOptionsBuilder<ConductorDbContext>()
+            .UseSqlite("Data Source=:memory:")
+            .Options;
+        var dbContext = new ConductorDbContext(options);
+
+        await dbContext.Database.OpenConnectionAsync();
+        await dbContext.Database.EnsureCreatedAsync();
+
+        return dbContext;
+    }
+
+    private static DataProtectionSecretStore CreateStore(ConductorDbContext dbContext)
+    {
+        IDataProtectionProvider dataProtectionProvider = new EphemeralDataProtectionProvider();
+        var protector = new DataProtectionSecretProtector(dataProtectionProvider);
+
+        return new DataProtectionSecretStore(dbContext, protector, TimeProvider.System);
+    }
+}


### PR DESCRIPTION
## Summary
- add a Data Protection-backed ISecretStore implementation for create, list, resolve, rotate, and delete flows
- persist protected values in a separate EncryptedSecretValues table with EF mapping and migration
- register secret services in the host and document the separated descriptor/value storage model
- mask secret-bearing request and resolved-secret ToString output

Fixes #37

## Validation
- dotnet restore Conductor.slnx
- dotnet build Conductor.slnx --no-restore --warnaserror
- dotnet test Conductor.slnx --no-build
- dotnet format Conductor.slnx --verify-no-changes --no-restore
- ./scripts/validate-docs.ps1