### PR TITLE
Add repository import model and UI shell

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -46,3 +46,35 @@ Responses:
 - `201 Created` with the registered instance summary.
 - `400 Bad Request` with validation errors when the URL, health probe, or runtime probe fails.
 - `409 Conflict` when the normalized base URL is already registered.
+
+## Repository Import
+
+`POST /api/repos/import` imports a GitHub repository record and can create an optional Symphony instance shell.
+
+Request:
+
+```json
+{
+  "repositoryFullName": "ReleasedGroup/TheConductor",
+  "defaultBranch": "main",
+  "visibility": "Private",
+  "createSymphonyInstance": true,
+  "instanceBaseUrl": "http://localhost:8080/",
+  "port": 8080,
+  "releaseTag": "latest",
+  "gitHubCredentialInheritanceMode": "InheritDefault",
+  "openAiCredentialInheritanceMode": "InheritDefault"
+}
+```
+
+Behavior:
+
+- Validates `owner/name` repository identity and derives GitHub clone/web URLs when explicit URLs are not provided.
+- Creates or updates the repository registry record.
+- Creates a `NotProvisioned` Symphony instance shell when orchestration is requested.
+- Records an audit event for the import.
+
+Responses:
+
+- `201 Created` with repository and optional instance identifiers.
+- `400 Bad Request` with validation errors when repository identity, instance URL, port, or specific secret references are invalid.

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -19,3 +19,9 @@ The Secrets page lists saved credential descriptors for orchestration. GitHub PA
 Use the Instances page to register an existing Symphony runtime. Provide the instance base URL and an optional display name. Conductor validates the Symphony health endpoint, reads runtime metadata, captures the first state snapshot when available, and then lists the runtime in the instance registry.
 
 If the health or runtime endpoint cannot be reached, Conductor shows the validation result and does not create an active instance record. A URL that is already registered returns a duplicate registration message.
+
+## Repository Import
+
+Use the Repositories page to import a GitHub repository by `owner/name`. The initial flow stores repository metadata, optional project assignment, visibility, default branch, and archived state.
+
+The page can also create a first Symphony instance shell in `NotProvisioned` state. The shell captures execution mode, instance URL, port, release selector, and credential inheritance choices so later provisioning work can start from a validated record.

--- a/src/Conductor.Core/Application/Queries/ProjectListQueryService.cs
+++ b/src/Conductor.Core/Application/Queries/ProjectListQueryService.cs
@@ -1,0 +1,21 @@
+using Conductor.Core.Domain;
+using Conductor.Core.Domain.Ids;
+
+namespace Conductor.Core.Application.Queries;
+
+public interface IProjectListQueryService
+{
+    Task<IReadOnlyList<ProjectListItemProjection>> ListProjectsAsync(
+        ProjectListQuery query,
+        CancellationToken cancellationToken = default);
+}
+
+public sealed record ProjectListQuery(
+    bool IncludeArchived = false,
+    string? Search = null);
+
+public sealed record ProjectListItemProjection(
+    ProjectId Id,
+    string Name,
+    string OwnerName,
+    ProjectStatus Status);

