### PR TITLE
Persist imported repository metadata

### DIFF
--- a/src/Conductor.Core/Abstractions/GitHub/IGitHubRepositoryClient.cs
+++ b/src/Conductor.Core/Abstractions/GitHub/IGitHubRepositoryClient.cs
@@ -1,3 +1,4 @@
+using Conductor.Core.Domain;
 using Conductor.Core.Domain.Repositories;
 
 namespace Conductor.Core.Abstractions.GitHub;
@@ -19,6 +20,7 @@ public sealed record GitHubRepositorySummary(
     string DefaultBranch,
     Uri CloneUrl,
     Uri WebUrl,
+    RepositoryVisibility Visibility,
     bool IsArchived)
 {
     public string FullName => $"{Owner}/{Name}";

--- a/src/Conductor.Core/Application/Repositories/IRepositoryImportService.cs
+++ b/src/Conductor.Core/Application/Repositories/IRepositoryImportService.cs
@@ -1,3 +1,4 @@
+using Conductor.Core.Abstractions.GitHub;
 using Conductor.Core.Common;
 using Conductor.Core.Domain;
 using Conductor.Core.Domain.Ids;
@@ -34,7 +35,26 @@ public sealed record RepositoryImportRequest(
     SecretId? OpenAiCredentialSecretId = null,
     string? WorkflowPath = null,
     string? DataPath = null,
-    string? RequestedByUserId = null);
+    string? RequestedByUserId = null)
+{
+    public static RepositoryImportRequest FromGitHubRepositorySummary(
+        GitHubRepositorySummary repository,
+        ProjectId? projectId = null,
+        bool createSymphonyInstance = false)
+    {
+        ArgumentNullException.ThrowIfNull(repository);
+
+        return new RepositoryImportRequest(
+            repository.FullName,
+            DefaultBranch: repository.DefaultBranch,
+            CloneUrl: repository.CloneUrl.AbsoluteUri,
+            WebUrl: repository.WebUrl.AbsoluteUri,
+            Visibility: repository.Visibility,
+            IsArchived: repository.IsArchived,
+            ProjectId: projectId,
+            CreateSymphonyInstance: createSymphonyInstance);
+    }
+}
 
 public sealed record RepositoryImportResult(
     string RepositoryId,

--- a/src/Conductor.Infrastructure.GitHub/GitHubRepositoryClient.cs
+++ b/src/Conductor.Infrastructure.GitHub/GitHubRepositoryClient.cs
@@ -4,6 +4,7 @@ using System.Net.Http.Headers;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Conductor.Core.Abstractions.GitHub;
+using Conductor.Core.Domain;
 
 namespace Conductor.Infrastructure.GitHub;
 
@@ -40,6 +41,7 @@ public sealed class GitHubRepositoryClient(HttpClient httpClient) : IGitHubRepos
                 item.DefaultBranch,
                 new Uri(item.CloneUrl),
                 new Uri(item.HtmlUrl),
+                MapVisibility(item),
                 item.Archived))
             .ToList();
     }
@@ -162,6 +164,19 @@ public sealed class GitHubRepositoryClient(HttpClient httpClient) : IGitHubRepos
                 permissions.Triage,
                 permissions.Pull);
 
+    private static RepositoryVisibility MapVisibility(GitHubRepositoryResponse repository)
+    {
+        if (Enum.TryParse(repository.Visibility, ignoreCase: true, out RepositoryVisibility visibility) &&
+            Enum.IsDefined(visibility))
+        {
+            return visibility;
+        }
+
+        return repository.IsPrivate
+            ? RepositoryVisibility.Private
+            : RepositoryVisibility.Public;
+    }
+
     private static ValidationResponseMetadata ReadMetadata(HttpResponseMessage response) =>
         new(
             ReadTokenScopes(response),
@@ -272,6 +287,11 @@ public sealed class GitHubRepositoryClient(HttpClient httpClient) : IGitHubRepos
 
         [JsonPropertyName("html_url")]
         public string HtmlUrl { get; init; } = string.Empty;
+
+        [JsonPropertyName("private")]
+        public bool IsPrivate { get; init; }
+
+        public string? Visibility { get; init; }
 
         public bool Archived { get; init; }
 

--- a/tests/Conductor.Core.Tests/FakeGitHubRepositoryClientTests.cs
+++ b/tests/Conductor.Core.Tests/FakeGitHubRepositoryClientTests.cs
@@ -1,4 +1,5 @@
 using Conductor.Core.Abstractions.GitHub;
+using Conductor.Core.Domain;
 using Conductor.Core.Domain.Repositories;
 using Conductor.Infrastructure.GitHub;
 
@@ -109,5 +110,6 @@ public sealed class FakeGitHubRepositoryClientTests
             "main",
             new Uri($"https://github.com/{owner}/{name}.git"),
             new Uri($"https://github.com/{owner}/{name}"),
+            RepositoryVisibility.Public,
             IsArchived: false);
 }

