### PR TITLE
Link repository imports to projects

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -91,6 +91,7 @@ Request:
   "repositoryFullName": "ReleasedGroup/TheConductor",
   "defaultBranch": "main",
   "visibility": "Private",
+  "projectId": "13d27b97-d3aa-4a97-9f52-c598eac89df9",
   "createSymphonyInstance": true,
   "instanceBaseUrl": "http://localhost:8080/",
   "port": 8080,
@@ -103,11 +104,12 @@ Request:
 Behavior:
 
 - Validates `owner/name` repository identity and derives GitHub clone/web URLs when explicit URLs are not provided.
+- Validates the selected project when `projectId` is supplied and links the imported repository to that project.
 - Creates or updates the repository registry record.
 - Creates a `NotProvisioned` Symphony instance shell when orchestration is requested.
 - Records an audit event for the import.
 
 Responses:
 
-- `201 Created` with repository and optional instance identifiers.
+- `201 Created` with repository, linked project, and optional instance identifiers.
 - `400 Bad Request` with validation errors when repository identity, instance URL, port, or specific secret references are invalid.

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -24,4 +24,6 @@ If the health or runtime endpoint cannot be reached, Conductor shows the validat
 
 Use the Repositories page to import a GitHub repository by `owner/name`. The initial flow stores repository metadata, optional project assignment, visibility, default branch, and archived state.
 
+When a project is selected during import, the repository is linked immediately and the import result confirms the project association.
+
 The page can also create a first Symphony instance shell in `NotProvisioned` state. The shell captures execution mode, instance URL, port, release selector, and credential inheritance choices so later provisioning work can start from a validated record.