--- a/src/Conductor.Core/Application/Repositories/IRepositoryImportService.cs
+++ b/src/Conductor.Core/Application/Repositories/IRepositoryImportService.cs
@@ -1,0 +1,381 @@
+using Conductor.Core.Common;
+using Conductor.Core.Domain;
+using Conductor.Core.Domain.Ids;
+using Conductor.Core.Domain.Releases;
+using Conductor.Core.Domain.Repositories;
+
+namespace Conductor.Core.Application.Repositories;
+
+public interface IRepositoryImportService
+{
+    Task<RepositoryImportResult> ImportAsync(
+        RepositoryImportRequest request,
+        CancellationToken cancellationToken = default);
+}
+
+public sealed record RepositoryImportRequest(
+    string RepositoryFullName,
+    string? DefaultBranch = null,
+    string? CloneUrl = null,
+    string? WebUrl = null,
+    RepositoryVisibility Visibility = RepositoryVisibility.Public,
+    bool IsArchived = false,
+    ProjectId? ProjectId = null,
+    bool CreateSymphonyInstance = false,
+    string? InstanceDisplayName = null,
+    ExecutionMode ExecutionMode = ExecutionMode.LocalProcess,
+    string? InstanceBaseUrl = null,
+    int? Port = null,
+    string? ReleaseTag = null,
+    WorkflowProfileId? WorkflowProfileId = null,
+    CredentialInheritanceMode GitHubCredentialInheritanceMode = CredentialInheritanceMode.InheritDefault,
+    SecretId? GitHubCredentialSecretId = null,
+    CredentialInheritanceMode OpenAiCredentialInheritanceMode = CredentialInheritanceMode.InheritDefault,
+    SecretId? OpenAiCredentialSecretId = null,
+    string? WorkflowPath = null,
+    string? DataPath = null,
+    string? RequestedByUserId = null);
+
+public sealed record RepositoryImportResult(
+    string RepositoryId,
+    string RepositoryFullName,
+    bool CreatedRepository,
+    string? SymphonyInstanceId,
+    bool CreatedSymphonyInstance,
+    string? SymphonyInstanceDisplayName,
+    DateTimeOffset ImportedAtUtc);
+
+public sealed class RepositoryImportValidationException : Exception
+{
+    public RepositoryImportValidationException(IReadOnlyDictionary<string, string[]> errors)
+        : base("Repository import failed validation.")
+    {
+        Errors = errors;
+    }
+
+    public IReadOnlyDictionary<string, string[]> Errors { get; }
+}
+
+public sealed record RepositoryImportCredentialSelection
+{
+    public RepositoryImportCredentialSelection(
+        CredentialInheritanceMode inheritanceMode,
+        SecretId? secretId = null)
+    {
+        if (!Enum.IsDefined(inheritanceMode))
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(inheritanceMode),
+                inheritanceMode,
+                "Credential inheritance mode is not supported.");
+        }
+
+        if (inheritanceMode == CredentialInheritanceMode.SpecificSecret)
+        {
+            if (secretId is null)
+            {
+                throw new ArgumentException("A specific credential selection requires a secret id.", nameof(secretId));
+            }
+
+            SecretId = new SecretId(Guard.NotEmpty(secretId.Value.Value, nameof(secretId)));
+        }
+        else if (secretId is not null)
+        {
+            throw new ArgumentException("Secret ids can only be set for specific credential selections.", nameof(secretId));
+        }
+
+        InheritanceMode = inheritanceMode;
+    }
+
+    public CredentialInheritanceMode InheritanceMode { get; }
+
+    public SecretId? SecretId { get; }
+}
+
+public sealed record RepositoryImportInstancePlan(
+    string DisplayName,
+    ExecutionMode ExecutionMode,
+    Uri BaseUrl,
+    int? Port,
+    ReleaseSelector ReleaseSelector,
+    WorkflowProfileId? WorkflowProfileId,
+    RepositoryImportCredentialSelection GitHubCredential,
+    RepositoryImportCredentialSelection OpenAiCredential,
+    string? WorkflowPath,
+    string? DataPath);
+
+public sealed record RepositoryImportPlan(
+    GitHubRepositoryFullName FullName,
+    string DefaultBranch,
+    Uri CloneUrl,
+    Uri WebUrl,
+    RepositoryVisibility Visibility,
+    bool IsArchived,
+    ProjectId? ProjectId,
+    RepositoryImportInstancePlan? InstancePlan)
+{
+    private const string LatestReleaseAlias = "latest";
+
+    public RepositoryOrchestrationStatus OrchestrationStatus =>
+        IsArchived ? RepositoryOrchestrationStatus.Ineligible : RepositoryOrchestrationStatus.Eligible;
+
+    public string? OrchestrationStatusReason =>
+        IsArchived ? "Archived repositories cannot be orchestrated." : null;
+
+    public static RepositoryImportPlan Create(RepositoryImportRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        Dictionary<string, List<string>> errors = new(StringComparer.Ordinal);
+
+        GitHubRepositoryFullName? fullName = null;
+        if (!GitHubRepositoryFullName.TryParse(request.RepositoryFullName, out fullName))
+        {
+            AddError(errors, nameof(request.RepositoryFullName), "Enter a GitHub repository full name in owner/name format.");
+        }
+
+        string defaultBranch = string.IsNullOrWhiteSpace(request.DefaultBranch)
+            ? "main"
+            : request.DefaultBranch.Trim();
+
+        ValidateEnum(request.Visibility, nameof(request.Visibility), errors);
+        ValidateNullableId(request.ProjectId, nameof(request.ProjectId), errors);
+
+        Uri? cloneUrl = null;
+        Uri? webUrl = null;
+        if (fullName is not null)
+        {
+            cloneUrl = ParseOptionalAbsoluteUri(
+                request.CloneUrl,
+                nameof(request.CloneUrl),
+                errors,
+                new Uri($"https://github.com/{fullName.Value}.git", UriKind.Absolute));
+            webUrl = ParseOptionalAbsoluteUri(
+                request.WebUrl,
+                nameof(request.WebUrl),
+                errors,
+                new Uri($"https://github.com/{fullName.Value}", UriKind.Absolute));
+        }
+
+        RepositoryImportInstancePlan? instancePlan = null;
+        if (request.CreateSymphonyInstance)
+        {
+            instancePlan = CreateInstancePlan(request, fullName, errors);
+
+            if (request.IsArchived)
+            {
+                AddError(errors, nameof(request.CreateSymphonyInstance), "Archived repositories cannot create a Symphony instance shell.");
+            }
+        }
+
+        if (errors.Count > 0)
+        {
+            throw new RepositoryImportValidationException(ToErrorDictionary(errors));
+        }
+
+        return new RepositoryImportPlan(
+            fullName!,
+            defaultBranch,
+            cloneUrl!,
+            webUrl!,
+            request.Visibility,
+            request.IsArchived,
+            request.ProjectId,
+            instancePlan);
+    }
+
+    private static RepositoryImportInstancePlan? CreateInstancePlan(
+        RepositoryImportRequest request,
+        GitHubRepositoryFullName? fullName,
+        Dictionary<string, List<string>> errors)
+    {
+        ValidateEnum(request.ExecutionMode, nameof(request.ExecutionMode), errors);
+        ValidateNullableId(request.WorkflowProfileId, nameof(request.WorkflowProfileId), errors);
+        ValidatePort(request.Port, nameof(request.Port), errors);
+
+        Uri? baseUrl = ParseRequiredHttpUri(
+            request.InstanceBaseUrl,
+            nameof(request.InstanceBaseUrl),
+            errors);
+        ReleaseSelector releaseSelector = CreateReleaseSelector(request.ReleaseTag);
+        RepositoryImportCredentialSelection? gitHubCredential = CreateCredentialSelection(
+            request.GitHubCredentialInheritanceMode,
+            request.GitHubCredentialSecretId,
+            nameof(request.GitHubCredentialSecretId),
+            errors);
+        RepositoryImportCredentialSelection? openAiCredential = CreateCredentialSelection(
+            request.OpenAiCredentialInheritanceMode,
+            request.OpenAiCredentialSecretId,
+            nameof(request.OpenAiCredentialSecretId),
+            errors);
+
+        if (baseUrl is null || gitHubCredential is null || openAiCredential is null)
+        {
+            return null;
+        }
+
+        int? port = request.Port ?? (baseUrl.IsDefaultPort ? null : baseUrl.Port);
+        string displayName = string.IsNullOrWhiteSpace(request.InstanceDisplayName)
+            ? fullName?.Value ?? "Imported repository"
+            : request.InstanceDisplayName.Trim();
+
+        return new RepositoryImportInstancePlan(
+            displayName,
+            request.ExecutionMode,
+            baseUrl,
+            port,
+            releaseSelector,
+            request.WorkflowProfileId,
+            gitHubCredential,
+            openAiCredential,
+            Guard.OptionalTrimmed(request.WorkflowPath),
+            Guard.OptionalTrimmed(request.DataPath));
+    }
+
+    private static RepositoryImportCredentialSelection? CreateCredentialSelection(
+        CredentialInheritanceMode inheritanceMode,
+        SecretId? secretId,
+        string fieldName,
+        Dictionary<string, List<string>> errors)
+    {
+        ValidateEnum(inheritanceMode, fieldName, errors);
+        ValidateNullableId(secretId, fieldName, errors);
+
+        try
+        {
+            return new RepositoryImportCredentialSelection(inheritanceMode, secretId);
+        }
+        catch (ArgumentException ex)
+        {
+            AddError(errors, fieldName, ex.Message);
+            return null;
+        }
+    }
+
+    private static ReleaseSelector CreateReleaseSelector(string? releaseTag)
+    {
+        string? normalized = Guard.OptionalTrimmed(releaseTag);
+
+        return normalized is null || string.Equals(normalized, LatestReleaseAlias, StringComparison.OrdinalIgnoreCase)
+            ? ReleaseSelector.Latest
+            : ReleaseSelector.PinnedTag(normalized);
+    }
+
+    private static Uri? ParseOptionalAbsoluteUri(
+        string? value,
+        string fieldName,
+        Dictionary<string, List<string>> errors,
+        Uri fallback)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return fallback;
+        }
+
+        if (Uri.TryCreate(value.Trim(), UriKind.Absolute, out Uri? uri))
+        {
+            return uri;
+        }
+
+        AddError(errors, fieldName, "Enter an absolute URL.");
+        return null;
+    }
+
+    private static Uri? ParseRequiredHttpUri(
+        string? value,
+        string fieldName,
+        Dictionary<string, List<string>> errors)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            AddError(errors, fieldName, "A Symphony instance base URL is required when creating an instance shell.");
+            return null;
+        }
+
+        if (!Uri.TryCreate(value.Trim(), UriKind.Absolute, out Uri? uri) ||
+            uri.Scheme is not "http" and not "https")
+        {
+            AddError(errors, fieldName, "Enter an absolute HTTP or HTTPS URL.");
+            return null;
+        }
+
+        if (!string.IsNullOrWhiteSpace(uri.Query) || !string.IsNullOrWhiteSpace(uri.Fragment))
+        {
+            AddError(errors, fieldName, "The instance URL cannot include a query string or fragment.");
+            return null;
+        }
+
+        return uri;
+    }
+
+    private static void ValidateEnum<TEnum>(
+        TEnum value,
+        string fieldName,
+        Dictionary<string, List<string>> errors)
+        where TEnum : struct, Enum
+    {
+        if (!Enum.IsDefined(value))
+        {
+            AddError(errors, fieldName, $"{typeof(TEnum).Name} value '{value}' is not supported.");
+        }
+    }
+
+    private static void ValidateNullableId<TId>(
+        TId? id,
+        string fieldName,
+        Dictionary<string, List<string>> errors)
+        where TId : struct
+    {
+        if (id is null)
+        {
+            return;
+        }
+
+        Guid value = id switch
+        {
+            ProjectId projectId => projectId.Value,
+            WorkflowProfileId workflowProfileId => workflowProfileId.Value,
+            SecretId secretId => secretId.Value,
+            _ => throw new ArgumentOutOfRangeException(nameof(id), id, "Identifier type is not supported."),
+        };
+
+        if (value == Guid.Empty)
+        {
+            AddError(errors, fieldName, "A non-empty identifier is required.");
+        }
+    }
+
+    private static void ValidatePort(
+        int? port,
+        string fieldName,
+        Dictionary<string, List<string>> errors)
+    {
+        if (port is < 1 or > 65535)
+        {
+            AddError(errors, fieldName, "A TCP port must be between 1 and 65535.");
+        }
+    }
+
+    private static void AddError(
+        Dictionary<string, List<string>> errors,
+        string fieldName,
+        string message)
+    {
+        if (!errors.TryGetValue(fieldName, out List<string>? messages))
+        {
+            messages = [];
+            errors[fieldName] = messages;
+        }
+
+        messages.Add(message);
+    }
+
+    private static IReadOnlyDictionary<string, string[]> ToErrorDictionary(
+        Dictionary<string, List<string>> errors)
+    {
+        return errors.ToDictionary(
+            item => item.Key,
+            item => item.Value.ToArray(),
+            StringComparer.Ordinal);
+    }
+}