--- a/tests/Conductor.Core.Tests/RepositoryImportModelTests.cs
+++ b/tests/Conductor.Core.Tests/RepositoryImportModelTests.cs
@@ -1,3 +1,4 @@
+using Conductor.Core.Abstractions.GitHub;
 using Conductor.Core.Application.Repositories;
 using Conductor.Core.Domain;
 using Conductor.Core.Domain.Ids;
@@ -40,6 +41,33 @@ public sealed class RepositoryImportModelTests
         Assert.Equal("v1.2.3", plan.InstancePlan.ReleaseSelector.ToString());
         Assert.Equal(CredentialInheritanceMode.None, plan.InstancePlan.GitHubCredential.InheritanceMode);
         Assert.Equal("./instances/theconductor/WORKFLOW.md", plan.InstancePlan.WorkflowPath);
+    }
+
+    [Fact]
+    public void RepositoryImportRequest_FromGitHubRepositorySummary_Copies_Discovered_Metadata()
+    {
+        ProjectId projectId = ProjectId.New();
+        GitHubRepositorySummary repository = new(
+            "ReleasedGroup",
+            "TheConductor",
+            "trunk",
+            new Uri("https://github.com/ReleasedGroup/TheConductor.git"),
+            new Uri("https://github.com/ReleasedGroup/TheConductor"),
+            RepositoryVisibility.Internal,
+            IsArchived: true);
+
+        RepositoryImportRequest request = RepositoryImportRequest.FromGitHubRepositorySummary(
+            repository,
+            projectId);
+
+        Assert.Equal("ReleasedGroup/TheConductor", request.RepositoryFullName);
+        Assert.Equal("trunk", request.DefaultBranch);
+        Assert.Equal("https://github.com/ReleasedGroup/TheConductor.git", request.CloneUrl);
+        Assert.Equal("https://github.com/ReleasedGroup/TheConductor", request.WebUrl);
+        Assert.Equal(RepositoryVisibility.Internal, request.Visibility);
+        Assert.True(request.IsArchived);
+        Assert.Equal(projectId, request.ProjectId);
+        Assert.False(request.CreateSymphonyInstance);
     }
 
     [Fact]

--- a/tests/Conductor.Integration.Tests/GitHubRepositoryClientTests.cs
+++ b/tests/Conductor.Integration.Tests/GitHubRepositoryClientTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Net.Http.Headers;
 using Conductor.Core.Abstractions.GitHub;
+using Conductor.Core.Domain;
 using Conductor.Core.Domain.Repositories;
 using Conductor.Infrastructure.GitHub;
 using Microsoft.Extensions.DependencyInjection;
@@ -154,7 +155,7 @@ public sealed class GitHubRepositoryClientTests
     }
 
     [Fact]