--- a/src/Conductor.Core/Application/Repositories/IRepositoryImportService.cs
+++ b/src/Conductor.Core/Application/Repositories/IRepositoryImportService.cs
@@ -43,7 +43,9 @@ public sealed record RepositoryImportResult(
     string? SymphonyInstanceId,
     bool CreatedSymphonyInstance,
     string? SymphonyInstanceDisplayName,
-    DateTimeOffset ImportedAtUtc);
+    DateTimeOffset ImportedAtUtc,
+    string? ProjectId = null,
+    string? ProjectName = null);
 
 public sealed class RepositoryImportValidationException : Exception
 {

--- a/src/Conductor.Host/Components/Pages/Repositories.razor
+++ b/src/Conductor.Host/Components/Pages/Repositories.razor
@@ -47,7 +47,7 @@
                 </label>
                 <label>
                     <span>Project</span>
-                    <select @bind="importForm.ProjectId" disabled="@isSubmitting">
+                    <select id="project-id" @bind="importForm.ProjectId" disabled="@isSubmitting">
                         <option value="">Unassigned</option>
                         @foreach (ProjectListItemProjection project in projects)
                         {
@@ -369,9 +369,13 @@
 
     private static string BuildImportSummary(RepositoryImportResult result)
     {
+        string projectSummary = string.IsNullOrWhiteSpace(result.ProjectName)
+            ? "It is unassigned."
+            : $"Linked to {result.ProjectName}.";
+
         return result.CreatedSymphonyInstance
-            ? $"{result.SymphonyInstanceDisplayName} was created in NotProvisioned state."
-            : "Repository metadata is ready for orchestration setup.";
+            ? $"{projectSummary} {result.SymphonyInstanceDisplayName} was created in NotProvisioned state."
+            : $"{projectSummary} Repository metadata is ready for orchestration setup.";
     }
 
     private sealed class RepositoryImportForm

--- a/src/Conductor.Host/Json/StronglyTypedIdJsonConverter.cs
+++ b/src/Conductor.Host/Json/StronglyTypedIdJsonConverter.cs
@@ -1,0 +1,53 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Conductor.Core.Domain.Ids;
+
+namespace Conductor.Host.Json;
+
+internal delegate bool TryParseStronglyTypedId<TId>(string? value, out TId id)
+    where TId : struct;
+
+internal sealed class StronglyTypedIdJsonConverter<TId> : JsonConverter<TId>
+    where TId : struct
+{
+    private readonly TryParseStronglyTypedId<TId> tryParse;
+
+    public StronglyTypedIdJsonConverter(TryParseStronglyTypedId<TId> tryParse)
+    {
+        this.tryParse = tryParse;
+    }
+
+    public override TId Read(
+        ref Utf8JsonReader reader,
+        Type typeToConvert,
+        JsonSerializerOptions options)
+    {
+        if (reader.TokenType != JsonTokenType.String)
+        {
+            throw new JsonException($"{typeToConvert.Name} must be a GUID string.");
+        }
+
+        string? value = reader.GetString();
+        if (tryParse(value, out TId id))
+        {
+            return id;
+        }
+
+        throw new JsonException($"{typeToConvert.Name} must be a non-empty GUID string.");
+    }
+
+    public override void Write(Utf8JsonWriter writer, TId value, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(value.ToString());
+    }
+}
+
+internal static class StronglyTypedIdJsonConverters
+{
+    public static void AddTo(JsonSerializerOptions options)
+    {
+        options.Converters.Add(new StronglyTypedIdJsonConverter<ProjectId>(ProjectId.TryParse));
+        options.Converters.Add(new StronglyTypedIdJsonConverter<WorkflowProfileId>(WorkflowProfileId.TryParse));
+        options.Converters.Add(new StronglyTypedIdJsonConverter<SecretId>(SecretId.TryParse));
+    }
+}

--- a/src/Conductor.Host/Program.cs
+++ b/src/Conductor.Host/Program.cs
@@ -3,6 +3,7 @@ using Conductor.Core.Application.Dashboard;
 using Conductor.Host.Components;
 using Conductor.Host.Dashboard;
 using Conductor.Host.Endpoints;
+using Conductor.Host.Json;
 using Conductor.Host.Workers;
 using Conductor.Infrastructure.Persistence.Sqlite;
 using Conductor.Infrastructure.Secrets;
@@ -17,6 +18,7 @@ builder.Services
 builder.Services.ConfigureHttpJsonOptions(options =>
 {
     options.SerializerOptions.Converters.Add(new JsonStringEnumConverter());
+    StronglyTypedIdJsonConverters.AddTo(options.SerializerOptions);
 });
 builder.Services.Configure<DashboardProjectionOptions>(
     builder.Configuration.GetSection(DashboardProjectionOptions.SectionName));

--- a/src/Conductor.Infrastructure.Persistence.Sqlite/Repositories/SqliteRepositoryImportService.cs
+++ b/src/Conductor.Infrastructure.Persistence.Sqlite/Repositories/SqliteRepositoryImportService.cs
@@ -30,7 +30,8 @@ internal sealed class SqliteRepositoryImportService : IRepositoryImportService
         CancellationToken cancellationToken = default)
     {
         RepositoryImportPlan plan = RepositoryImportPlan.Create(request);
-        await ValidateReferencesAsync(plan, cancellationToken);
+        RepositoryImportReferenceValidationResult referenceResult =
+            await ValidateReferencesAsync(plan, cancellationToken);
 
         DateTimeOffset now = timeProvider.GetUtcNow();
 
@@ -45,6 +46,8 @@ internal sealed class SqliteRepositoryImportService : IRepositoryImportService
         string metadataJson = JsonSerializer.Serialize(new
         {
             repositoryFullName = plan.FullName.Value,
+            projectId = plan.ProjectId?.ToString(),
+            projectName = referenceResult.ProjectName,
             createdRepository = repositoryResult.CreatedRepository,
             createSymphonyInstance = plan.InstancePlan is not null,
             createdSymphonyInstance = instanceResult.CreatedInstance,
@@ -76,19 +79,32 @@ internal sealed class SqliteRepositoryImportService : IRepositoryImportService
             instanceResult.Instance?.Id.ToString(),
             instanceResult.CreatedInstance,
             instanceResult.Instance?.DisplayName,
-            now);
+            now,
+            plan.ProjectId?.ToString(),
+            referenceResult.ProjectName);
     }
 
-    private async Task ValidateReferencesAsync(
+    private async Task<RepositoryImportReferenceValidationResult> ValidateReferencesAsync(
         RepositoryImportPlan plan,
         CancellationToken cancellationToken)
     {
         Dictionary<string, List<string>> errors = new(StringComparer.Ordinal);
+        string? projectName = null;
 
-        if (plan.ProjectId is { } projectId &&
-            !await dbContext.Projects.AsNoTracking().AnyAsync(project => project.Id == projectId, cancellationToken))
+        if (plan.ProjectId is { } projectId)
         {
-            AddError(errors, nameof(RepositoryImportRequest.ProjectId), "The selected project does not exist.");
+            Project? project = await dbContext.Projects
+                .AsNoTracking()
+                .FirstOrDefaultAsync(candidate => candidate.Id == projectId, cancellationToken);
+
+            if (project is null)
+            {
+                AddError(errors, nameof(RepositoryImportRequest.ProjectId), "The selected project does not exist.");
+            }
+            else
+            {
+                projectName = project.Name;
+            }
         }
 
         if (plan.InstancePlan?.WorkflowProfileId is { } workflowProfileId &&
@@ -117,6 +133,8 @@ internal sealed class SqliteRepositoryImportService : IRepositoryImportService
         {
             throw new RepositoryImportValidationException(ToErrorDictionary(errors));
         }
+
+        return new RepositoryImportReferenceValidationResult(projectName);
     }
 
     private async Task ValidateSecretReferenceAsync(
@@ -267,4 +285,6 @@ internal sealed class SqliteRepositoryImportService : IRepositoryImportService
             item => item.Value.ToArray(),
             StringComparer.Ordinal);
     }
+
+    private sealed record RepositoryImportReferenceValidationResult(string? ProjectName);
 }

--- a/tests/Conductor.Api.Tests/RepositoryImportEndpointTests.cs
+++ b/tests/Conductor.Api.Tests/RepositoryImportEndpointTests.cs
@@ -3,6 +3,9 @@ using System.Net;
 using System.Net.Http.Json;
 using Conductor.Core.Abstractions.Symphony;
 using Conductor.Core.Domain;
+using Conductor.Core.Domain.Ids;
+using Conductor.Core.Domain.Projects;
+using Conductor.Core.Domain.Repositories;
 using Conductor.Infrastructure.Persistence.Sqlite;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
@@ -16,11 +19,15 @@ namespace Conductor.Api.Tests;
 
 public sealed class RepositoryImportEndpointTests
 {
+    private static readonly ProjectId PlatformProjectId =
+        ProjectId.Parse("13d27b97-d3aa-4a97-9f52-c598eac89df9");
+
     [Fact]
     public async Task Import_Creates_Repository_And_Instance_Shell()
     {
         await using RepositoryImportApiFactory factory = new();
         using HttpClient client = factory.CreateClient();
+        await SeedProjectAsync(factory);
 
         HttpResponseMessage response = await client.PostAsJsonAsync(
             "/api/repos/import",
@@ -29,6 +36,7 @@ public sealed class RepositoryImportEndpointTests
                 repositoryFullName = "ReleasedGroup/TheConductor",
                 defaultBranch = "main",
                 visibility = "Private",
+                projectId = PlatformProjectId.ToString(),
                 createSymphonyInstance = true,
                 instanceDisplayName = "Conductor local",
                 executionMode = "LocalProcess",
@@ -44,6 +52,8 @@ public sealed class RepositoryImportEndpointTests
         Assert.NotNull(body);
         Assert.Equal("ReleasedGroup/TheConductor", body.RepositoryFullName);
         Assert.True(body.CreatedRepository);
+        Assert.Equal(PlatformProjectId.ToString(), body.ProjectId);
+        Assert.Equal("Platform", body.ProjectName);
         Assert.True(body.CreatedSymphonyInstance);
         Assert.NotNull(body.SymphonyInstanceId);
 
@@ -53,6 +63,8 @@ public sealed class RepositoryImportEndpointTests
         Assert.Equal(1, await CountAsync(dbContext, "Repositories"));
         Assert.Equal(1, await CountAsync(dbContext, "SymphonyInstances"));
         Assert.Equal(1, await CountAsync(dbContext, "AuditEvents"));
+        Repository repository = await dbContext.Repositories.SingleAsync();
+        Assert.Equal(PlatformProjectId, repository.ProjectId);
     }
 
     [Fact]
@@ -89,6 +101,25 @@ public sealed class RepositoryImportEndpointTests
         object? value = await command.ExecuteScalarAsync();
 
         return Convert.ToInt64(value);
+    }
+
+    private static async Task SeedProjectAsync(RepositoryImportApiFactory factory)
+    {
+        await using AsyncServiceScope scope = factory.Services.CreateAsyncScope();
+        ConductorDbContext dbContext = scope.ServiceProvider.GetRequiredService<ConductorDbContext>();
+        DateTimeOffset now = DateTimeOffset.Parse("2026-04-29T02:00:00Z");
+
+        dbContext.Projects.Add(new Project(
+            PlatformProjectId,
+            "Platform",
+            "ReleasedGroup",
+            description: null,
+            "main",
+            ProjectStatus.Active,
+            now,
+            now));
+
+        await dbContext.SaveChangesAsync();
     }
 
     private sealed class RepositoryImportApiFactory : WebApplicationFactory<Program>
@@ -187,5 +218,7 @@ public sealed class RepositoryImportEndpointTests
         string RepositoryFullName,
         bool CreatedRepository,
         bool CreatedSymphonyInstance,
-        string? SymphonyInstanceId);
+        string? SymphonyInstanceId,
+        string? ProjectId,
+        string? ProjectName);
 }