--- a/src/Conductor.Host/Components/Pages/Repositories.razor
+++ b/src/Conductor.Host/Components/Pages/Repositories.razor
@@ -1,0 +1,417 @@
+@page "/repositories"
+@rendermode InteractiveServer
+@using Conductor.Core.Application.Queries
+@using Conductor.Core.Application.Repositories
+@using Conductor.Core.Domain
+@using Conductor.Core.Domain.Ids
+@inject IRepositoryImportService RepositoryImportService
+@inject IRepositoryListQueryService RepositoryListQueryService
+@inject IProjectListQueryService ProjectListQueryService
+
+<PageTitle>Repositories - Conductor</PageTitle>
+
+<section class="repositories-page">
+    <header class="dashboard-header">
+        <div>
+            <p class="eyebrow">Repository registry</p>
+            <h1>Repositories</h1>
+            <p class="dashboard-summary">Import GitHub repositories and prepare orchestration shells.</p>
+        </div>
+        <div class="dashboard-meta">
+            <StatusBadge Text="@($"{repositories.Count} managed")" Tone="@StatusBadgeTone.Info" />
+        </div>
+    </header>
+
+    <section class="repository-import" aria-label="Import GitHub repository">
+        <form class="repository-import-form" @onsubmit="ImportRepositoryAsync" @onsubmit:preventDefault>
+            <div class="import-form-grid">
+                <label>
+                    <span>GitHub repository</span>
+                    <input
+                        id="repository-full-name"
+                        type="text"
+                        required
+                        placeholder="owner/name"
+                        autocomplete="off"
+                        @bind="importForm.RepositoryFullName"
+                        disabled="@isSubmitting" />
+                </label>
+                <label>
+                    <span>Default branch</span>
+                    <input
+                        type="text"
+                        required
+                        maxlength="255"
+                        @bind="importForm.DefaultBranch"
+                        disabled="@isSubmitting" />
+                </label>
+                <label>
+                    <span>Project</span>
+                    <select @bind="importForm.ProjectId" disabled="@isSubmitting">
+                        <option value="">Unassigned</option>
+                        @foreach (ProjectListItemProjection project in projects)
+                        {
+                            <option value="@project.Id.ToString()">@project.Name</option>
+                        }
+                    </select>
+                </label>
+                <label>
+                    <span>Visibility</span>
+                    <select @bind="importForm.Visibility" disabled="@isSubmitting">
+                        @foreach (RepositoryVisibility visibility in Enum.GetValues<RepositoryVisibility>())
+                        {
+                            <option value="@visibility.ToString()">@visibility</option>
+                        }
+                    </select>
+                </label>
+            </div>
+
+            <div class="import-options">
+                <label class="checkbox-row">
+                    <input
+                        id="repository-archived"
+                        type="checkbox"
+                        @bind="importForm.IsArchived"
+                        disabled="@isSubmitting" />
+                    <span>Archived</span>
+                </label>
+                <label class="checkbox-row">
+                    <input
+                        id="create-instance-shell"
+                        type="checkbox"
+                        @bind="importForm.CreateSymphonyInstance"
+                        disabled="@isSubmitting || importForm.IsArchived" />
+                    <span>Create Symphony instance shell</span>
+                </label>
+            </div>
+
+            @if (importForm.CreateSymphonyInstance && !importForm.IsArchived)
+            {
+                <fieldset class="orchestration-shell">
+                    <legend>Orchestration shell</legend>
+                    <div class="import-form-grid">
+                        <label>
+                            <span>Instance name</span>
+                            <input
+                                type="text"
+                                maxlength="200"
+                                @bind="importForm.InstanceDisplayName"
+                                disabled="@isSubmitting" />
+                        </label>
+                        <label>
+                            <span>Instance URL</span>
+                            <input
+                                id="instance-base-url"
+                                type="url"
+                                required
+                                inputmode="url"
+                                @bind="importForm.InstanceBaseUrl"
+                                disabled="@isSubmitting" />
+                        </label>
+                        <label>
+                            <span>Execution mode</span>
+                            <select @bind="importForm.ExecutionMode" disabled="@isSubmitting">
+                                @foreach (ExecutionMode executionMode in Enum.GetValues<ExecutionMode>())
+                                {
+                                    <option value="@executionMode.ToString()">@executionMode</option>
+                                }
+                            </select>
+                        </label>
+                        <label>
+                            <span>Port</span>
+                            <input
+                                type="number"
+                                min="1"
+                                max="65535"
+                                @bind="importForm.Port"
+                                disabled="@isSubmitting" />
+                        </label>
+                        <label>
+                            <span>Symphony release</span>
+                            <input
+                                type="text"
+                                maxlength="128"
+                                @bind="importForm.ReleaseTag"
+                                disabled="@isSubmitting" />
+                        </label>
+                        <label>
+                            <span>GitHub credential</span>
+                            <select @bind="importForm.GitHubCredentialMode" disabled="@isSubmitting">
+                                <option value="@CredentialInheritanceMode.InheritDefault.ToString()">Inherit default</option>
+                                <option value="@CredentialInheritanceMode.None.ToString()">None</option>
+                            </select>
+                        </label>
+                        <label>
+                            <span>OpenAI/Codex credential</span>
+                            <select @bind="importForm.OpenAiCredentialMode" disabled="@isSubmitting">
+                                <option value="@CredentialInheritanceMode.InheritDefault.ToString()">Inherit default</option>
+                                <option value="@CredentialInheritanceMode.None.ToString()">None</option>
+                            </select>
+                        </label>
+                    </div>
+                </fieldset>
+            }
+
+            <div class="form-actions">
+                <button type="submit" disabled="@isSubmitting">
+                    @(isSubmitting ? "Importing" : "Import repository")
+                </button>
+            </div>
+        </form>
+
+        @if (validationMessages.Count > 0)
+        {
+            <ErrorState
+                Title="Repository was not imported."
+                Message="Review the validation result and retry."
+                Detail="@string.Join(" ", validationMessages)" />
+        }
+        else if (importError is not null)
+        {
+            <ErrorState
+                Title="Repository was not imported."
+                Message="The import request did not complete."
+                Detail="@importError" />
+        }
+        else if (importResult is not null)
+        {
+            <SuccessState
+                Title="@($"{importResult.RepositoryFullName} imported")"
+                Message="@BuildImportSummary(importResult)" />
+        }
+    </section>
+
+    <section class="repositories-panel" aria-label="Managed repositories">
+        <div class="instances-panel-header">
+            <div>
+                <p class="eyebrow">Registry</p>
+                <h2>Managed repositories</h2>
+            </div>
+        </div>
+
+        @if (loadError is not null)
+        {
+            <ErrorState
+                Title="Repositories could not be loaded."
+                Message="Check the persistence store and retry."
+                Detail="@loadError" />
+        }
+        else if (isLoading)
+        {
+            <LoadingState
+                Title="Loading repositories"
+                Message="Reading persisted repository registry data." />
+        }
+        else if (repositories.Count == 0)
+        {
+            <EmptyState
+                Title="No repositories are imported."
+                Message="Imported GitHub repositories will appear here after validation succeeds." />
+        }
+        else
+        {
+            <div class="repositories-table-wrap">
+                <table class="repositories-table">
+                    <thead>
+                        <tr>
+                            <th scope="col">Repository</th>
+                            <th scope="col">Project</th>
+                            <th scope="col">Branch</th>
+                            <th scope="col">Health</th>
+                            <th scope="col">Instances</th>
+                            <th scope="col">Last health</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (RepositoryListItemProjection repository in repositories)
+                        {
+                            <tr>
+                                <td>
+                                    <strong>@repository.FullName</strong>
+                                    <a href="@repository.WebUrl.AbsoluteUri" target="_blank" rel="noreferrer">@repository.Provider</a>
+                                </td>
+                                <td>@(repository.ProjectName ?? "Unassigned")</td>
+                                <td>@repository.DefaultBranch</td>
+                                <td>
+                                    <StatusBadge
+                                        Text="@repository.WorstHealthStatus.ToString()"
+                                        Tone="@MapHealthTone(repository.WorstHealthStatus)" />
+                                </td>
+                                <td>
+                                    <span>@repository.InstanceCount total</span>
+                                    <small>@repository.RunningInstanceCount running</small>
+                                </td>
+                                <td>@FormatTimestamp(repository.LastHealthCheckAtUtc)</td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+        }
+    </section>
+</section>
+
+@code {
+    private readonly RepositoryImportForm importForm = new();
+    private IReadOnlyList<RepositoryListItemProjection> repositories = [];
+    private IReadOnlyList<ProjectListItemProjection> projects = [];
+    private readonly List<string> validationMessages = [];
+    private RepositoryImportResult? importResult;
+    private string? importError;
+    private string? loadError;
+    private bool isLoading = true;
+    private bool isSubmitting;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadPageDataAsync();
+    }
+
+    private async Task ImportRepositoryAsync()
+    {
+        validationMessages.Clear();
+        importError = null;
+        importResult = null;
+        isSubmitting = true;
+
+        try
+        {
+            importResult = await RepositoryImportService.ImportAsync(CreateRequest());
+            importForm.Reset();
+            await LoadPageDataAsync();
+        }
+        catch (RepositoryImportValidationException ex)
+        {
+            validationMessages.AddRange(ex.Errors.SelectMany(error => error.Value));
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or IOException)
+        {
+            importError = ex.Message;
+        }
+        finally
+        {
+            isSubmitting = false;
+        }
+    }
+
+    private RepositoryImportRequest CreateRequest()
+    {
+        ProjectId? projectId = null;
+        if (ProjectId.TryParse(importForm.ProjectId, out ProjectId parsedProjectId))
+        {
+            projectId = parsedProjectId;
+        }
+
+        return new RepositoryImportRequest(
+            importForm.RepositoryFullName,
+            importForm.DefaultBranch,
+            Visibility: ParseEnum<RepositoryVisibility>(importForm.Visibility),
+            IsArchived: importForm.IsArchived,
+            ProjectId: projectId,
+            CreateSymphonyInstance: importForm.CreateSymphonyInstance,
+            InstanceDisplayName: importForm.InstanceDisplayName,
+            ExecutionMode: ParseEnum<ExecutionMode>(importForm.ExecutionMode),
+            InstanceBaseUrl: importForm.InstanceBaseUrl,
+            Port: importForm.Port,
+            ReleaseTag: importForm.ReleaseTag,
+            GitHubCredentialInheritanceMode: ParseEnum<CredentialInheritanceMode>(importForm.GitHubCredentialMode),
+            OpenAiCredentialInheritanceMode: ParseEnum<CredentialInheritanceMode>(importForm.OpenAiCredentialMode),
+            RequestedByUserId: "ui");
+    }
+
+    private async Task LoadPageDataAsync()
+    {
+        isLoading = true;
+        loadError = null;
+
+        try
+        {
+            projects = await ProjectListQueryService.ListProjectsAsync(new ProjectListQuery());
+            repositories = await RepositoryListQueryService.ListRepositoriesAsync(new RepositoryListQuery());
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or IOException)
+        {
+            loadError = ex.Message;
+        }
+        finally
+        {
+            isLoading = false;
+        }
+    }
+
+    private static TEnum ParseEnum<TEnum>(string value)
+        where TEnum : struct, Enum
+    {
+        return Enum.TryParse(value, out TEnum parsed)
+            ? parsed
+            : default;
+    }
+
+    private static StatusBadgeTone MapHealthTone(InstanceHealthStatus healthStatus) => healthStatus switch
+    {
+        InstanceHealthStatus.Healthy => StatusBadgeTone.Success,
+        InstanceHealthStatus.Warning => StatusBadgeTone.Warning,
+        InstanceHealthStatus.Critical or InstanceHealthStatus.Offline => StatusBadgeTone.Critical,
+        _ => StatusBadgeTone.Neutral,
+    };
+
+    private static string FormatTimestamp(DateTimeOffset? timestamp)
+    {
+        return timestamp is null
+            ? "Not checked"
+            : timestamp.Value.ToLocalTime().ToString("MMM d, yyyy HH:mm");
+    }
+
+    private static string BuildImportSummary(RepositoryImportResult result)
+    {
+        return result.CreatedSymphonyInstance
+            ? $"{result.SymphonyInstanceDisplayName} was created in NotProvisioned state."
+            : "Repository metadata is ready for orchestration setup.";
+    }
+
+    private sealed class RepositoryImportForm
+    {
+        public string RepositoryFullName { get; set; } = string.Empty;
+
+        public string DefaultBranch { get; set; } = "main";
+
+        public string ProjectId { get; set; } = string.Empty;
+
+        public string Visibility { get; set; } = RepositoryVisibility.Public.ToString();
+
+        public bool IsArchived { get; set; }
+
+        public bool CreateSymphonyInstance { get; set; }
+
+        public string? InstanceDisplayName { get; set; }
+
+        public string ExecutionMode { get; set; } = Conductor.Core.Domain.ExecutionMode.LocalProcess.ToString();
+
+        public string InstanceBaseUrl { get; set; } = "http://localhost:8080/";
+
+        public int? Port { get; set; } = 8080;
+
+        public string ReleaseTag { get; set; } = "latest";
+
+        public string GitHubCredentialMode { get; set; } = CredentialInheritanceMode.InheritDefault.ToString();
+
+        public string OpenAiCredentialMode { get; set; } = CredentialInheritanceMode.InheritDefault.ToString();
+
+        public void Reset()
+        {
+            RepositoryFullName = string.Empty;
+            DefaultBranch = "main";
+            ProjectId = string.Empty;
+            Visibility = RepositoryVisibility.Public.ToString();
+            IsArchived = false;
+            CreateSymphonyInstance = false;
+            InstanceDisplayName = null;
+            ExecutionMode = Conductor.Core.Domain.ExecutionMode.LocalProcess.ToString();
+            InstanceBaseUrl = "http://localhost:8080/";
+            Port = 8080;
+            ReleaseTag = "latest";
+            GitHubCredentialMode = CredentialInheritanceMode.InheritDefault.ToString();
+            OpenAiCredentialMode = CredentialInheritanceMode.InheritDefault.ToString();
+        }
+    }
+}

