### PR TITLE
Add GitHub repository discovery client

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -6,6 +6,18 @@ This document describes Conductor's public and internal HTTP APIs as endpoints b
 
 The current API direction is defined in [requirements.md](requirements.md) and [technical.md](technical.md).
 
+## GitHub Repository Discovery Client
+
+Conductor registers a typed HTTP client called `GitHubRepository` for GitHub repository discovery and credential checks. The client uses GitHub GraphQL so organization, repository, issue, pull request, label, milestone, branch protection, and default-branch status-check metadata can be fetched through the repository-facing `IGitHubRepositoryClient` abstraction.
+
+| Client method | Purpose | Notes |
+| --- | --- | --- |
+| `ListOrganizationsAsync` | Lists organizations visible to the configured GitHub identity. | Returns login, display name, description, avatar URL, and GitHub web URL. |
+| `ListRepositoriesAsync` | Lists repositories accessible to the configured GitHub identity. | Uses owner, collaborator, and organization-member affiliations. |
+| `SearchRepositoriesAsync` | Searches repositories visible to the configured GitHub identity. | Accepts GitHub repository search syntax and returns the same metadata shape as list results. |
+
+Repository summaries include owner/name, derived HTTPS clone URL, GitHub web URL, default branch when present, visibility, archived status, open issue count, open pull request count, labels, open milestones, branch protection summary, and default-branch status-check state. Authentication is supplied by the caller through the configured HTTP client or future secret-resolution workflow; PAT values must not be stored in `appsettings.json`.
+
 ## Symphony Runtime Client
 
 Conductor registers a named HTTP client called `SymphonyApi` for calls to existing Symphony runtimes. The typed client uses the Symphony instance base URL and appends these runtime endpoints:
@@ -47,11 +59,9 @@ Responses:
 - `400 Bad Request` with validation errors when the URL, health probe, or runtime probe fails.
 - `409 Conflict` when the normalized base URL is already registered.
 
-## GitHub Repository Client
+## GitHub Repository Credential Checks
 