--- a/tests/Conductor.Blazor.Tests/RepositoriesPageTests.cs
+++ b/tests/Conductor.Blazor.Tests/RepositoriesPageTests.cs
@@ -21,6 +21,7 @@ public sealed class RepositoriesPageTests
 
         IRenderedComponent<Repositories> page = context.Render<Repositories>();
         page.Find("#repository-full-name").Change("ReleasedGroup/TheConductor");
+        page.Find("#project-id").Change(StaticProjectListQueryService.PlatformProjectId.ToString());
         page.Find("#create-instance-shell").Change(true);
         page.Find("#instance-base-url").Change("http://localhost:8080/");
 
@@ -28,10 +29,12 @@ public sealed class RepositoriesPageTests
 
         Assert.NotNull(importService.LastRequest);
         Assert.Equal("ReleasedGroup/TheConductor", importService.LastRequest.RepositoryFullName);
+        Assert.Equal(StaticProjectListQueryService.PlatformProjectId, importService.LastRequest.ProjectId);
         Assert.True(importService.LastRequest.CreateSymphonyInstance);
         Assert.Equal("http://localhost:8080/", importService.LastRequest.InstanceBaseUrl);
         Assert.Equal(CredentialInheritanceMode.InheritDefault, importService.LastRequest.GitHubCredentialInheritanceMode);
         Assert.Contains("ReleasedGroup/TheConductor imported", page.Markup, StringComparison.Ordinal);