-    public async Task SearchRepositoriesAsync_Maps_Public_Search_Response()
+    public async Task SearchRepositoriesAsync_Maps_Search_Response_Metadata()
     {
         var handler = new QueueHandler(_ => JsonResponse(
             HttpStatusCode.OK,
@@ -167,6 +168,8 @@ public sealed class GitHubRepositoryClientTests
                   "default_branch": "main",
                   "clone_url": "https://github.com/ReleasedGroup/TheConductor.git",
                   "html_url": "https://github.com/ReleasedGroup/TheConductor",
+                  "private": true,
+                  "visibility": "internal",
                   "archived": false
                 }
               ]
@@ -183,6 +186,8 @@ public sealed class GitHubRepositoryClientTests
         Assert.Equal("TheConductor", repository.Name);
         Assert.Equal("main", repository.DefaultBranch);
         Assert.Equal(new Uri("https://github.com/ReleasedGroup/TheConductor.git"), repository.CloneUrl);
+        Assert.Equal(new Uri("https://github.com/ReleasedGroup/TheConductor"), repository.WebUrl);
+        Assert.Equal(RepositoryVisibility.Internal, repository.Visibility);
         Assert.False(repository.IsArchived);
 
         RecordedRequest request = Assert.Single(handler.Requests);

--- a/tests/Conductor.Persistence.Tests/SqliteRepositoryImportServiceTests.cs
+++ b/tests/Conductor.Persistence.Tests/SqliteRepositoryImportServiceTests.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using System.Text.Json;
+using Conductor.Core.Abstractions.GitHub;
 using Conductor.Core.Application.Repositories;
 using Conductor.Core.Domain;
 using Conductor.Core.Domain.Auditing;
@@ -71,6 +72,48 @@ public sealed class SqliteRepositoryImportServiceTests
         Assert.True(metadata.GetProperty("createSymphonyInstance").GetBoolean());
         Assert.True(metadata.GetProperty("createdSymphonyInstance").GetBoolean());
         Assert.Equal(instance.Id.ToString(), metadata.GetProperty("symphonyInstanceId").GetString());
+    }
+
+    [Fact]
+    public async Task ImportAsync_Persists_Discovered_Repository_Metadata()
+    {
+        DateTimeOffset importedAtUtc = DateTimeOffset.Parse("2026-04-29T04:00:00Z");
+        await using ServiceProvider provider = BuildProvider(importedAtUtc);
+        await using AsyncServiceScope scope = provider.CreateAsyncScope();
+        ConductorDbContext dbContext = scope.ServiceProvider.GetRequiredService<ConductorDbContext>();
+        await dbContext.Database.MigrateAsync();
+        IRepositoryImportService importService = scope.ServiceProvider.GetRequiredService<IRepositoryImportService>();
+
+        GitHubRepositorySummary discoveredRepository = new(
+            "ReleasedGroup",
+            "TheConductor",
+            "trunk",
+            new Uri("https://github.com/ReleasedGroup/TheConductor.git"),
+            new Uri("https://github.com/ReleasedGroup/TheConductor"),
+            RepositoryVisibility.Internal,
+            IsArchived: true);
+
+        RepositoryImportResult result = await importService.ImportAsync(
+            RepositoryImportRequest.FromGitHubRepositorySummary(discoveredRepository) with
+            {
+                RequestedByUserId = "nick",
+            });
+
+        Repository repository = await dbContext.Repositories.SingleAsync();
+
+        Assert.True(result.CreatedRepository);
+        Assert.False(result.CreatedSymphonyInstance);
+        Assert.Equal("ReleasedGroup/TheConductor", result.RepositoryFullName);
+        Assert.Equal("ReleasedGroup", repository.Owner);
+        Assert.Equal("TheConductor", repository.Name);
+        Assert.Equal("trunk", repository.DefaultBranch);
+        Assert.Equal(discoveredRepository.CloneUrl, repository.CloneUrl);
+        Assert.Equal(discoveredRepository.WebUrl, repository.WebUrl);
+        Assert.Equal(RepositoryVisibility.Internal, repository.Visibility);
+        Assert.True(repository.IsArchived);
+        Assert.Equal(importedAtUtc, repository.LastSyncedAtUtc);
+        Assert.Equal(RepositoryOrchestrationStatus.Ineligible, repository.OrchestrationStatus);
+        Assert.Equal("Archived repositories cannot be orchestrated.", repository.OrchestrationStatusReason);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Add repository visibility to GitHub discovery summaries and map it from the real GitHub search response.
- Add a conversion path from discovered GitHub repository metadata into repository import requests.
- Cover persistence of discovered owner/name, default branch, clone URL, web URL, visibility, and archived status through the SQLite import service.

## Validation
- `dotnet restore Conductor.slnx`: passed
- `dotnet build Conductor.slnx --no-restore --warnaserror`: passed with 0 warnings
- `dotnet test Conductor.slnx --no-build`: passed, 179 tests
- `dotnet format Conductor.slnx --no-restore --verify-no-changes`: passed
- `git diff --check`: passed

Closes #49