--- a/src/Conductor.Host/Endpoints/RepositoryEndpoints.cs
+++ b/src/Conductor.Host/Endpoints/RepositoryEndpoints.cs
@@ -1,0 +1,52 @@
+using Conductor.Core.Application.Queries;
+using Conductor.Core.Application.Repositories;
+
+namespace Conductor.Host.Endpoints;
+
+public static class RepositoryEndpoints
+{
+    public static IEndpointRouteBuilder MapConductorRepositories(this IEndpointRouteBuilder endpoints)
+    {
+        RouteGroupBuilder group = endpoints
+            .MapGroup("/api/repos")
+            .WithTags("Repositories");
+
+        group.MapGet("/", ListRepositoriesAsync)
+            .WithName("ListRepositories")
+            .Produces<IReadOnlyList<RepositoryListItemProjection>>();
+
+        group.MapPost("/import", ImportRepositoryAsync)
+            .WithName("ImportRepository")
+            .Produces<RepositoryImportResult>(StatusCodes.Status201Created)
+            .ProducesValidationProblem();
+
+        return endpoints;
+    }
+
+    private static async Task<IReadOnlyList<RepositoryListItemProjection>> ListRepositoriesAsync(
+        IRepositoryListQueryService repositoryListQueryService,
+        CancellationToken cancellationToken)
+    {
+        return await repositoryListQueryService.ListRepositoriesAsync(
+            new RepositoryListQuery(),
+            cancellationToken);
+    }
+
+    private static async Task<IResult> ImportRepositoryAsync(
+        RepositoryImportRequest request,
+        IRepositoryImportService repositoryImportService,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            RepositoryImportResult result =
+                await repositoryImportService.ImportAsync(request, cancellationToken);
+
+            return Results.Created($"/repositories/{result.RepositoryId}", result);
+        }
+        catch (RepositoryImportValidationException ex)
+        {
+            return Results.ValidationProblem(ex.Errors);
+        }
+    }
+}

--- a/src/Conductor.Host/Program.cs
+++ b/src/Conductor.Host/Program.cs
@@ -1,3 +1,4 @@
+using System.Text.Json.Serialization;
 using Conductor.Core.Application.Dashboard;
 using Conductor.Host.Components;
 using Conductor.Host.Dashboard;
@@ -13,6 +14,10 @@ builder.Services
     .AddRazorComponents()
     .AddInteractiveServerComponents();
 
+builder.Services.ConfigureHttpJsonOptions(options =>
+{
+    options.SerializerOptions.Converters.Add(new JsonStringEnumConverter());
+});
 builder.Services.Configure<DashboardProjectionOptions>(
     builder.Configuration.GetSection(DashboardProjectionOptions.SectionName));
 builder.Services.AddSingleton<IDashboardProjectionStore, JsonFileDashboardProjectionStore>();
@@ -39,6 +44,7 @@ app.UseAntiforgery();
 app.MapGet("/favicon.ico", () => Results.NoContent()).ExcludeFromDescription();
 app.MapConductorHealth();
 app.MapConductorInstances();
+app.MapConductorRepositories();
 app.MapRazorComponents<App>()
     .AddInteractiveServerRenderMode();
 

--- a/src/Conductor.Host/wwwroot/app.css
+++ b/src/Conductor.Host/wwwroot/app.css
@@ -91,7 +91,8 @@ a {
 }
 
 .dashboard,
