### PR TITLE
[codex] Cover repository import audit fields

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -105,7 +105,7 @@ Behavior:
 - Validates `owner/name` repository identity and derives GitHub clone/web URLs when explicit URLs are not provided.
 - Creates or updates the repository registry record.
 - Creates a `NotProvisioned` Symphony instance shell when orchestration is requested.
-- Records an audit event for the import.
+- Records an audit event for the import with the actor from `requestedByUserId` or `system`, the target repository identifier, the import timestamp, a `Succeeded` outcome, and metadata containing the repository full name and optional instance shell outcome.
 
 Responses:
 

--- a/tests/Conductor.Persistence.Tests/SqliteRepositoryImportServiceTests.cs
+++ b/tests/Conductor.Persistence.Tests/SqliteRepositoryImportServiceTests.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Text.Json;
 using Conductor.Core.Application.Repositories;
 using Conductor.Core.Domain;
 using Conductor.Core.Domain.Auditing;
@@ -54,6 +55,20 @@ public sealed class SqliteRepositoryImportServiceTests
         Assert.Equal(CredentialInheritanceMode.None, instance.GitHubCredentialInheritanceMode);
         Assert.Equal("ImportRepository", auditEvent.Action);
         Assert.Equal("nick", auditEvent.ActorUserId);
+        Assert.Equal("Repository", auditEvent.TargetResourceType);
+        Assert.Equal(repository.Id.ToString(), auditEvent.TargetResourceId);
+        Assert.Equal(importedAtUtc, auditEvent.OccurredAtUtc);
+        Assert.Equal(AuditEventOutcome.Succeeded, auditEvent.Outcome);
+        Assert.Equal("Imported repository ReleasedGroup/TheConductor.", auditEvent.Message);
+
+        using JsonDocument auditMetadata = JsonDocument.Parse(auditEvent.MetadataJson!);
+        JsonElement metadata = auditMetadata.RootElement;
+
+        Assert.Equal("ReleasedGroup/TheConductor", metadata.GetProperty("repositoryFullName").GetString());
+        Assert.True(metadata.GetProperty("createdRepository").GetBoolean());
+        Assert.True(metadata.GetProperty("createSymphonyInstance").GetBoolean());
+        Assert.True(metadata.GetProperty("createdSymphonyInstance").GetBoolean());
+        Assert.Equal(instance.Id.ToString(), metadata.GetProperty("symphonyInstanceId").GetString());
     }
 
     [Fact]


### PR DESCRIPTION
Closes #52.

## Summary
- Adds persistence regression coverage for repository import audit actor, target repository, timestamp, outcome, message, and metadata fields.
- Documents the `POST /api/repos/import` audit event details in the API guide.

## Validation
- `dotnet test tests\Conductor.Persistence.Tests\Conductor.Persistence.Tests.csproj --filter SqliteRepositoryImportServiceTests`
- `dotnet restore Conductor.slnx`
- `dotnet build Conductor.slnx --no-restore --warnaserror`
- `dotnet test Conductor.slnx --no-build`
- `dotnet format Conductor.slnx --verify-no-changes`
- `pwsh -File scripts\validate-docs.ps1`