+        Assert.Contains("Linked to Platform.", page.Markup, StringComparison.Ordinal);
         Assert.Contains("Conductor local was created in NotProvisioned state.", page.Markup, StringComparison.Ordinal);
         Assert.Contains("Managed repositories", page.Markup, StringComparison.Ordinal);
         Assert.Contains("ReleasedGroup/ExistingService", page.Markup, StringComparison.Ordinal);
@@ -54,7 +57,9 @@ public sealed class RepositoriesPageTests
                 Guid.NewGuid().ToString("D"),
                 CreatedSymphonyInstance: true,
                 "Conductor local",
-                DateTimeOffset.Parse("2026-04-29T02:00:00Z")));
+                DateTimeOffset.Parse("2026-04-29T02:00:00Z"),
+                request.ProjectId?.ToString(),
+                request.ProjectId is null ? null : "Platform"));
         }
     }
 
@@ -89,6 +94,9 @@ public sealed class RepositoriesPageTests
 
     private sealed class StaticProjectListQueryService : IProjectListQueryService
     {
+        public static readonly ProjectId PlatformProjectId =
+            ProjectId.Parse("bdfe0e41-15b5-4d7d-9153-7dd0f6fe1032");
+
         public Task<IReadOnlyList<ProjectListItemProjection>> ListProjectsAsync(
             ProjectListQuery query,
             CancellationToken cancellationToken = default)
@@ -96,7 +104,7 @@ public sealed class RepositoriesPageTests
             IReadOnlyList<ProjectListItemProjection> projects =
             [
                 new ProjectListItemProjection(
-                    ProjectId.New(),
+                    PlatformProjectId,
                     "Platform",
                     "ReleasedGroup",
                     ProjectStatus.Active),

--- a/tests/Conductor.Persistence.Tests/SqliteRepositoryImportServiceTests.cs
+++ b/tests/Conductor.Persistence.Tests/SqliteRepositoryImportServiceTests.cs
@@ -1,7 +1,10 @@
 using System.Globalization;
+using System.Text.Json;
 using Conductor.Core.Application.Repositories;
 using Conductor.Core.Domain;
 using Conductor.Core.Domain.Auditing;
+using Conductor.Core.Domain.Ids;
+using Conductor.Core.Domain.Projects;
 using Conductor.Core.Domain.Repositories;
 using Conductor.Core.Domain.Symphony;
 using Conductor.Infrastructure.Persistence.Sqlite;
@@ -92,6 +95,42 @@ public sealed class SqliteRepositoryImportServiceTests
         Assert.Equal(RepositoryVisibility.Internal, repository.Visibility);
         Assert.Equal(1, await dbContext.SymphonyInstances.CountAsync());
         Assert.Equal(2, await dbContext.AuditEvents.CountAsync());
+    }
+
+    [Fact]
+    public async Task ImportAsync_Assigns_Selected_Project_And_Returns_Project_Metadata()
+    {
+        DateTimeOffset importedAtUtc = DateTimeOffset.Parse("2026-04-29T04:00:00Z");
+        await using ServiceProvider provider = BuildProvider(importedAtUtc);
+        await using AsyncServiceScope scope = provider.CreateAsyncScope();
+        ConductorDbContext dbContext = scope.ServiceProvider.GetRequiredService<ConductorDbContext>();
+        await dbContext.Database.MigrateAsync();
+        ProjectId projectId = ProjectId.New();
+        dbContext.Projects.Add(new Project(
+            projectId,
+            "Platform",
+            "ReleasedGroup",
+            description: null,
+            "main",
+            ProjectStatus.Active,
+            importedAtUtc,
+            importedAtUtc));
+        await dbContext.SaveChangesAsync();
+        IRepositoryImportService importService = scope.ServiceProvider.GetRequiredService<IRepositoryImportService>();
+
+        RepositoryImportResult result = await importService.ImportAsync(new RepositoryImportRequest(
+            "ReleasedGroup/TheConductor",
+            ProjectId: projectId));
+
+        Repository repository = await dbContext.Repositories.SingleAsync();
+        AuditEvent auditEvent = await dbContext.AuditEvents.SingleAsync();
+        using JsonDocument metadata = JsonDocument.Parse(auditEvent.MetadataJson!);
+
+        Assert.Equal(projectId, repository.ProjectId);
+        Assert.Equal(projectId.ToString(), result.ProjectId);
+        Assert.Equal("Platform", result.ProjectName);
+        Assert.Equal(projectId.ToString(), metadata.RootElement.GetProperty("projectId").GetString());
+        Assert.Equal("Platform", metadata.RootElement.GetProperty("projectName").GetString());
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Return linked project metadata from repository import results and audit metadata.
- Show the selected project in the repository import wizard success state.
- Accept strongly typed import IDs as GUID strings in HTTP JSON requests.
- Cover project association through persistence, API, and Blazor tests.

## Validation
- `dotnet restore Conductor.slnx`: passed
- `dotnet build Conductor.slnx --no-restore --warnaserror`: passed with 0 warnings
- `dotnet test Conductor.slnx --no-build`: passed
- `dotnet format Conductor.slnx --no-restore --verify-no-changes`: passed

Closes #50