-.instances-page {
+.instances-page,
+.repositories-page {
   display: grid;
   gap: 24px;
   max-width: 1220px;
@@ -1147,7 +1148,9 @@ h2 {
 }
 
 .instance-registration,
-.instances-panel {
+.instances-panel,
+.repository-import,
+.repositories-panel {
   display: grid;
   gap: 18px;
   padding: 24px;
@@ -1176,6 +1179,113 @@ h2 {
   font-size: 0.8rem;
   font-weight: 800;
   text-transform: uppercase;
+}
+
+.repository-import-form {
+  display: grid;
+  gap: 18px;
+}
+
+.import-form-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(240px, 1fr));
+  gap: 12px;
+}
+
+.repository-import-form label {
+  display: grid;
+  gap: 8px;
+  color: #dbe6ee;
+  font-size: 0.88rem;
+  font-weight: 700;
+}
+
+.repository-import-form input,
+.repository-import-form select {
+  width: 100%;
+  min-height: 42px;
+  padding: 9px 11px;
+  border: 1px solid #3b4652;
+  border-radius: 6px;
+  background: #111417;
+  color: #ffffff;
+  font: inherit;
+}
+
+.repository-import-form input[type="checkbox"] {
+  width: 18px;
+  height: 18px;
+  min-height: 18px;
+  padding: 0;
+}
+
+.repository-import-form input:focus,
+.repository-import-form select:focus {
+  border-color: #9ee7d7;
+  outline: 2px solid rgba(158, 231, 215, 0.18);
+  outline-offset: 1px;
+}
+
+.repository-import-form input:disabled,
+.repository-import-form select:disabled {
+  cursor: not-allowed;
+  opacity: 0.66;
+}
+
+.import-options,
+.form-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+}
+
+.checkbox-row {
+  display: inline-flex;
+  grid-template-columns: none;
+  align-items: center;
+  min-height: 34px;
+  gap: 8px;
+}
+
+.orchestration-shell {
+  display: grid;
+  gap: 14px;
+  margin: 0;
+  padding: 18px;
+  border: 1px solid #2b3138;
+  border-radius: 8px;
+  background: #191f25;
+}
+
+.orchestration-shell legend {
+  padding: 0 6px;
+  color: #aeb9c5;
+  font-size: 0.8rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.form-actions button {
+  min-height: 42px;
+  padding: 0 16px;
+  border: 1px solid #2d6f5e;
+  border-radius: 6px;
+  background: #1f7665;
+  color: #ffffff;
+  font: inherit;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.form-actions button:hover:not(:disabled),
+.form-actions button:focus-visible {
+  background: #259078;
+}
+
+.form-actions button:disabled {
+  cursor: not-allowed;
+  opacity: 0.66;
 }
 
 .registration-form {
@@ -1249,25 +1359,30 @@ h2 {
   margin-bottom: 0;
 }
 
-.instances-table-wrap {
+.instances-table-wrap,
+.repositories-table-wrap {
   overflow-x: auto;
 }
 
-.instances-table {
+.instances-table,
+.repositories-table {
   width: 100%;
   min-width: 780px;
   border-collapse: collapse;
 }
 
 .instances-table th,
-.instances-table td {
+.instances-table td,
+.repositories-table th,
+.repositories-table td {
   padding: 14px 12px;
   border-top: 1px solid #2b3138;
   text-align: left;
   vertical-align: middle;
 }
 
-.instances-table th {
+.instances-table th,
+.repositories-table th {
   color: #aeb9c5;
   font-size: 0.78rem;
   font-weight: 800;
@@ -1316,21 +1431,30 @@ h2 {
   color: #f2c14e;
 }
 
-.instances-table td {
+.instances-table td,
+.repositories-table td {
   color: #dbe6ee;
 }
 
-.instances-table td:first-child {
+.instances-table td:first-child,
+.repositories-table td:first-child,
+.repositories-table td:nth-child(5) {
   display: grid;
   gap: 5px;
 }
 
-.instances-table td:first-child a {
+.instances-table td:first-child a,
+.repositories-table td:first-child a,
+.repositories-table small {
   width: fit-content;
   max-width: 100%;
   color: #9cc2ff;
   font-size: 0.84rem;
   overflow-wrap: anywhere;
+}
+
+.repositories-table small {
+  color: #aeb9c5;
 }
 
 .ui-state {
@@ -1488,6 +1612,7 @@ h2 {
   .activity-panel,
   .registration-form,
   .form-fields,
+  .import-form-grid,
   .live-activity-header,
   .startup-panel dl {
     grid-template-columns: 1fr;

--- a/src/Conductor.Infrastructure.Persistence.Sqlite/Queries/SqliteProjectionQueryService.cs
+++ b/src/Conductor.Infrastructure.Persistence.Sqlite/Queries/SqliteProjectionQueryService.cs
@@ -14,6 +14,7 @@ namespace Conductor.Infrastructure.Persistence.Sqlite.Queries;
 public sealed class SqliteProjectionQueryService :
     IDashboardQueryService,
     IRepositoryListQueryService,
+    IProjectListQueryService,
     IInstanceSummaryQueryService
 {
     private readonly ConductorDbContext dbContext;
@@ -137,6 +138,36 @@ public sealed class SqliteProjectionQueryService :
             .ThenBy(repository => repository.Owner)
             .ThenBy(repository => repository.Name)
             .ToArray();
+    }
+
+    public async Task<IReadOnlyList<ProjectListItemProjection>> ListProjectsAsync(
+        ProjectListQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        IQueryable<Project> projects = dbContext.Projects.AsNoTracking();
+
+        if (!query.IncludeArchived)
+        {
+            projects = projects.Where(project => project.Status != ProjectStatus.Archived);
+        }
+
+        if (!string.IsNullOrWhiteSpace(query.Search))
+        {
+            string search = query.Search.Trim();
+            projects = projects.Where(project =>
+                project.Name.Contains(search) ||
+                project.OwnerName.Contains(search));
+        }
+
+        return await projects
+            .OrderBy(project => project.Name)
+            .ThenBy(project => project.OwnerName)
+            .Select(project => new ProjectListItemProjection(
+                project.Id,
+                project.Name,
+                project.OwnerName,
+                project.Status))
+            .ToArrayAsync(cancellationToken);
     }
 
     public async Task<IReadOnlyList<InstanceSummaryProjection>> ListInstanceSummariesAsync(

--- a/src/Conductor.Infrastructure.Persistence.Sqlite/Repositories/SqliteRepositoryImportService.cs
+++ b/src/Conductor.Infrastructure.Persistence.Sqlite/Repositories/SqliteRepositoryImportService.cs
@@ -1,0 +1,270 @@
+using System.Text.Json;
+using Conductor.Core.Application.Repositories;
+using Conductor.Core.Domain;
+using Conductor.Core.Domain.Auditing;
+using Conductor.Core.Domain.Ids;
+using Conductor.Core.Domain.Projects;
+using Conductor.Core.Domain.Repositories;
+using Conductor.Core.Domain.Secrets;
+using Conductor.Core.Domain.Symphony;
+using Conductor.Core.Domain.Workflows;
+using Microsoft.EntityFrameworkCore;
+
+namespace Conductor.Infrastructure.Persistence.Sqlite.Repositories;
+
+internal sealed class SqliteRepositoryImportService : IRepositoryImportService
+{
+    private readonly ConductorDbContext dbContext;
+    private readonly TimeProvider timeProvider;
+
+    public SqliteRepositoryImportService(
+        ConductorDbContext dbContext,
+        TimeProvider timeProvider)
+    {
+        this.dbContext = dbContext;
+        this.timeProvider = timeProvider;
+    }
+
+    public async Task<RepositoryImportResult> ImportAsync(
+        RepositoryImportRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        RepositoryImportPlan plan = RepositoryImportPlan.Create(request);
+        await ValidateReferencesAsync(plan, cancellationToken);
+
+        DateTimeOffset now = timeProvider.GetUtcNow();
+
+        await using Microsoft.EntityFrameworkCore.Storage.IDbContextTransaction transaction =
+            await dbContext.Database.BeginTransactionAsync(cancellationToken);
+
+        (Repository Repository, bool CreatedRepository) repositoryResult =
+            await CreateOrUpdateRepositoryAsync(plan, now, cancellationToken);
+        (SymphonyInstance? Instance, bool CreatedInstance) instanceResult =
+            await CreateInstanceShellAsync(repositoryResult.Repository, plan, now, cancellationToken);
+
+        string metadataJson = JsonSerializer.Serialize(new
+        {
+            repositoryFullName = plan.FullName.Value,
+            createdRepository = repositoryResult.CreatedRepository,
+            createSymphonyInstance = plan.InstancePlan is not null,
+            createdSymphonyInstance = instanceResult.CreatedInstance,
+            symphonyInstanceId = instanceResult.Instance?.Id.ToString(),
+            executionMode = plan.InstancePlan?.ExecutionMode.ToString(),
+            releaseSelector = plan.InstancePlan?.ReleaseSelector.ToString(),
+            workflowProfileId = plan.InstancePlan?.WorkflowProfileId?.ToString(),
+        });
+
+        dbContext.AuditEvents.Add(new AuditEvent(
+            AuditEventId.New(),
+            string.IsNullOrWhiteSpace(request.RequestedByUserId) ? "system" : request.RequestedByUserId.Trim(),
+            "ImportRepository",
+            "Repository",
+            repositoryResult.Repository.Id.ToString(),
+            now,
+            AuditEventOutcome.Succeeded,
+            correlationId: null,
+            message: $"Imported repository {plan.FullName.Value}.",
+            metadataJson: metadataJson));
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+        await transaction.CommitAsync(cancellationToken);
+
+        return new RepositoryImportResult(
+            repositoryResult.Repository.Id.ToString(),
+            plan.FullName.Value,
+            repositoryResult.CreatedRepository,
+            instanceResult.Instance?.Id.ToString(),
+            instanceResult.CreatedInstance,
+            instanceResult.Instance?.DisplayName,
+            now);
+    }
+
+    private async Task ValidateReferencesAsync(
+        RepositoryImportPlan plan,
+        CancellationToken cancellationToken)
+    {
+        Dictionary<string, List<string>> errors = new(StringComparer.Ordinal);
+
+        if (plan.ProjectId is { } projectId &&
+            !await dbContext.Projects.AsNoTracking().AnyAsync(project => project.Id == projectId, cancellationToken))
+        {
+            AddError(errors, nameof(RepositoryImportRequest.ProjectId), "The selected project does not exist.");
+        }
+
+        if (plan.InstancePlan?.WorkflowProfileId is { } workflowProfileId &&
+            !await dbContext.WorkflowProfiles.AsNoTracking().AnyAsync(profile => profile.Id == workflowProfileId, cancellationToken))
+        {
+            AddError(errors, nameof(RepositoryImportRequest.WorkflowProfileId), "The selected workflow profile does not exist.");
+        }
+
+        if (plan.InstancePlan is { } instancePlan)
+        {
+            await ValidateSecretReferenceAsync(
+                instancePlan.GitHubCredential,
+                SecretType.GitHubToken,
+                nameof(RepositoryImportRequest.GitHubCredentialSecretId),
+                errors,
+                cancellationToken);
+            await ValidateSecretReferenceAsync(
+                instancePlan.OpenAiCredential,
+                SecretType.OpenAiApiKey,
+                nameof(RepositoryImportRequest.OpenAiCredentialSecretId),
+                errors,
+                cancellationToken);
+        }
+
+        if (errors.Count > 0)
+        {
+            throw new RepositoryImportValidationException(ToErrorDictionary(errors));
+        }
+    }
+
+    private async Task ValidateSecretReferenceAsync(
+        RepositoryImportCredentialSelection credential,
+        SecretType expectedSecretType,
+        string fieldName,
+        Dictionary<string, List<string>> errors,
+        CancellationToken cancellationToken)
+    {
+        if (credential.InheritanceMode != CredentialInheritanceMode.SpecificSecret)
+        {
+            return;
+        }
+
+        bool exists = await dbContext.SecretDescriptors
+            .AsNoTracking()
+            .AnyAsync(
+                descriptor => descriptor.Id == credential.SecretId && descriptor.SecretType == expectedSecretType,
+                cancellationToken);
+
+        if (!exists)
+        {
+            AddError(errors, fieldName, $"The selected {expectedSecretType} secret does not exist.");
+        }
+    }
+
+    private async Task<(Repository Repository, bool CreatedRepository)> CreateOrUpdateRepositoryAsync(
+        RepositoryImportPlan plan,
+        DateTimeOffset importedAtUtc,
+        CancellationToken cancellationToken)
+    {
+        Repository? repository = await dbContext.Repositories
+            .FirstOrDefaultAsync(
+                candidate =>
+                    candidate.Provider == RepositoryProvider.GitHub &&
+                    candidate.Owner == plan.FullName.Owner &&
+                    candidate.Name == plan.FullName.Name,
+                cancellationToken);
+
+        if (repository is null)
+        {
+            repository = new Repository(
+                RepositoryId.New(),
+                RepositoryProvider.GitHub,
+                plan.FullName,
+                plan.DefaultBranch,
+                plan.CloneUrl,
+                plan.WebUrl,
+                plan.Visibility,
+                plan.IsArchived,
+                plan.ProjectId,
+                importedAtUtc,
+                plan.OrchestrationStatus,
+                plan.OrchestrationStatusReason);
+
+            dbContext.Repositories.Add(repository);
+            return (repository, CreatedRepository: true);
+        }
+
+        repository.AssignToProject(plan.ProjectId);
+        repository.RefreshMetadata(
+            plan.DefaultBranch,
+            plan.CloneUrl,
+            plan.WebUrl,
+            plan.Visibility,
+            plan.IsArchived,
+            importedAtUtc);
+
+        if (plan.IsArchived)
+        {
+            repository.MarkOrchestrationIneligible("Archived repositories cannot be orchestrated.");
+        }
+        else
+        {
+            repository.MarkOrchestrationEligible();
+        }
+
+        return (repository, CreatedRepository: false);
+    }
+
+    private async Task<(SymphonyInstance? Instance, bool CreatedInstance)> CreateInstanceShellAsync(
+        Repository repository,
+        RepositoryImportPlan plan,
+        DateTimeOffset importedAtUtc,
+        CancellationToken cancellationToken)
+    {
+        if (plan.InstancePlan is null)
+        {
+            return (null, CreatedInstance: false);
+        }
+
+        RepositoryImportInstancePlan instancePlan = plan.InstancePlan;
+        SymphonyInstance? existingInstance = await dbContext.SymphonyInstances
+            .FirstOrDefaultAsync(
+                instance =>
+                    instance.RepositoryId == repository.Id &&
+                    instance.DisplayName == instancePlan.DisplayName &&
+                    instance.LifecycleStatus != InstanceLifecycleStatus.Destroyed,
+                cancellationToken);
+
+        if (existingInstance is not null)
+        {
+            return (existingInstance, CreatedInstance: false);
+        }
+
+        SymphonyInstance instance = new(
+            SymphonyInstanceId.New(),
+            repository.Id,
+            instancePlan.DisplayName,
+            instancePlan.ExecutionMode,
+            instancePlan.BaseUrl,
+            importedAtUtc,
+            InstanceLifecycleStatus.NotProvisioned,
+            InstanceHealthStatus.Unknown,
+            port: instancePlan.Port,
+            symphonyReleaseTag: instancePlan.ReleaseSelector.ToString(),
+            gitHubCredentialSecretId: instancePlan.GitHubCredential.SecretId,
+            gitHubCredentialInheritanceMode: instancePlan.GitHubCredential.InheritanceMode,
+            openAiCredentialSecretId: instancePlan.OpenAiCredential.SecretId,
+            openAiCredentialInheritanceMode: instancePlan.OpenAiCredential.InheritanceMode,
+            workflowPath: instancePlan.WorkflowPath,
+            dataPath: instancePlan.DataPath);
+
+        dbContext.SymphonyInstances.Add(instance);
+
+        return (instance, CreatedInstance: true);
+    }
+
+    private static void AddError(
+        Dictionary<string, List<string>> errors,
+        string fieldName,
+        string message)
+    {
+        if (!errors.TryGetValue(fieldName, out List<string>? messages))
+        {
+            messages = [];
+            errors[fieldName] = messages;
+        }
+
+        messages.Add(message);
+    }
+
+    private static IReadOnlyDictionary<string, string[]> ToErrorDictionary(
+        Dictionary<string, List<string>> errors)
+    {
+        return errors.ToDictionary(
+            item => item.Key,
+            item => item.Value.ToArray(),
+            StringComparer.Ordinal);
+    }
+}

--- a/src/Conductor.Infrastructure.Persistence.Sqlite/SqlitePersistenceServiceCollectionExtensions.cs
+++ b/src/Conductor.Infrastructure.Persistence.Sqlite/SqlitePersistenceServiceCollectionExtensions.cs
@@ -1,11 +1,13 @@
 using Conductor.Core.Application.Dashboard;
 using Conductor.Core.Application.Instances;
 using Conductor.Core.Application.Queries;
+using Conductor.Core.Application.Repositories;
 using Conductor.Core.Application.Secrets;
 using Conductor.Core.Application.Snapshots;
 using Conductor.Infrastructure.Persistence.Sqlite.Dashboard;
 using Conductor.Infrastructure.Persistence.Sqlite.Instances;
 using Conductor.Infrastructure.Persistence.Sqlite.Queries;
+using Conductor.Infrastructure.Persistence.Sqlite.Repositories;
 using Conductor.Infrastructure.Persistence.Sqlite.Snapshots;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
@@ -38,6 +40,9 @@ public static class SqlitePersistenceServiceCollectionExtensions
             provider.GetRequiredService<SqliteProjectionQueryService>());
         services.AddScoped<IRepositoryListQueryService>(provider =>
             provider.GetRequiredService<SqliteProjectionQueryService>());
+        services.AddScoped<IProjectListQueryService>(provider =>
+            provider.GetRequiredService<SqliteProjectionQueryService>());
+        services.AddScoped<IRepositoryImportService, SqliteRepositoryImportService>();
         services.AddScoped<IInstanceSummaryQueryService>(provider =>
             provider.GetRequiredService<SqliteProjectionQueryService>());
         services.AddScoped<ISecretDescriptorQueryService, SqliteSecretDescriptorQueryService>();

--- a/tests/Conductor.Api.Tests/RepositoryImportEndpointTests.cs
+++ b/tests/Conductor.Api.Tests/RepositoryImportEndpointTests.cs
@@ -1,0 +1,167 @@
+using System.Data.Common;
+using System.Net;
+using System.Net.Http.Json;
+using Conductor.Core.Abstractions.Symphony;
+using Conductor.Core.Domain;
+using Conductor.Infrastructure.Persistence.Sqlite;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Conductor.Api.Tests;
+
+public sealed class RepositoryImportEndpointTests
+{
+    [Fact]
+    public async Task Import_Creates_Repository_And_Instance_Shell()
+    {
+        await using RepositoryImportApiFactory factory = new();
+        using HttpClient client = factory.CreateClient();
+
+        HttpResponseMessage response = await client.PostAsJsonAsync(
+            "/api/repos/import",
+            new
+            {
+                repositoryFullName = "ReleasedGroup/TheConductor",
+                defaultBranch = "main",
+                visibility = "Private",
+                createSymphonyInstance = true,
+                instanceDisplayName = "Conductor local",
+                executionMode = "LocalProcess",
+                instanceBaseUrl = "http://localhost:8080/",
+                releaseTag = "latest",
+                gitHubCredentialInheritanceMode = "None",
+                openAiCredentialInheritanceMode = "InheritDefault",
+            });
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        ImportResponse? body = await response.Content.ReadFromJsonAsync<ImportResponse>();
+
+        Assert.NotNull(body);
+        Assert.Equal("ReleasedGroup/TheConductor", body.RepositoryFullName);
+        Assert.True(body.CreatedRepository);
+        Assert.True(body.CreatedSymphonyInstance);
+        Assert.NotNull(body.SymphonyInstanceId);
+
+        await using AsyncServiceScope scope = factory.Services.CreateAsyncScope();
+        ConductorDbContext dbContext = scope.ServiceProvider.GetRequiredService<ConductorDbContext>();
+
+        Assert.Equal(1, await CountAsync(dbContext, "Repositories"));
+        Assert.Equal(1, await CountAsync(dbContext, "SymphonyInstances"));
+        Assert.Equal(1, await CountAsync(dbContext, "AuditEvents"));
+    }
+
+    [Fact]
+    public async Task Import_Returns_ValidationProblem_When_Repository_Name_Is_Invalid()
+    {
+        await using RepositoryImportApiFactory factory = new();
+        using HttpClient client = factory.CreateClient();
+
+        HttpResponseMessage response = await client.PostAsJsonAsync(
+            "/api/repos/import",
+            new
+            {
+                repositoryFullName = "TheConductor",
+            });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        await using AsyncServiceScope scope = factory.Services.CreateAsyncScope();
+        ConductorDbContext dbContext = scope.ServiceProvider.GetRequiredService<ConductorDbContext>();
+
+        Assert.Equal(0, await CountAsync(dbContext, "Repositories"));
+    }
+
+    private static async Task<long> CountAsync(ConductorDbContext dbContext, string tableName)
+    {
+        await using DbCommand command = dbContext.Database.GetDbConnection().CreateCommand();
+        command.CommandText = $"SELECT COUNT(*) FROM \"{tableName}\";";
+
+        if (command.Connection?.State != System.Data.ConnectionState.Open)
+        {
+            await dbContext.Database.OpenConnectionAsync();
+        }
+
+        object? value = await command.ExecuteScalarAsync();
+
+        return Convert.ToInt64(value);
+    }
+
+    private sealed class RepositoryImportApiFactory : WebApplicationFactory<Program>
+    {
+        private readonly SqliteConnection connection = new("Data Source=:memory:");
+
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            connection.Open();
+
+            builder.ConfigureServices(services =>
+            {
+                services.RemoveAll<DbContextOptions<ConductorDbContext>>();
+                services.RemoveAll<ISymphonyApiClient>();
+
+                services.AddDbContext<ConductorDbContext>(options => options.UseSqlite(connection));
+                services.AddSingleton<ISymphonyApiClient>(new NoOpSymphonyApiClient());
+            });
+        }
+
+        public override async ValueTask DisposeAsync()
+        {
+            await connection.DisposeAsync();
+            await base.DisposeAsync();
+        }
+    }
+
+    private sealed class NoOpSymphonyApiClient : ISymphonyApiClient
+    {
+        public Task<SymphonyHealthResponse> GetHealthAsync(Uri baseUri, CancellationToken cancellationToken)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task<SymphonyRuntimeResponse> GetRuntimeAsync(Uri baseUri, CancellationToken cancellationToken)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task<SymphonyStateResponse> GetStateAsync(Uri baseUri, CancellationToken cancellationToken)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task<SymphonyWorkflowDocument> GetWorkflowAsync(Uri baseUri, CancellationToken cancellationToken)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task<SymphonyWorkflowDocument> SaveWorkflowAsync(
+            Uri baseUri,
+            SymphonyWorkflowDocument document,
+            CancellationToken cancellationToken)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task<SymphonyIssueResponse?> GetIssueAsync(
+            Uri baseUri,
+            string issueIdentifier,
+            CancellationToken cancellationToken)
+        {
+            throw new NotSupportedException();
+        }
+
+        public Task<SymphonyRefreshResponse> RequestRefreshAsync(Uri baseUri, CancellationToken cancellationToken)
+        {
+            throw new NotSupportedException();
+        }
+    }
+
+    private sealed record ImportResponse(
+        string RepositoryFullName,
+        bool CreatedRepository,
+        bool CreatedSymphonyInstance,
+        string? SymphonyInstanceId);
+}

--- a/tests/Conductor.Blazor.Tests/RepositoriesPageTests.cs
+++ b/tests/Conductor.Blazor.Tests/RepositoriesPageTests.cs
@@ -1,0 +1,108 @@
+using Bunit;
+using Conductor.Core.Application.Queries;
+using Conductor.Core.Application.Repositories;
+using Conductor.Core.Domain;
+using Conductor.Core.Domain.Ids;
+using Conductor.Host.Components.Pages;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Conductor.Blazor.Tests;
+
+public sealed class RepositoriesPageTests
+{
+    [Fact]
+    public async Task Repositories_Submits_Import_Request_With_Instance_Shell()
+    {
+        using BunitContext context = new();
+        FakeRepositoryImportService importService = new();
+        context.Services.AddSingleton<IRepositoryImportService>(importService);
+        context.Services.AddSingleton<IRepositoryListQueryService>(new StaticRepositoryListQueryService());
+        context.Services.AddSingleton<IProjectListQueryService>(new StaticProjectListQueryService());
+
+        IRenderedComponent<Repositories> page = context.Render<Repositories>();
+        page.Find("#repository-full-name").Change("ReleasedGroup/TheConductor");
+        page.Find("#create-instance-shell").Change(true);
+        page.Find("#instance-base-url").Change("http://localhost:8080/");
+
+        await page.Find("form").SubmitAsync();
+
+        Assert.NotNull(importService.LastRequest);
+        Assert.Equal("ReleasedGroup/TheConductor", importService.LastRequest.RepositoryFullName);
+        Assert.True(importService.LastRequest.CreateSymphonyInstance);
+        Assert.Equal("http://localhost:8080/", importService.LastRequest.InstanceBaseUrl);
+        Assert.Equal(CredentialInheritanceMode.InheritDefault, importService.LastRequest.GitHubCredentialInheritanceMode);
+        Assert.Contains("ReleasedGroup/TheConductor imported", page.Markup, StringComparison.Ordinal);
+        Assert.Contains("Conductor local was created in NotProvisioned state.", page.Markup, StringComparison.Ordinal);
+        Assert.Contains("Managed repositories", page.Markup, StringComparison.Ordinal);
+        Assert.Contains("ReleasedGroup/ExistingService", page.Markup, StringComparison.Ordinal);
+    }
+
+    private sealed class FakeRepositoryImportService : IRepositoryImportService
+    {
+        public RepositoryImportRequest? LastRequest { get; private set; }
+
+        public Task<RepositoryImportResult> ImportAsync(
+            RepositoryImportRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            LastRequest = request;
+
+            return Task.FromResult(new RepositoryImportResult(
+                Guid.NewGuid().ToString("D"),
+                "ReleasedGroup/TheConductor",
+                CreatedRepository: true,
+                Guid.NewGuid().ToString("D"),
+                CreatedSymphonyInstance: true,
+                "Conductor local",
+                DateTimeOffset.Parse("2026-04-29T02:00:00Z")));
+        }
+    }
+
+    private sealed class StaticRepositoryListQueryService : IRepositoryListQueryService
+    {
+        public Task<IReadOnlyList<RepositoryListItemProjection>> ListRepositoriesAsync(
+            RepositoryListQuery query,
+            CancellationToken cancellationToken = default)
+        {
+            IReadOnlyList<RepositoryListItemProjection> repositories =
+            [
+                new RepositoryListItemProjection(
+                    RepositoryId.New(),
+                    null,
+                    null,
+                    RepositoryProvider.GitHub,
+                    "ReleasedGroup",
+                    "ExistingService",
+                    "ReleasedGroup/ExistingService",
+                    "main",
+                    new Uri("https://github.com/ReleasedGroup/ExistingService"),
+                    IsArchived: false,
+                    InstanceCount: 1,
+                    RunningInstanceCount: 0,
+                    InstanceHealthStatus.Unknown,
+                    LastHealthCheckAtUtc: null),
+            ];
+
+            return Task.FromResult(repositories);
+        }
+    }
+
+    private sealed class StaticProjectListQueryService : IProjectListQueryService
+    {
+        public Task<IReadOnlyList<ProjectListItemProjection>> ListProjectsAsync(
+            ProjectListQuery query,
+            CancellationToken cancellationToken = default)
+        {
+            IReadOnlyList<ProjectListItemProjection> projects =
+            [
+                new ProjectListItemProjection(
+                    ProjectId.New(),
+                    "Platform",
+                    "ReleasedGroup",
+                    ProjectStatus.Active),
+            ];
+
+            return Task.FromResult(projects);
+        }
+    }
+}

--- a/tests/Conductor.Core.Tests/RepositoryImportModelTests.cs
+++ b/tests/Conductor.Core.Tests/RepositoryImportModelTests.cs
@@ -1,0 +1,77 @@
+using Conductor.Core.Application.Repositories;
+using Conductor.Core.Domain;
+using Conductor.Core.Domain.Ids;
+using Conductor.Core.Domain.Repositories;
+
+namespace Conductor.Core.Tests;
+
+public sealed class RepositoryImportModelTests
+{
+    [Fact]
+    public void RepositoryImportPlan_Derives_GitHub_Metadata_And_Instance_Shell()
+    {
+        ProjectId projectId = ProjectId.New();
+        RepositoryImportPlan plan = RepositoryImportPlan.Create(new RepositoryImportRequest(
+            " ReleasedGroup / TheConductor ",
+            " trunk ",
+            Visibility: RepositoryVisibility.Private,
+            ProjectId: projectId,
+            CreateSymphonyInstance: true,
+            InstanceDisplayName: " Main Conductor ",
+            ExecutionMode: ExecutionMode.Docker,
+            InstanceBaseUrl: "http://localhost:8080/",
+            ReleaseTag: " v1.2.3 ",
+            GitHubCredentialInheritanceMode: CredentialInheritanceMode.None,
+            OpenAiCredentialInheritanceMode: CredentialInheritanceMode.InheritDefault,
+            WorkflowPath: " ./instances/theconductor/WORKFLOW.md "));
+
+        Assert.Equal("ReleasedGroup/TheConductor", plan.FullName.Value);
+        Assert.Equal("trunk", plan.DefaultBranch);
+        Assert.Equal(new Uri("https://github.com/ReleasedGroup/TheConductor.git"), plan.CloneUrl);
+        Assert.Equal(new Uri("https://github.com/ReleasedGroup/TheConductor"), plan.WebUrl);
+        Assert.Equal(RepositoryVisibility.Private, plan.Visibility);
+        Assert.Equal(projectId, plan.ProjectId);
+        Assert.Equal(RepositoryOrchestrationStatus.Eligible, plan.OrchestrationStatus);
+
+        Assert.NotNull(plan.InstancePlan);
+        Assert.Equal("Main Conductor", plan.InstancePlan.DisplayName);
+        Assert.Equal(ExecutionMode.Docker, plan.InstancePlan.ExecutionMode);
+        Assert.Equal(8080, plan.InstancePlan.Port);
+        Assert.Equal("v1.2.3", plan.InstancePlan.ReleaseSelector.ToString());
+        Assert.Equal(CredentialInheritanceMode.None, plan.InstancePlan.GitHubCredential.InheritanceMode);
+        Assert.Equal("./instances/theconductor/WORKFLOW.md", plan.InstancePlan.WorkflowPath);
+    }
+
+    [Fact]
+    public void RepositoryImportPlan_Rejects_Invalid_Repository_And_Instance_Inputs()
+    {
+        RepositoryImportValidationException exception = Assert.Throws<RepositoryImportValidationException>(() =>
+            RepositoryImportPlan.Create(new RepositoryImportRequest(
+                "not-a-full-name",
+                CreateSymphonyInstance: true,
+                InstanceBaseUrl: "not-a-url",
+                Port: 70000,
+                GitHubCredentialInheritanceMode: CredentialInheritanceMode.SpecificSecret,
+                IsArchived: true)));
+
+        Assert.Contains(nameof(RepositoryImportRequest.RepositoryFullName), exception.Errors.Keys);
+        Assert.Contains(nameof(RepositoryImportRequest.InstanceBaseUrl), exception.Errors.Keys);
+        Assert.Contains(nameof(RepositoryImportRequest.Port), exception.Errors.Keys);
+        Assert.Contains(nameof(RepositoryImportRequest.GitHubCredentialSecretId), exception.Errors.Keys);
+        Assert.Contains(nameof(RepositoryImportRequest.CreateSymphonyInstance), exception.Errors.Keys);
+    }
+
+    [Fact]
+    public void RepositoryImportPlan_Treats_Blank_Release_As_Latest()
+    {
+        RepositoryImportPlan plan = RepositoryImportPlan.Create(new RepositoryImportRequest(
+            "ReleasedGroup/TheConductor",
+            CreateSymphonyInstance: true,
+            InstanceBaseUrl: "https://conductor.local/",
+            ReleaseTag: "   "));
+
+        Assert.NotNull(plan.InstancePlan);
+        Assert.True(plan.InstancePlan.ReleaseSelector.IsLatest);
+        Assert.Equal("latest", plan.InstancePlan.ReleaseSelector.ToString());
+    }
+}

--- a/tests/Conductor.Persistence.Tests/SqliteRepositoryImportServiceTests.cs
+++ b/tests/Conductor.Persistence.Tests/SqliteRepositoryImportServiceTests.cs
@@ -1,0 +1,141 @@
+using System.Globalization;
+using Conductor.Core.Application.Repositories;
+using Conductor.Core.Domain;
+using Conductor.Core.Domain.Auditing;
+using Conductor.Core.Domain.Repositories;
+using Conductor.Core.Domain.Symphony;
+using Conductor.Infrastructure.Persistence.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Conductor.Persistence.Tests;
+
+public sealed class SqliteRepositoryImportServiceTests
+{
+    [Fact]
+    public async Task ImportAsync_Creates_Repository_Instance_Shell_And_Audit_Event()
+    {
+        DateTimeOffset importedAtUtc = DateTimeOffset.Parse("2026-04-29T04:00:00Z");
+        await using ServiceProvider provider = BuildProvider(importedAtUtc);
+        await using AsyncServiceScope scope = provider.CreateAsyncScope();
+        ConductorDbContext dbContext = scope.ServiceProvider.GetRequiredService<ConductorDbContext>();
+        await dbContext.Database.MigrateAsync();
+        IRepositoryImportService importService = scope.ServiceProvider.GetRequiredService<IRepositoryImportService>();
+
+        RepositoryImportResult result = await importService.ImportAsync(new RepositoryImportRequest(
+            "ReleasedGroup/TheConductor",
+            "main",
+            Visibility: RepositoryVisibility.Private,
+            CreateSymphonyInstance: true,
+            InstanceDisplayName: "Conductor local",
+            ExecutionMode: ExecutionMode.LocalProcess,
+            InstanceBaseUrl: "http://localhost:8080/",
+            ReleaseTag: "latest",
+            GitHubCredentialInheritanceMode: CredentialInheritanceMode.None,
+            OpenAiCredentialInheritanceMode: CredentialInheritanceMode.InheritDefault,
+            RequestedByUserId: "nick"));
+
+        Repository repository = await dbContext.Repositories.SingleAsync();
+        SymphonyInstance instance = await dbContext.SymphonyInstances.SingleAsync();
+        AuditEvent auditEvent = await dbContext.AuditEvents.SingleAsync();
+
+        Assert.True(result.CreatedRepository);
+        Assert.True(result.CreatedSymphonyInstance);
+        Assert.Equal(repository.Id.ToString(), result.RepositoryId);
+        Assert.Equal(instance.Id.ToString(), result.SymphonyInstanceId);
+        Assert.Equal("ReleasedGroup/TheConductor", repository.FullName.Value);
+        Assert.Equal(RepositoryVisibility.Private, repository.Visibility);
+        Assert.Equal(importedAtUtc, repository.LastSyncedAtUtc);
+        Assert.Equal("Conductor local", instance.DisplayName);
+        Assert.Equal(InstanceLifecycleStatus.NotProvisioned, instance.LifecycleStatus);
+        Assert.Equal(InstanceHealthStatus.Unknown, instance.HealthStatus);
+        Assert.Equal("latest", instance.SymphonyReleaseTag);
+        Assert.Equal(CredentialInheritanceMode.None, instance.GitHubCredentialInheritanceMode);
+        Assert.Equal("ImportRepository", auditEvent.Action);
+        Assert.Equal("nick", auditEvent.ActorUserId);
+    }
+
+    [Fact]
+    public async Task ImportAsync_Updates_Existing_Repository_And_Does_Not_Duplicate_Instance_Shell()
+    {
+        DateTimeOffset importedAtUtc = DateTimeOffset.Parse("2026-04-29T04:00:00Z");
+        await using ServiceProvider provider = BuildProvider(importedAtUtc);
+        await using AsyncServiceScope scope = provider.CreateAsyncScope();
+        ConductorDbContext dbContext = scope.ServiceProvider.GetRequiredService<ConductorDbContext>();
+        await dbContext.Database.MigrateAsync();
+        IRepositoryImportService importService = scope.ServiceProvider.GetRequiredService<IRepositoryImportService>();
+
+        var request = new RepositoryImportRequest(
+            "ReleasedGroup/TheConductor",
+            "main",
+            CreateSymphonyInstance: true,
+            InstanceDisplayName: "Conductor local",
+            InstanceBaseUrl: "http://localhost:8080/",
+            GitHubCredentialInheritanceMode: CredentialInheritanceMode.None,
+            OpenAiCredentialInheritanceMode: CredentialInheritanceMode.None);
+
+        RepositoryImportResult firstResult = await importService.ImportAsync(request);
+        RepositoryImportResult secondResult = await importService.ImportAsync(request with
+        {
+            DefaultBranch = "trunk",
+            Visibility = RepositoryVisibility.Internal,
+        });
+
+        Repository repository = await dbContext.Repositories.SingleAsync();
+
+        Assert.True(firstResult.CreatedRepository);
+        Assert.False(secondResult.CreatedRepository);
+        Assert.True(firstResult.CreatedSymphonyInstance);
+        Assert.False(secondResult.CreatedSymphonyInstance);
+        Assert.Equal("trunk", repository.DefaultBranch);
+        Assert.Equal(RepositoryVisibility.Internal, repository.Visibility);
+        Assert.Equal(1, await dbContext.SymphonyInstances.CountAsync());
+        Assert.Equal(2, await dbContext.AuditEvents.CountAsync());
+    }
+
+    [Fact]
+    public async Task ImportAsync_Rejects_Missing_Project_Reference_Without_Writing()
+    {
+        DateTimeOffset importedAtUtc = DateTimeOffset.Parse("2026-04-29T04:00:00Z");
+        await using ServiceProvider provider = BuildProvider(importedAtUtc);
+        await using AsyncServiceScope scope = provider.CreateAsyncScope();
+        ConductorDbContext dbContext = scope.ServiceProvider.GetRequiredService<ConductorDbContext>();
+        await dbContext.Database.MigrateAsync();
+        IRepositoryImportService importService = scope.ServiceProvider.GetRequiredService<IRepositoryImportService>();
+
+        RepositoryImportValidationException exception = await Assert.ThrowsAsync<RepositoryImportValidationException>(() =>
+            importService.ImportAsync(new RepositoryImportRequest(
+                "ReleasedGroup/TheConductor",
+                ProjectId: Conductor.Core.Domain.Ids.ProjectId.New())));
+
+        Assert.Contains(nameof(RepositoryImportRequest.ProjectId), exception.Errors.Keys);
+        Assert.Equal(0, await dbContext.Repositories.CountAsync());
+        Assert.Equal(0, await dbContext.AuditEvents.CountAsync());
+    }
+
+    private static ServiceProvider BuildProvider(DateTimeOffset utcNow)
+    {
+        string databasePath = Path.Combine(
+            Path.GetTempPath(),
+            "conductor-repository-import-tests",
+            Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture),
+            "conductor.db");
+        IConfiguration configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [$"ConnectionStrings:{SqlitePersistenceOptions.ConnectionStringName}"] = $"Data Source={databasePath};Cache=Shared",
+            })
+            .Build();
+        ServiceCollection services = new();
+        services.AddSingleton<TimeProvider>(new FixedTimeProvider(utcNow));
+        services.AddConductorPersistence(configuration);
+
+        return services.BuildServiceProvider(validateScopes: true);
+    }
+
+    private sealed class FixedTimeProvider(DateTimeOffset utcNow) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => utcNow;
+    }
+}


### PR DESCRIPTION
## Summary
- Adds the repository import request/plan/result data model and SQLite-backed import service.
- Adds `/api/repos/import` plus JSON enum handling for repository import requests.
- Adds the `/repositories` Blazor shell with import form, optional NotProvisioned Symphony instance shell, and repository registry list.
- Adds focused core, persistence, API, and bUnit coverage plus docs for the new import flow.

Closes #43

## Validation
- `dotnet restore Conductor.slnx`: passed
- `dotnet build Conductor.slnx --no-restore --warnaserror`: passed with no warnings
- `dotnet test Conductor.slnx --no-build`: passed, 116 tests
- `dotnet format Conductor.slnx --no-restore --verify-no-changes`: passed
- `./scripts/validate-docs.ps1`: passed

## Notes
- Live GitHub repository discovery remains a later Sprint 5 concern; this PR provides the manual import data model and first UI shell.