-Conductor registers a typed HTTP client called `GitHubRepository` for GitHub repository discovery and credential checks.
-
-PAT validation uses `GET /repos/{owner}/{repo}` with the selected token as a bearer token. A `200` response confirms the token can reach the target repository metadata; when GitHub returns a repository `permissions` object, Conductor also checks that at least one read-capable repository permission is present. `401`, `403`, `404`, and rate-limit responses are mapped to actionable validation statuses without storing or returning the PAT value.
+PAT validation uses `GET /repos/{owner}/{repo}` with the selected token as a bearer token on the same repository-facing client. A `200` response confirms the token can reach the target repository metadata; when GitHub returns a repository `permissions` object, Conductor also checks that at least one read-capable repository permission is present. `401`, `403`, `404`, and rate-limit responses are mapped to actionable validation statuses without storing or returning the PAT value.
 
 ## Instance Credential Assignment
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -19,6 +19,8 @@ All test projects target `net10.0`, use xUnit, and are included in `Conductor.sl
 
 Symphony API response fixtures live under `tests/Conductor.Integration.Tests/Fixtures/Symphony` and are copied into the integration test output for deterministic client and mapping tests.
 
+GitHub repository discovery tests use fake HTTP handlers with queued GraphQL responses. The default suite verifies organization discovery, repository metadata mapping, repository search payloads, PAT access validation mapping, and DI registration without requiring live GitHub credentials.
+
 ## Local Validation
 
 Run the same baseline checks used by CI:
@@ -39,8 +41,9 @@ Tests that require real external services must be opt-in so the default suite re
 
 GitHub repository discovery tests should use `FakeGitHubRepositoryClient` from
 `Conductor.Infrastructure.GitHub` unless they are explicitly validating live
-GitHub behavior. Seed the fake with `GitHubRepositorySummary` values and use
-`QueueSearchFailure` to exercise retry and error-handling paths without live
+GitHub behavior. Seed the fake with `GitHubOrganizationSummary` and
+`GitHubRepositorySummary` values, then use `QueueSearchFailure` or repository
+access validation requests to exercise error-handling paths without live
 credentials.
 
 Use these flags when those suites are added:

--- a/docs/writeup.md
+++ b/docs/writeup.md
@@ -16,7 +16,7 @@ house so buolt it in dotnet 10 with blazor webassembly front end.
 ## The Solution
 
 The final solution is a practical coordination tool for managing multiple professional software development engagements from a single control surface. It means
-we can democratise professional software development; give vibe coders somewhere to go and manage the non functional requirements which differentiate vibe apps 
+we can democratise professional software development; give vibe coders somewhere to go and manage the non functional requirements which differentiate vibe apps
 from real production ones. We're giving the world the ability to deliver commercial quality code at a fraction of the price and time of historical development.
 
 Small entrepreneurs now really have a chance to get out a working, reliable, secure and sclaable software solution without breaking the bank (and leaving money

--- a/src/Conductor.Core/Abstractions/GitHub/IGitHubRepositoryClient.cs
+++ b/src/Conductor.Core/Abstractions/GitHub/IGitHubRepositoryClient.cs
@@ -5,6 +5,12 @@ namespace Conductor.Core.Abstractions.GitHub;
 
 public interface IGitHubRepositoryClient
 {
+    Task<IReadOnlyList<GitHubOrganizationSummary>> ListOrganizationsAsync(
+        CancellationToken cancellationToken);
+
+    Task<IReadOnlyList<GitHubRepositorySummary>> ListRepositoriesAsync(
+        CancellationToken cancellationToken);
+
     Task<IReadOnlyList<GitHubRepositorySummary>> SearchRepositoriesAsync(
         string query,
         CancellationToken cancellationToken);
@@ -14,16 +20,153 @@ public interface IGitHubRepositoryClient
         CancellationToken cancellationToken);
 }
 
-public sealed record GitHubRepositorySummary(
-    string Owner,
-    string Name,
-    string DefaultBranch,
-    Uri CloneUrl,
+public sealed record GitHubOrganizationSummary(
+    string Login,
+    string? DisplayName,
     Uri WebUrl,
-    RepositoryVisibility Visibility,
-    bool IsArchived)
+    Uri? AvatarUrl,
+    string? Description);
+
+public sealed record GitHubRepositorySummary
 {
+    public GitHubRepositorySummary(
+        string owner,
+        string name,
+        string defaultBranch,
+        Uri cloneUrl,
+        Uri webUrl,
+        bool isArchived,
+        RepositoryVisibility visibility = RepositoryVisibility.Public,
+        int openIssueCount = 0,
+        int openPullRequestCount = 0,
+        IReadOnlyList<GitHubLabelSummary>? labels = null,
+        IReadOnlyList<GitHubMilestoneSummary>? milestones = null,
+        GitHubBranchProtectionSummary? branchProtection = null,
+        GitHubActionsStatusSummary? actionsStatus = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(owner);
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+        ArgumentNullException.ThrowIfNull(cloneUrl);
+        ArgumentNullException.ThrowIfNull(webUrl);
+
+        if (!cloneUrl.IsAbsoluteUri)
+        {
+            throw new ArgumentException("Clone URL must be absolute.", nameof(cloneUrl));
+        }
+
+        if (!webUrl.IsAbsoluteUri)
+        {
+            throw new ArgumentException("Web URL must be absolute.", nameof(webUrl));
+        }
+
+        Owner = owner.Trim();
+        Name = name.Trim();
+        DefaultBranch = defaultBranch.Trim();
+        CloneUrl = cloneUrl;
+        WebUrl = webUrl;
+        IsArchived = isArchived;
+        Visibility = visibility;
+        OpenIssueCount = Math.Max(0, openIssueCount);
+        OpenPullRequestCount = Math.Max(0, openPullRequestCount);
+        Labels = labels ?? [];
+        Milestones = milestones ?? [];
+        BranchProtection = branchProtection ?? GitHubBranchProtectionSummary.Unknown;
+        ActionsStatus = actionsStatus ?? GitHubActionsStatusSummary.Unknown;
+    }
+
+    public GitHubRepositorySummary(
+        string owner,
+        string name,
+        string defaultBranch,
+        Uri cloneUrl,
+        Uri webUrl,
+        RepositoryVisibility visibility,
+        bool IsArchived)
+        : this(
+            owner,
+            name,
+            defaultBranch,
+            cloneUrl,
+            webUrl,
+            IsArchived,
+            visibility)
+    {
+    }
+
+    public string Owner { get; }
+
+    public string Name { get; }
+
     public string FullName => $"{Owner}/{Name}";
+
+    public string DefaultBranch { get; }
+
+    public Uri CloneUrl { get; }
+
+    public Uri WebUrl { get; }
+
+    public bool IsArchived { get; }
+
+    public RepositoryVisibility Visibility { get; }
+
+    public int OpenIssueCount { get; }
+
+    public int OpenPullRequestCount { get; }
+
+    public IReadOnlyList<GitHubLabelSummary> Labels { get; }
+
+    public IReadOnlyList<GitHubMilestoneSummary> Milestones { get; }
+
+    public GitHubBranchProtectionSummary BranchProtection { get; }
+
+    public GitHubActionsStatusSummary ActionsStatus { get; }
+}
+
+public sealed record GitHubLabelSummary(
+    string Name,
+    string? Color,
+    string? Description);
+
+public sealed record GitHubMilestoneSummary(
+    string Title,
+    string State,
+    DateOnly? DueOn);
+
+public sealed record GitHubBranchProtectionSummary(
+    bool IsKnown,
+    bool DefaultBranchProtected,
+    int ProtectedBranchRuleCount,
+    bool RequiresPullRequestReviews,
+    int RequiredApprovingReviewCount,
+    bool RequiresStatusChecks,
+    IReadOnlyList<string> RequiredStatusCheckContexts)
+{
+    public static GitHubBranchProtectionSummary Unknown { get; } = new(
+        IsKnown: false,
+        DefaultBranchProtected: false,
+        ProtectedBranchRuleCount: 0,
+        RequiresPullRequestReviews: false,
+        RequiredApprovingReviewCount: 0,
+        RequiresStatusChecks: false,
+        RequiredStatusCheckContexts: []);
+
+    public static GitHubBranchProtectionSummary None { get; } = new(
+        IsKnown: true,
+        DefaultBranchProtected: false,
+        ProtectedBranchRuleCount: 0,
+        RequiresPullRequestReviews: false,
+        RequiredApprovingReviewCount: 0,
+        RequiresStatusChecks: false,
+        RequiredStatusCheckContexts: []);
+}
+
+public sealed record GitHubActionsStatusSummary(
+    bool IsKnown,
+    string? DefaultBranchStatusCheckState)
+{
+    public static GitHubActionsStatusSummary Unknown { get; } = new(
+        IsKnown: false,
+        DefaultBranchStatusCheckState: null);
 }
 
 public sealed record GitHubRepositoryAccessValidationRequest(

--- a/src/Conductor.Infrastructure.GitHub/Conductor.Infrastructure.GitHub.csproj
+++ b/src/Conductor.Infrastructure.GitHub/Conductor.Infrastructure.GitHub.csproj
@@ -2,9 +2,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Http" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\Conductor.Core\Conductor.Core.csproj" />
   </ItemGroup>
 

--- a/src/Conductor.Infrastructure.GitHub/FakeGitHubRepositoryClient.cs
+++ b/src/Conductor.Infrastructure.GitHub/FakeGitHubRepositoryClient.cs
@@ -5,6 +5,7 @@ namespace Conductor.Infrastructure.GitHub;
 public sealed class FakeGitHubRepositoryClient : IGitHubRepositoryClient
 {
     private readonly object syncRoot = new();
+    private readonly List<GitHubOrganizationSummary> organizations = [];
     private readonly List<GitHubRepositorySummary> repositories = [];
     private readonly List<string> searchQueries = [];
     private readonly List<GitHubRepositoryAccessValidationRequest> validationRequests = [];
@@ -17,6 +18,25 @@ public sealed class FakeGitHubRepositoryClient : IGitHubRepositoryClient
     public FakeGitHubRepositoryClient(IEnumerable<GitHubRepositorySummary> repositories)
     {
         AddRepositories(repositories);
+    }
+
+    public FakeGitHubRepositoryClient(
+        IEnumerable<GitHubRepositorySummary> repositories,
+        IEnumerable<GitHubOrganizationSummary> organizations)
+    {
+        AddRepositories(repositories);
+        AddOrganizations(organizations);
+    }
+
+    public IReadOnlyList<GitHubOrganizationSummary> Organizations
+    {
+        get
+        {
+            lock (syncRoot)
+            {
+                return organizations.ToArray();
+            }
+        }
     }
 
     public IReadOnlyList<GitHubRepositorySummary> Repositories
@@ -52,6 +72,26 @@ public sealed class FakeGitHubRepositoryClient : IGitHubRepositoryClient
         }
     }
 
+    public void AddOrganization(GitHubOrganizationSummary organization)
+    {
+        ArgumentNullException.ThrowIfNull(organization);
+
+        lock (syncRoot)
+        {
+            organizations.Add(organization);
+        }
+    }
+
+    public void AddOrganizations(IEnumerable<GitHubOrganizationSummary> organizations)
+    {
+        ArgumentNullException.ThrowIfNull(organizations);
+
+        foreach (GitHubOrganizationSummary organization in organizations)
+        {
+            AddOrganization(organization);
+        }
+    }
+
     public void AddRepository(GitHubRepositorySummary repository)
     {
         ArgumentNullException.ThrowIfNull(repository);
@@ -79,6 +119,34 @@ public sealed class FakeGitHubRepositoryClient : IGitHubRepositoryClient
         lock (syncRoot)
         {
             searchFailures.Enqueue(exception);
+        }
+    }
+
+    public Task<IReadOnlyList<GitHubOrganizationSummary>> ListOrganizationsAsync(
+        CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled<IReadOnlyList<GitHubOrganizationSummary>>(cancellationToken);
+        }
+
+        lock (syncRoot)
+        {
+            return Task.FromResult<IReadOnlyList<GitHubOrganizationSummary>>(organizations.ToArray());
+        }
+    }
+
+    public Task<IReadOnlyList<GitHubRepositorySummary>> ListRepositoriesAsync(
+        CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return Task.FromCanceled<IReadOnlyList<GitHubRepositorySummary>>(cancellationToken);
+        }
+
+        lock (syncRoot)
+        {
+            return Task.FromResult<IReadOnlyList<GitHubRepositorySummary>>(repositories.ToArray());
         }
     }
 

--- a/src/Conductor.Infrastructure.GitHub/GitHubRepositoryClient.cs
+++ b/src/Conductor.Infrastructure.GitHub/GitHubRepositoryClient.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using System.Net;
 using System.Net.Http.Headers;
+using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Conductor.Core.Abstractions.GitHub;
@@ -12,38 +13,101 @@ public sealed class GitHubRepositoryClient(HttpClient httpClient) : IGitHubRepos
 {
     public const string HttpClientName = "GitHubRepository";
 
+    private const int PageSize = 100;
+
     private static readonly Uri DefaultApiBaseUri = new("https://api.github.com/");
     private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
     private static readonly ProductInfoHeaderValue UserAgent = new("Conductor", "1.0");
+
+    public async Task<IReadOnlyList<GitHubOrganizationSummary>> ListOrganizationsAsync(
+        CancellationToken cancellationToken)
+    {
+        List<GitHubOrganizationSummary> organizations = [];
+        string? after = null;
+
+        do
+        {
+            using JsonDocument document = await SendGraphQlAsync(
+                ViewerOrganizationsQuery,
+                new { after },
+                cancellationToken);
+
+            JsonElement connection = document.RootElement
+                .GetProperty("data")
+                .GetProperty("viewer")
+                .GetProperty("organizations");
+
+            foreach (JsonElement node in ReadNodes(connection))
+            {
+                organizations.Add(ToOrganizationSummary(node));
+            }
+
+            after = ReadNextCursor(connection);
+        }
+        while (after is not null);
+
+        return organizations;
+    }
+
+    public async Task<IReadOnlyList<GitHubRepositorySummary>> ListRepositoriesAsync(
+        CancellationToken cancellationToken)
+    {
+        List<GitHubRepositorySummary> repositories = [];
+        string? after = null;
+
+        do
+        {
+            using JsonDocument document = await SendGraphQlAsync(
+                ViewerRepositoriesQuery,
+                new { after },
+                cancellationToken);
+
+            JsonElement connection = document.RootElement
+                .GetProperty("data")
+                .GetProperty("viewer")
+                .GetProperty("repositories");
+
+            foreach (JsonElement node in ReadNodes(connection))
+            {
+                repositories.Add(ToRepositorySummary(node));
+            }
+
+            after = ReadNextCursor(connection);
+        }
+        while (after is not null);
+
+        return repositories;
+    }
 
     public async Task<IReadOnlyList<GitHubRepositorySummary>> SearchRepositoriesAsync(
         string query,
         CancellationToken cancellationToken)
     {
         string normalizedQuery = RequireNonEmpty(query, nameof(query));
-        string endpoint = $"search/repositories?q={Uri.EscapeDataString(normalizedQuery)}&per_page=25";
+        List<GitHubRepositorySummary> repositories = [];
+        string? after = null;
 
-        using HttpRequestMessage request = CreateRequest(HttpMethod.Get, endpoint, personalAccessToken: null);
-        using HttpResponseMessage response = await httpClient.SendAsync(
-            request,
-            HttpCompletionOption.ResponseContentRead,
-            cancellationToken);
+        do
+        {
+            using JsonDocument document = await SendGraphQlAsync(
+                SearchRepositoriesQuery,
+                new { query = normalizedQuery, after },
+                cancellationToken);
 
-        string body = await ReadBodyAsync(response, cancellationToken);
-        EnsureSuccess(response, "GitHub repository search");
+            JsonElement connection = document.RootElement
+                .GetProperty("data")
+                .GetProperty("search");
 
-        GitHubSearchResponse searchResponse = Deserialize<GitHubSearchResponse>(body);
+            foreach (JsonElement node in ReadNodes(connection))
+            {
+                repositories.Add(ToRepositorySummary(node));
+            }
 
-        return searchResponse.Items
-            .Select(item => new GitHubRepositorySummary(
-                item.Owner.Login,
-                item.Name,
-                item.DefaultBranch,
-                new Uri(item.CloneUrl),
-                new Uri(item.HtmlUrl),
-                MapVisibility(item),
-                item.Archived))
-            .ToList();
+            after = ReadNextCursor(connection);
+        }
+        while (after is not null);
+
+        return repositories;
     }
 
     public async Task<GitHubRepositoryAccessValidationResult> ValidateRepositoryAccessAsync(
@@ -53,7 +117,8 @@ public sealed class GitHubRepositoryClient(HttpClient httpClient) : IGitHubRepos
         ArgumentNullException.ThrowIfNull(request);
 
         string token = RequireNonEmpty(request.PersonalAccessToken, nameof(request.PersonalAccessToken));
-        string endpoint = $"repos/{Uri.EscapeDataString(request.RepositoryFullName.Owner)}/{Uri.EscapeDataString(request.RepositoryFullName.Name)}";
+        string endpoint =
+            $"repos/{Uri.EscapeDataString(request.RepositoryFullName.Owner)}/{Uri.EscapeDataString(request.RepositoryFullName.Name)}";
 
         using HttpRequestMessage httpRequest = CreateRequest(HttpMethod.Get, endpoint, token);
         using HttpResponseMessage response = await httpClient.SendAsync(
@@ -117,6 +182,31 @@ public sealed class GitHubRepositoryClient(HttpClient httpClient) : IGitHubRepos
         };
     }
 
+    private async Task<JsonDocument> SendGraphQlAsync(
+        string query,
+        object variables,
+        CancellationToken cancellationToken)
+    {
+        using HttpRequestMessage request = CreateRequest(HttpMethod.Post, "graphql", personalAccessToken: null);
+        request.Content = new StringContent(
+            JsonSerializer.Serialize(new GraphQlRequest(query, variables), JsonOptions),
+            Encoding.UTF8,
+            "application/json");
+
+        using HttpResponseMessage response = await httpClient.SendAsync(
+            request,
+            HttpCompletionOption.ResponseContentRead,
+            cancellationToken);
+
+        string body = await ReadBodyAsync(response, cancellationToken);
+        EnsureGraphQlSuccess(response, body);
+
+        JsonDocument document = JsonDocument.Parse(body);
+        EnsureNoGraphQlErrors(document);
+
+        return document;
+    }
+
     private HttpRequestMessage CreateRequest(
         HttpMethod method,
         string endpoint,
@@ -139,6 +229,46 @@ public sealed class GitHubRepositoryClient(HttpClient httpClient) : IGitHubRepos
     {
         Uri baseUri = httpClient.BaseAddress ?? DefaultApiBaseUri;
         return new Uri(baseUri, endpoint);
+    }
+
+    private static void EnsureGraphQlSuccess(HttpResponseMessage response, string body)
+    {
+        if (response.IsSuccessStatusCode)
+        {
+            return;
+        }
+
+        string suffix = TryReadGitHubMessage(body) is { Length: > 0 } message
+            ? $" {message}"
+            : string.Empty;
+
+        throw new HttpRequestException(
+            $"GitHub GraphQL endpoint returned HTTP {(int)response.StatusCode} ({response.ReasonPhrase}).{suffix}",
+            inner: null,
+            response.StatusCode);
+    }
+
+    private static void EnsureNoGraphQlErrors(JsonDocument document)
+    {
+        if (!document.RootElement.TryGetProperty("errors", out JsonElement errors)
+            || errors.ValueKind != JsonValueKind.Array
+            || errors.GetArrayLength() == 0)
+        {
+            return;
+        }
+
+        string[] messages = errors
+            .EnumerateArray()
+            .Select(error => ReadOptionalString(error, "message"))
+            .Where(message => !string.IsNullOrWhiteSpace(message))
+            .Select(message => message!)
+            .ToArray();
+
+        string joinedMessages = messages.Length == 0
+            ? "Unknown GraphQL error."
+            : string.Join("; ", messages);
+
+        throw new HttpRequestException($"GitHub GraphQL returned errors: {joinedMessages}");
     }
 
     private static GitHubRepositoryAccessValidationResult CreateResult(
@@ -214,12 +344,9 @@ public sealed class GitHubRepositoryClient(HttpClient httpClient) : IGitHubRepos
     {
         int? reset = ReadIntHeader(response, "X-RateLimit-Reset");
 
-        if (reset is null)
-        {
-            return null;
-        }
-
-        return DateTimeOffset.FromUnixTimeSeconds(reset.Value);
+        return reset is null
+            ? null
+            : DateTimeOffset.FromUnixTimeSeconds(reset.Value);
     }
 
     private static async Task<string> ReadBodyAsync(
@@ -228,19 +355,6 @@ public sealed class GitHubRepositoryClient(HttpClient httpClient) : IGitHubRepos
         response.Content is null
             ? string.Empty
             : await response.Content.ReadAsStringAsync(cancellationToken);
-
-    private static void EnsureSuccess(HttpResponseMessage response, string operation)
-    {
-        if (response.IsSuccessStatusCode)
-        {
-            return;
-        }
-
-        throw new HttpRequestException(
-            $"{operation} returned HTTP {(int)response.StatusCode} ({response.ReasonPhrase}).",
-            inner: null,
-            response.StatusCode);
-    }
 
     private static T Deserialize<T>(string json)
     {
@@ -251,6 +365,317 @@ public sealed class GitHubRepositoryClient(HttpClient httpClient) : IGitHubRepos
 
         return JsonSerializer.Deserialize<T>(json, JsonOptions)
             ?? throw new JsonException("GitHub returned an unexpected JSON response.");
+    }
+
+    private static GitHubOrganizationSummary ToOrganizationSummary(JsonElement node)
+    {
+        string login = ReadRequiredString(node, "login");
+
+        return new GitHubOrganizationSummary(
+            login,
+            ReadOptionalString(node, "name"),
+            ReadRequiredUri(node, "url"),
+            ReadOptionalUri(node, "avatarUrl"),
+            ReadOptionalString(node, "description"));
+    }
+
+    private static GitHubRepositorySummary ToRepositorySummary(JsonElement node)
+    {
+        string owner = ReadRequiredString(node.GetProperty("owner"), "login");
+        string name = ReadRequiredString(node, "name");
+        string defaultBranch = ReadDefaultBranch(node);
+
+        return new GitHubRepositorySummary(
+            owner,
+            name,
+            defaultBranch,
+            BuildHttpsCloneUrl(owner, name),
+            ReadRequiredUri(node, "url"),
+            ReadBoolean(node, "isArchived"),
+            MapVisibility(ReadOptionalString(node, "visibility")),
+            ReadConnectionTotalCount(node, "issues"),
+            ReadConnectionTotalCount(node, "pullRequests"),
+            ReadLabels(node),
+            ReadMilestones(node),
+            ReadBranchProtection(node, defaultBranch),
+            ReadActionsStatus(node));
+    }
+
+    private static IReadOnlyList<JsonElement> ReadNodes(JsonElement connection)
+    {
+        if (!connection.TryGetProperty("nodes", out JsonElement nodes)
+            || nodes.ValueKind != JsonValueKind.Array)
+        {
+            return [];
+        }
+
+        return nodes
+            .EnumerateArray()
+            .Where(node => node.ValueKind == JsonValueKind.Object)
+            .ToArray();
+    }
+
+    private static string? ReadNextCursor(JsonElement connection)
+    {
+        if (!connection.TryGetProperty("pageInfo", out JsonElement pageInfo)
+            || !ReadBoolean(pageInfo, "hasNextPage"))
+        {
+            return null;
+        }
+
+        return ReadOptionalString(pageInfo, "endCursor");
+    }
+
+    private static string ReadDefaultBranch(JsonElement repository)
+    {
+        if (repository.TryGetProperty("defaultBranchRef", out JsonElement branch)
+            && branch.ValueKind == JsonValueKind.Object)
+        {
+            return ReadOptionalString(branch, "name")?.Trim() ?? string.Empty;
+        }
+
+        return string.Empty;
+    }
+
+    private static IReadOnlyList<GitHubLabelSummary> ReadLabels(JsonElement repository)
+    {
+        if (!repository.TryGetProperty("labels", out JsonElement labelsConnection))
+        {
+            return [];
+        }
+
+        return ReadNodes(labelsConnection)
+            .Select(label => new GitHubLabelSummary(
+                ReadRequiredString(label, "name"),
+                ReadOptionalString(label, "color"),
+                ReadOptionalString(label, "description")))
+            .ToArray();
+    }
+
+    private static IReadOnlyList<GitHubMilestoneSummary> ReadMilestones(JsonElement repository)
+    {
+        if (!repository.TryGetProperty("milestones", out JsonElement milestonesConnection))
+        {
+            return [];
+        }
+
+        return ReadNodes(milestonesConnection)
+            .Select(milestone => new GitHubMilestoneSummary(
+                ReadRequiredString(milestone, "title"),
+                ReadOptionalString(milestone, "state") ?? "OPEN",
+                ReadDateOnly(milestone, "dueOn")))
+            .ToArray();
+    }
+
+    private static GitHubBranchProtectionSummary ReadBranchProtection(
+        JsonElement repository,
+        string defaultBranch)
+    {
+        if (!repository.TryGetProperty("branchProtectionRules", out JsonElement rulesConnection))
+        {
+            return GitHubBranchProtectionSummary.Unknown;
+        }
+
+        int totalCount = ReadInteger(rulesConnection, "totalCount");
+        if (totalCount == 0)
+        {
+            return GitHubBranchProtectionSummary.None;
+        }
+
+        bool defaultBranchProtected = false;
+        bool requiresReviews = false;
+        bool requiresStatusChecks = false;
+        int requiredApprovals = 0;
+        HashSet<string> contexts = new(StringComparer.Ordinal);
+
+        foreach (JsonElement rule in ReadNodes(rulesConnection))
+        {
+            string pattern = ReadOptionalString(rule, "pattern") ?? string.Empty;
+            defaultBranchProtected |= RuleCanMatchBranch(pattern, defaultBranch);
+            requiresReviews |= ReadBoolean(rule, "requiresApprovingReviews");
+            requiresStatusChecks |= ReadBoolean(rule, "requiresStatusChecks");
+            requiredApprovals = Math.Max(
+                requiredApprovals,
+                ReadInteger(rule, "requiredApprovingReviewCount"));
+
+            if (rule.TryGetProperty("requiredStatusCheckContexts", out JsonElement checkContexts)
+                && checkContexts.ValueKind == JsonValueKind.Array)
+            {
+                foreach (JsonElement context in checkContexts.EnumerateArray())
+                {
+                    if (context.ValueKind == JsonValueKind.String
+                        && context.GetString() is { Length: > 0 } value)
+                    {
+                        contexts.Add(value);
+                    }
+                }
+            }
+        }
+
+        return new GitHubBranchProtectionSummary(
+            IsKnown: true,
+            defaultBranchProtected,
+            totalCount,
+            requiresReviews,
+            requiredApprovals,
+            requiresStatusChecks,
+            contexts.Order(StringComparer.Ordinal).ToArray());
+    }
+
+    private static GitHubActionsStatusSummary ReadActionsStatus(JsonElement repository)
+    {
+        if (!repository.TryGetProperty("defaultBranchRef", out JsonElement branch)
+            || branch.ValueKind != JsonValueKind.Object
+            || !branch.TryGetProperty("target", out JsonElement target)
+            || target.ValueKind != JsonValueKind.Object
+            || !target.TryGetProperty("statusCheckRollup", out JsonElement statusCheckRollup)
+            || statusCheckRollup.ValueKind is JsonValueKind.Null or JsonValueKind.Undefined)
+        {
+            return new GitHubActionsStatusSummary(
+                IsKnown: true,
+                DefaultBranchStatusCheckState: null);
+        }
+
+        return new GitHubActionsStatusSummary(
+            IsKnown: true,
+            ReadOptionalString(statusCheckRollup, "state"));
+    }
+
+    private static bool RuleCanMatchBranch(string pattern, string branch)
+    {
+        if (string.IsNullOrWhiteSpace(pattern) || string.IsNullOrWhiteSpace(branch))
+        {
+            return false;
+        }
+
+        if (string.Equals(pattern, branch, StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        if (pattern == "*")
+        {
+            return true;
+        }
+
+        if (pattern.EndsWith('*') && branch.StartsWith(pattern[..^1], StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        return pattern.StartsWith('*') && branch.EndsWith(pattern[1..], StringComparison.Ordinal);
+    }
+
+    private static RepositoryVisibility MapVisibility(string? visibility) =>
+        visibility?.ToUpperInvariant() switch
+        {
+            "PRIVATE" => RepositoryVisibility.Private,
+            "INTERNAL" => RepositoryVisibility.Internal,
+            _ => RepositoryVisibility.Public,
+        };
+
+    private static int ReadConnectionTotalCount(JsonElement element, string propertyName)
+    {
+        if (!element.TryGetProperty(propertyName, out JsonElement connection)
+            || connection.ValueKind != JsonValueKind.Object)
+        {
+            return 0;
+        }
+
+        return ReadInteger(connection, "totalCount");
+    }
+
+    private static int ReadInteger(JsonElement element, string propertyName)
+    {
+        if (!element.TryGetProperty(propertyName, out JsonElement property))
+        {
+            return 0;
+        }
+
+        return property.ValueKind == JsonValueKind.Number && property.TryGetInt32(out int value)
+            ? value
+            : 0;
+    }
+
+    private static bool ReadBoolean(JsonElement element, string propertyName)
+    {
+        if (!element.TryGetProperty(propertyName, out JsonElement property))
+        {
+            return false;
+        }
+
+        return property.ValueKind == JsonValueKind.True
+            || (property.ValueKind == JsonValueKind.String
+                && bool.TryParse(property.GetString(), out bool value)
+                && value);
+    }
+
+    private static Uri BuildHttpsCloneUrl(string owner, string name) =>
+        new($"https://github.com/{owner}/{name}.git");
+
+    private static Uri ReadRequiredUri(JsonElement element, string propertyName)
+    {
+        string value = ReadRequiredString(element, propertyName);
+
+        return Uri.TryCreate(value, UriKind.Absolute, out Uri? uri)
+            ? uri
+            : throw new InvalidOperationException($"GitHub response field '{propertyName}' was not an absolute URI.");
+    }
+
+    private static Uri? ReadOptionalUri(JsonElement element, string propertyName)
+    {
+        string? value = ReadOptionalString(element, propertyName);
+
+        return value is not null && Uri.TryCreate(value, UriKind.Absolute, out Uri? uri)
+            ? uri
+            : null;
+    }
+
+    private static DateOnly? ReadDateOnly(JsonElement element, string propertyName)
+    {
+        string? value = ReadOptionalString(element, propertyName);
+
+        return value is not null
+            && DateOnly.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.None, out DateOnly date)
+                ? date
+                : null;
+    }
+
+    private static string ReadRequiredString(JsonElement element, string propertyName) =>
+        ReadOptionalString(element, propertyName) is { Length: > 0 } value
+            ? value
+            : throw new InvalidOperationException($"GitHub response field '{propertyName}' was missing or empty.");
+
+    private static string? ReadOptionalString(JsonElement element, string propertyName)
+    {
+        if (!element.TryGetProperty(propertyName, out JsonElement property)
+            || property.ValueKind == JsonValueKind.Null
+            || property.ValueKind == JsonValueKind.Undefined)
+        {
+            return null;
+        }
+
+        return property.ValueKind == JsonValueKind.String
+            ? property.GetString()
+            : property.ToString();
+    }
+
+    private static string? TryReadGitHubMessage(string body)
+    {
+        if (string.IsNullOrWhiteSpace(body))
+        {
+            return null;
+        }
+
+        try
+        {
+            using JsonDocument document = JsonDocument.Parse(body);
+            return ReadOptionalString(document.RootElement, "message");
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
     }
 
     private static string RequireNonEmpty(string value, string parameterName)
@@ -267,11 +692,6 @@ public sealed class GitHubRepositoryClient(HttpClient httpClient) : IGitHubRepos
         IReadOnlyList<string> TokenScopes,
         int? RateLimitRemaining,
         DateTimeOffset? RateLimitResetUtc);
-
-    private sealed record GitHubSearchResponse
-    {
-        public IReadOnlyList<GitHubRepositoryResponse> Items { get; init; } = [];
-    }
 
     private sealed record GitHubRepositoryResponse
     {
@@ -315,4 +735,122 @@ public sealed class GitHubRepositoryClient(HttpClient httpClient) : IGitHubRepos
 
         public bool Pull { get; init; }
     }
+
+    private sealed record GraphQlRequest(string Query, object Variables);
+
+    private const string RepositoryFieldsFragment =
+        """
+        fragment RepositoryFields on Repository {
+          owner {
+            login
+          }
+          name
+          url
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                statusCheckRollup {
+                  state
+                }
+              }
+            }
+          }
+          visibility
+          isArchived
+          issues(states: OPEN) {
+            totalCount
+          }
+          pullRequests(states: OPEN) {
+            totalCount
+          }
+          labels(first: 50, orderBy: { field: NAME, direction: ASC }) {
+            nodes {
+              name
+              color
+              description
+            }
+          }
+          milestones(first: 50, states: OPEN, orderBy: { field: DUE_DATE, direction: ASC }) {
+            nodes {
+              title
+              state
+              dueOn
+            }
+          }
+          branchProtectionRules(first: 20) {
+            totalCount
+            nodes {
+              pattern
+              requiresApprovingReviews
+              requiredApprovingReviewCount
+              requiresStatusChecks
+              requiredStatusCheckContexts
+            }
+          }
+        }
+        """;
+
+    private static readonly string ViewerOrganizationsQuery =
+        $$"""
+        query($after: String) {
+          viewer {
+            organizations(first: {{PageSize}}, after: $after) {
+              nodes {
+                login
+                name
+                description
+                url
+                avatarUrl
+              }
+              pageInfo {
+                hasNextPage
+                endCursor
+              }
+            }
+          }
+        }
+        """;
+
+    private static readonly string ViewerRepositoriesQuery =
+        $$"""
+        query($after: String) {
+          viewer {
+            repositories(
+              first: {{PageSize}},
+              after: $after,
+              affiliations: [OWNER, COLLABORATOR, ORGANIZATION_MEMBER],
+              orderBy: { field: NAME, direction: ASC }) {
+              nodes {
+                ...RepositoryFields
+              }
+              pageInfo {
+                hasNextPage
+                endCursor
+              }
+            }
+          }
+        }
+
+        {{RepositoryFieldsFragment}}
+        """;
+
+    private static readonly string SearchRepositoriesQuery =
+        $$"""
+        query($query: String!, $after: String) {
+          search(query: $query, type: REPOSITORY, first: {{PageSize}}, after: $after) {
+            nodes {
+              ... on Repository {
+                ...RepositoryFields
+              }
+            }
+            pageInfo {
+              hasNextPage
+              endCursor
+            }
+          }
+        }
+
+        {{RepositoryFieldsFragment}}
+        """;
 }

--- a/src/Conductor.Infrastructure.GitHub/GitHubServiceCollectionExtensions.cs
+++ b/src/Conductor.Infrastructure.GitHub/GitHubServiceCollectionExtensions.cs
@@ -14,7 +14,7 @@ public static class GitHubServiceCollectionExtensions
             client =>
             {
                 client.BaseAddress = new Uri("https://api.github.com/");
-                client.Timeout = TimeSpan.FromSeconds(10);
+                client.Timeout = TimeSpan.FromSeconds(30);
             });
 
         return services;

--- a/tests/Conductor.Core.Tests/FakeGitHubRepositoryClientTests.cs
+++ b/tests/Conductor.Core.Tests/FakeGitHubRepositoryClientTests.cs
@@ -8,6 +8,43 @@ namespace Conductor.Core.Tests;
 public sealed class FakeGitHubRepositoryClientTests
 {
     [Fact]
+    public async Task ListOrganizationsAsync_Returns_Seeded_Organizations()
+    {
+        var client = new FakeGitHubRepositoryClient();
+        client.AddOrganization(new GitHubOrganizationSummary(
+            "ReleasedGroup",
+            "Released Group",
+            new Uri("https://github.com/ReleasedGroup"),
+            AvatarUrl: null,
+            Description: "Delivery tooling"));
+
+        IReadOnlyList<GitHubOrganizationSummary> organizations =
+            await client.ListOrganizationsAsync(CancellationToken.None);
+
+        GitHubOrganizationSummary organization = Assert.Single(organizations);
+        Assert.Equal("ReleasedGroup", organization.Login);
+        Assert.Equal("Released Group", organization.DisplayName);
+        Assert.Equal("Delivery tooling", organization.Description);
+    }
+
+    [Fact]
+    public async Task ListRepositoriesAsync_Returns_Seeded_Repositories()
+    {
+        var client = new FakeGitHubRepositoryClient(
+            [
+                Repository("ReleasedGroup", "TheConductor"),
+                Repository("ReleasedGroup", "api-service"),
+            ]);
+
+        IReadOnlyList<GitHubRepositorySummary> repositories =
+            await client.ListRepositoriesAsync(CancellationToken.None);
+
+        Assert.Equal(
+            ["ReleasedGroup/TheConductor", "ReleasedGroup/api-service"],
+            repositories.Select(repository => repository.FullName));
+    }
+
+    [Fact]
     public async Task SearchRepositoriesAsync_Filters_Seeded_Repositories_Deterministically()
     {
         var client = new FakeGitHubRepositoryClient(

--- a/tests/Conductor.Integration.Tests/GitHubRepositoryClientTests.cs
+++ b/tests/Conductor.Integration.Tests/GitHubRepositoryClientTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
-using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
 using Conductor.Core.Abstractions.GitHub;
 using Conductor.Core.Domain;
 using Conductor.Core.Domain.Repositories;
@@ -58,8 +59,8 @@ public sealed class GitHubRepositoryClientTests
         Assert.Equal("GET /repos/ReleasedGroup/TheConductor", $"{request.Method} {request.Uri.AbsolutePath}");
         Assert.Equal("Bearer", request.AuthorizationScheme);
         Assert.Equal("ghp_selected_pat", request.AuthorizationParameter);
-        Assert.Contains("application/vnd.github+json", request.Accept);
-        Assert.Contains("Conductor/1.0", request.UserAgent);
+        Assert.Contains("application/vnd.github+json", request.Accept, StringComparison.Ordinal);
+        Assert.Contains("Conductor/1.0", request.UserAgent, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -155,45 +156,212 @@ public sealed class GitHubRepositoryClientTests
     }
 
     [Fact]
-    public async Task SearchRepositoriesAsync_Maps_Search_Response_Metadata()
+    public async Task ListOrganizationsAsync_Maps_Accessible_Organizations()
     {
         var handler = new QueueHandler(_ => JsonResponse(
-            HttpStatusCode.OK,
             """
             {
-              "items": [
-                {
-                  "owner": { "login": "ReleasedGroup" },
-                  "name": "TheConductor",
-                  "default_branch": "main",
-                  "clone_url": "https://github.com/ReleasedGroup/TheConductor.git",
-                  "html_url": "https://github.com/ReleasedGroup/TheConductor",
-                  "private": true,
-                  "visibility": "internal",
-                  "archived": false
+              "data": {
+                "viewer": {
+                  "organizations": {
+                    "nodes": [
+                      {
+                        "login": "ReleasedGroup",
+                        "name": "Released Group",
+                        "description": "Delivery tooling",
+                        "url": "https://github.com/ReleasedGroup",
+                        "avatarUrl": "https://avatars.githubusercontent.com/u/42?v=4"
+                      }
+                    ],
+                    "pageInfo": {
+                      "hasNextPage": false,
+                      "endCursor": null
+                    }
+                  }
                 }
-              ]
+              }
             }
             """));
         GitHubRepositoryClient client = CreateClient(handler);
 
-        IReadOnlyList<GitHubRepositorySummary> repositories = await client.SearchRepositoriesAsync(
-            "releasedgroup conductor",
-            CancellationToken.None);
+        IReadOnlyList<GitHubOrganizationSummary> organizations =
+            await client.ListOrganizationsAsync(CancellationToken.None);
+
+        GitHubOrganizationSummary organization = Assert.Single(organizations);
+        Assert.Equal("ReleasedGroup", organization.Login);
+        Assert.Equal("Released Group", organization.DisplayName);
+        Assert.Equal(new Uri("https://github.com/ReleasedGroup"), organization.WebUrl);
+        Assert.Equal(new Uri("https://avatars.githubusercontent.com/u/42?v=4"), organization.AvatarUrl);
+        Assert.Equal("Delivery tooling", organization.Description);
+        Assert.Equal("POST /graphql", Format(Assert.Single(handler.Requests)));
+        Assert.Contains("organizations", handler.Requests[0].Content ?? string.Empty, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ListRepositoriesAsync_Maps_Core_Metadata()
+    {
+        var handler = new QueueHandler(_ => JsonResponse(
+            """
+            {
+              "data": {
+                "viewer": {
+                  "repositories": {
+                    "nodes": [
+                      {
+                        "owner": {
+                          "login": "ReleasedGroup"
+                        },
+                        "name": "TheConductor",
+                        "url": "https://github.com/ReleasedGroup/TheConductor",
+                        "defaultBranchRef": {
+                          "name": "main",
+                          "target": {
+                            "statusCheckRollup": {
+                              "state": "SUCCESS"
+                            }
+                          }
+                        },
+                        "visibility": "PRIVATE",
+                        "isArchived": false,
+                        "issues": {
+                          "totalCount": 3
+                        },
+                        "pullRequests": {
+                          "totalCount": 2
+                        },
+                        "labels": {
+                          "nodes": [
+                            {
+                              "name": "bug",
+                              "color": "d73a4a",
+                              "description": "Something is not working"
+                            }
+                          ]
+                        },
+                        "milestones": {
+                          "nodes": [
+                            {
+                              "title": "Sprint 5",
+                              "state": "OPEN",
+                              "dueOn": "2026-05-15"
+                            }
+                          ]
+                        },
+                        "branchProtectionRules": {
+                          "totalCount": 1,
+                          "nodes": [
+                            {
+                              "pattern": "main",
+                              "requiresApprovingReviews": true,
+                              "requiredApprovingReviewCount": 2,
+                              "requiresStatusChecks": true,
+                              "requiredStatusCheckContexts": [
+                                "build",
+                                "test"
+                              ]
+                            }
+                          ]
+                        }
+                      }
+                    ],
+                    "pageInfo": {
+                      "hasNextPage": false,
+                      "endCursor": null
+                    }
+                  }
+                }
+              }
+            }
+            """));
+        GitHubRepositoryClient client = CreateClient(handler);
+
+        IReadOnlyList<GitHubRepositorySummary> repositories =
+            await client.ListRepositoriesAsync(CancellationToken.None);
 
         GitHubRepositorySummary repository = Assert.Single(repositories);
         Assert.Equal("ReleasedGroup", repository.Owner);
         Assert.Equal("TheConductor", repository.Name);
+        Assert.Equal("ReleasedGroup/TheConductor", repository.FullName);
         Assert.Equal("main", repository.DefaultBranch);
         Assert.Equal(new Uri("https://github.com/ReleasedGroup/TheConductor.git"), repository.CloneUrl);
         Assert.Equal(new Uri("https://github.com/ReleasedGroup/TheConductor"), repository.WebUrl);
-        Assert.Equal(RepositoryVisibility.Internal, repository.Visibility);
+        Assert.Equal(RepositoryVisibility.Private, repository.Visibility);
         Assert.False(repository.IsArchived);
+        Assert.Equal(3, repository.OpenIssueCount);
+        Assert.Equal(2, repository.OpenPullRequestCount);
+        Assert.Equal("bug", Assert.Single(repository.Labels).Name);
+        Assert.Equal("Sprint 5", Assert.Single(repository.Milestones).Title);
+        Assert.Equal(new DateOnly(2026, 5, 15), repository.Milestones[0].DueOn);
+        Assert.True(repository.BranchProtection.IsKnown);
+        Assert.True(repository.BranchProtection.DefaultBranchProtected);
+        Assert.True(repository.BranchProtection.RequiresPullRequestReviews);
+        Assert.Equal(2, repository.BranchProtection.RequiredApprovingReviewCount);
+        Assert.True(repository.BranchProtection.RequiresStatusChecks);
+        Assert.Equal(["build", "test"], repository.BranchProtection.RequiredStatusCheckContexts);
+        Assert.True(repository.ActionsStatus.IsKnown);
+        Assert.Equal("SUCCESS", repository.ActionsStatus.DefaultBranchStatusCheckState);
+    }
 
-        RecordedRequest request = Assert.Single(handler.Requests);
-        Assert.Equal("GET /search/repositories", $"{request.Method} {request.Uri.AbsolutePath}");
-        Assert.Equal("?q=releasedgroup%20conductor&per_page=25", request.Uri.Query);
-        Assert.Null(request.AuthorizationScheme);
+    [Fact]
+    public async Task SearchRepositoriesAsync_Sends_Query_And_Maps_Results()
+    {
+        var handler = new QueueHandler(_ => JsonResponse(
+            """
+            {
+              "data": {
+                "search": {
+                  "nodes": [
+                    {
+                      "owner": {
+                        "login": "ReleasedGroup"
+                      },
+                      "name": "ArchivedTool",
+                      "url": "https://github.com/ReleasedGroup/ArchivedTool",
+                      "defaultBranchRef": null,
+                      "visibility": "PUBLIC",
+                      "isArchived": true,
+                      "issues": {
+                        "totalCount": 0
+                      },
+                      "pullRequests": {
+                        "totalCount": 0
+                      },
+                      "labels": {
+                        "nodes": []
+                      },
+                      "milestones": {
+                        "nodes": []
+                      },
+                      "branchProtectionRules": {
+                        "totalCount": 0,
+                        "nodes": []
+                      }
+                    }
+                  ],
+                  "pageInfo": {
+                    "hasNextPage": false,
+                    "endCursor": null
+                  }
+                }
+              }
+            }
+            """));
+        GitHubRepositoryClient client = CreateClient(handler);
+
+        IReadOnlyList<GitHubRepositorySummary> repositories =
+            await client.SearchRepositoriesAsync("org:ReleasedGroup conductor", CancellationToken.None);
+
+        GitHubRepositorySummary repository = Assert.Single(repositories);
+        Assert.Equal("ArchivedTool", repository.Name);
+        Assert.Equal(string.Empty, repository.DefaultBranch);
+        Assert.True(repository.IsArchived);
+        Assert.Equal(RepositoryVisibility.Public, repository.Visibility);
+        Assert.Equal(GitHubBranchProtectionSummary.None, repository.BranchProtection);
+
+        using JsonDocument requestPayload = JsonDocument.Parse(handler.Requests[0].Content!);
+        Assert.Equal(
+            "org:ReleasedGroup conductor",
+            requestPayload.RootElement.GetProperty("variables").GetProperty("query").GetString());
     }
 
     [Fact]
@@ -225,14 +393,34 @@ public sealed class GitHubRepositoryClientTests
         return new GitHubRepositoryClient(httpClient);
     }
 
-    private static HttpResponseMessage JsonResponse(HttpStatusCode statusCode, string json)
-    {
-        var response = new HttpResponseMessage(statusCode)
+    private static string Format(RecordedRequest request) =>
+        $"{request.Method} {request.Uri.AbsolutePath}";
+
+    private static HttpResponseMessage JsonResponse(string json) =>
+        JsonResponse(HttpStatusCode.OK, json);
+
+    private static HttpResponseMessage JsonResponse(HttpStatusCode statusCode, string json) =>
+        new(statusCode)
         {
-            Content = new StringContent(json),
+            Content = new StringContent(json, Encoding.UTF8, "application/json"),
         };
-        response.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
-        return response;
+
+    private static async Task<RecordedRequest> RecordRequestAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        string? content = request.Content is null
+            ? null
+            : await request.Content.ReadAsStringAsync(cancellationToken);
+
+        return new RecordedRequest(
+            request.Method.Method,
+            request.RequestUri ?? throw new InvalidOperationException("Request URI was not set."),
+            request.Headers.Authorization?.Scheme,
+            request.Headers.Authorization?.Parameter,
+            string.Join(" ", request.Headers.UserAgent.Select(value => value.ToString())),
+            string.Join(", ", request.Headers.Accept.Select(value => value.MediaType)),
+            content);
     }
 
     private sealed class QueueHandler(
@@ -242,20 +430,14 @@ public sealed class GitHubRepositoryClientTests
 
         public List<RecordedRequest> Requests { get; } = [];
 
-        protected override Task<HttpResponseMessage> SendAsync(
+        protected override async Task<HttpResponseMessage> SendAsync(
             HttpRequestMessage request,
             CancellationToken cancellationToken)
         {
-            var recordedRequest = new RecordedRequest(
-                request.Method.Method,
-                request.RequestUri ?? throw new InvalidOperationException("Request URI was not set."),
-                request.Headers.Authorization?.Scheme,
-                request.Headers.Authorization?.Parameter,
-                string.Join(" ", request.Headers.UserAgent.Select(value => value.ToString())),
-                string.Join(", ", request.Headers.Accept.Select(value => value.MediaType)));
+            RecordedRequest recordedRequest = await RecordRequestAsync(request, cancellationToken);
 
             Requests.Add(recordedRequest);
-            return Task.FromResult(responses.Dequeue()(recordedRequest));
+            return responses.Dequeue()(recordedRequest);
         }
     }
 
@@ -265,5 +447,6 @@ public sealed class GitHubRepositoryClientTests
         string? AuthorizationScheme,
         string? AuthorizationParameter,
         string UserAgent,
-        string Accept);
+        string Accept,
+        string? Content);
 }


### PR DESCRIPTION
## Summary
- Add a GitHub GraphQL repository discovery client for accessible organizations, accessible repositories, and repository search.
- Expand repository summaries with visibility, open issue/PR counts, labels, milestones, branch protection, and default-branch status-check state.
- Preserve the current main-branch PAT repository access validation flow on the same GitHub client and fake test client.
- Register the GitHub client in host DI and document discovery plus credential-check behavior.

## Validation
- `dotnet restore Conductor.slnx`: passed with no errors or warnings
- `dotnet build Conductor.slnx --no-restore --warnaserror`: passed with no errors or warnings
- `dotnet test Conductor.slnx --no-build --collect:"XPlat Code Coverage"`: passed with no errors or warnings
- `dotnet format Conductor.slnx --no-restore --verify-no-changes`: passed with no errors or warnings
- `./scripts/validate-docs.ps1`: passed
- `git diff --check`: passed

## Notes
- Rebased onto current `main` at `d055794` and resolved overlapping GitHub client changes from the repository import and PAT validation work.
- Includes a one-line trailing-whitespace cleanup in `docs/writeup.md` so the docs workflow remains green on the latest main.

Closes #46
