### PR TITLE
[codex] Add repository metadata detail pages

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -25,3 +25,5 @@ If the health or runtime endpoint cannot be reached, Conductor shows the validat
 Use the Repositories page to import a GitHub repository by `owner/name`. The initial flow stores repository metadata, optional project assignment, visibility, default branch, and archived state.
 
 The page can also create a first Symphony instance shell in `NotProvisioned` state. The shell captures execution mode, instance URL, port, release selector, and credential inheritance choices so later provisioning work can start from a validated record.
+
+Imported repositories appear in the managed repository registry with project, visibility, default branch, archive state, orchestration eligibility, instance counts, last sync, and latest health metadata. Open a repository row to review its detail page, including clone and web URLs, sync metadata, orchestration status, and active Symphony instances attached to that repository.

--- a/src/Conductor.Core/Application/Queries/RepositoryListQueryService.cs
+++ b/src/Conductor.Core/Application/Queries/RepositoryListQueryService.cs
@@ -8,6 +8,10 @@ public interface IRepositoryListQueryService
     Task<IReadOnlyList<RepositoryListItemProjection>> ListRepositoriesAsync(
         RepositoryListQuery query,
         CancellationToken cancellationToken = default);
+
+    Task<RepositoryDetailProjection?> GetRepositoryAsync(
+        RepositoryId repositoryId,
+        CancellationToken cancellationToken = default);
 }
 
 public sealed record RepositoryListQuery(
@@ -24,8 +28,34 @@ public sealed record RepositoryListItemProjection(
     string Name,
     string FullName,
     string DefaultBranch,
+    Uri CloneUrl,
     Uri WebUrl,
+    RepositoryVisibility Visibility,
     bool IsArchived,
+    DateTimeOffset? LastSyncedAtUtc,
+    RepositoryOrchestrationStatus OrchestrationStatus,
+    string? OrchestrationStatusReason,
+    int InstanceCount,
+    int RunningInstanceCount,
+    InstanceHealthStatus WorstHealthStatus,
+    DateTimeOffset? LastHealthCheckAtUtc);
+
+public sealed record RepositoryDetailProjection(
+    RepositoryId Id,
+    ProjectId? ProjectId,
+    string? ProjectName,
+    RepositoryProvider Provider,
+    string Owner,
+    string Name,
+    string FullName,
+    string DefaultBranch,
+    Uri CloneUrl,
+    Uri WebUrl,
+    RepositoryVisibility Visibility,
+    bool IsArchived,
+    DateTimeOffset? LastSyncedAtUtc,
+    RepositoryOrchestrationStatus OrchestrationStatus,
+    string? OrchestrationStatusReason,
     int InstanceCount,
     int RunningInstanceCount,
     InstanceHealthStatus WorstHealthStatus,

--- a/src/Conductor.Host/Components/Pages/Repositories.razor
+++ b/src/Conductor.Host/Components/Pages/Repositories.razor
@@ -216,10 +216,10 @@
                         <tr>
                             <th scope="col">Repository</th>
                             <th scope="col">Project</th>
-                            <th scope="col">Branch</th>
-                            <th scope="col">Health</th>
+                            <th scope="col">Metadata</th>
+                            <th scope="col">Orchestration</th>
                             <th scope="col">Instances</th>
-                            <th scope="col">Last health</th>
+                            <th scope="col">Last sync</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -233,17 +233,29 @@
                                     <a href="@repository.WebUrl.AbsoluteUri" target="_blank" rel="noreferrer">@repository.Provider</a>
                                 </td>
                                 <td>@(repository.ProjectName ?? "Unassigned")</td>
-                                <td>@repository.DefaultBranch</td>
+                                <td>
+                                    <span>@repository.Visibility</span>
+                                    <small>@repository.DefaultBranch branch</small>
+                                    <small>@(repository.IsArchived ? "Archived" : "Active")</small>
+                                </td>
                                 <td>
                                     <StatusBadge
-                                        Text="@repository.WorstHealthStatus.ToString()"
-                                        Tone="@MapHealthTone(repository.WorstHealthStatus)" />
+                                        Text="@repository.OrchestrationStatus.ToString()"
+                                        Tone="@MapOrchestrationTone(repository.OrchestrationStatus)" />
+                                    @if (!string.IsNullOrWhiteSpace(repository.OrchestrationStatusReason))
+                                    {
+                                        <small>@repository.OrchestrationStatusReason</small>
+                                    }
+                                    <small>@repository.WorstHealthStatus health</small>
                                 </td>
                                 <td>
                                     <span>@repository.InstanceCount total</span>
                                     <small>@repository.RunningInstanceCount running</small>
                                 </td>
-                                <td>@FormatTimestamp(repository.LastHealthCheckAtUtc)</td>
+                                <td>
+                                    <span>@FormatTimestamp(repository.LastSyncedAtUtc)</span>
+                                    <small>Health @FormatTimestamp(repository.LastHealthCheckAtUtc)</small>
+                                </td>
                             </tr>
                         }
                     </tbody>
@@ -352,13 +364,10 @@
             : default;
     }
 
-    private static StatusBadgeTone MapHealthTone(InstanceHealthStatus healthStatus) => healthStatus switch
-    {
-        InstanceHealthStatus.Healthy => StatusBadgeTone.Success,
-        InstanceHealthStatus.Warning => StatusBadgeTone.Warning,
-        InstanceHealthStatus.Critical or InstanceHealthStatus.Offline => StatusBadgeTone.Critical,
-        _ => StatusBadgeTone.Neutral,
-    };
+    private static StatusBadgeTone MapOrchestrationTone(RepositoryOrchestrationStatus orchestrationStatus) =>
+        orchestrationStatus == RepositoryOrchestrationStatus.Eligible
+            ? StatusBadgeTone.Success
+            : StatusBadgeTone.Warning;
 
     private static string FormatTimestamp(DateTimeOffset? timestamp)
     {

--- a/src/Conductor.Host/Components/Pages/RepositoryDetail.razor
+++ b/src/Conductor.Host/Components/Pages/RepositoryDetail.razor
@@ -1,74 +1,180 @@
 @page "/repositories/{RepositoryId:guid}"
+@rendermode InteractiveServer
 @using Conductor.Core.Application.Queries
 @using Conductor.Core.Domain
 @using Conductor.Core.Domain.Ids
-@inject IRepositoryListQueryService RepositoryQueries
-@inject IInstanceSummaryQueryService InstanceQueries
+@inject IRepositoryListQueryService RepositoryListQueryService
+@inject IInstanceSummaryQueryService InstanceSummaryQueryService
 
-<PageTitle>Repository - Conductor</PageTitle>
+<PageTitle>@BuildPageTitle() - Conductor</PageTitle>
 
-<section class="dashboard">
-    @if (Repository is null)
+<section class="repository-detail-page">
+    <header class="dashboard-header">
+        <div>
+            <a class="breadcrumb-link" href="/repositories">Repositories</a>
+            <p class="eyebrow">Repository metadata</p>
+            <h1>@(repository?.FullName ?? "Repository")</h1>
+            <p class="dashboard-summary">@BuildHeaderSummary()</p>
+        </div>
+        @if (repository is { } headerRepository)
+        {
+            <div class="dashboard-meta">
+                <StatusBadge Text="@headerRepository.Visibility.ToString()" Tone="@StatusBadgeTone.Info" />
+                <StatusBadge
+                    Text="@headerRepository.OrchestrationStatus.ToString()"
+                    Tone="@MapOrchestrationTone(headerRepository.OrchestrationStatus)" />
+                <StatusBadge
+                    Text="@headerRepository.WorstHealthStatus.ToString()"
+                    Tone="@MapHealthTone(headerRepository.WorstHealthStatus)" />
+            </div>
+        }
+    </header>
+
+    @if (loadError is not null)
     {
-        <section class="empty-state">
-            <p>Repository not found.</p>
-        </section>
+        <ErrorState
+            Title="Repository could not be loaded."
+            Message="Check the persistence store and retry."
+            Detail="@loadError" />
+    }
+    else if (isLoading)
+    {
+        <LoadingState
+            Title="Loading repository"
+            Message="Reading repository metadata and instance summaries." />
+    }
+    else if (repository is null)
+    {
+        <EmptyState
+            Title="Repository was not found."
+            Message="The imported repository may have been removed or the link is stale." />
     }
     else
     {
-        <header class="dashboard-header">
-            <div>
-                <p class="eyebrow">Repository command centre</p>
-                <h1>@Repository.FullName</h1>
-                <p class="dashboard-summary">Seeded repository and Symphony runtime state.</p>
+        <section class="repository-detail-panel" aria-label="Repository metadata">
+            <div class="instances-panel-header">
+                <div>
+                    <p class="eyebrow">Metadata</p>
+                    <h2>Imported repository</h2>
+                </div>
             </div>
-            <span class="@HealthStatusClass(Repository.WorstHealthStatus)">@Repository.WorstHealthStatus</span>
-        </header>
 
-        <section class="detail-grid">
-            <article class="detail-panel">
-                <span>Project</span>
-                <strong>@(Repository.ProjectName ?? "Unassigned")</strong>
-            </article>
-            <article class="detail-panel">
-                <span>Default branch</span>
-                <strong>@Repository.DefaultBranch</strong>
-            </article>
-            <article class="detail-panel">
-                <span>Instances</span>
-                <strong>@Repository.RunningInstanceCount / @Repository.InstanceCount running</strong>
-            </article>
-            <article class="detail-panel">
-                <span>Last check</span>
-                <strong>@FormatLastSeen(Repository.LastHealthCheckAtUtc)</strong>
-            </article>
+            <dl class="repository-metadata-grid">
+                <div>
+                    <dt>Provider</dt>
+                    <dd>@repository.Provider</dd>
+                </div>
+                <div>
+                    <dt>Project</dt>
+                    <dd>@(repository.ProjectName ?? "Unassigned")</dd>
+                </div>
+                <div>
+                    <dt>Owner</dt>
+                    <dd>@repository.Owner</dd>
+                </div>
+                <div>
+                    <dt>Name</dt>
+                    <dd>@repository.Name</dd>
+                </div>
+                <div>
+                    <dt>Default branch</dt>
+                    <dd>@repository.DefaultBranch</dd>
+                </div>
+                <div>
+                    <dt>Visibility</dt>
+                    <dd>@repository.Visibility</dd>
+                </div>
+                <div>
+                    <dt>Archived</dt>
+                    <dd>@(repository.IsArchived ? "Yes" : "No")</dd>
+                </div>
+                <div>
+                    <dt>Last synced</dt>
+                    <dd>@FormatTimestamp(repository.LastSyncedAtUtc)</dd>
+                </div>
+                <div>
+                    <dt>Orchestration</dt>
+                    <dd>@repository.OrchestrationStatus</dd>
+                </div>
+                <div>
+                    <dt>Health</dt>
+                    <dd>@repository.WorstHealthStatus</dd>
+                </div>
+                <div class="metadata-wide">
+                    <dt>Clone URL</dt>
+                    <dd><code>@repository.CloneUrl.AbsoluteUri</code></dd>
+                </div>
+                <div class="metadata-wide">
+                    <dt>Repository URL</dt>
+                    <dd>
+                        <a class="metadata-link" href="@repository.WebUrl.AbsoluteUri" target="_blank" rel="noreferrer">
+                            @repository.WebUrl.AbsoluteUri
+                        </a>
+                    </dd>
+                </div>
+                @if (!string.IsNullOrWhiteSpace(repository.OrchestrationStatusReason))
+                {
+                    <div class="metadata-wide">
+                        <dt>Status reason</dt>
+                        <dd>@repository.OrchestrationStatusReason</dd>
+                    </div>
+                }
+            </dl>
         </section>
 
-        <section class="data-panel">
-            <div class="panel-header">
+        <section class="repository-detail-panel" aria-label="Repository instances">
+            <div class="instances-panel-header">
                 <div>
-                    <h2>Runtime connection</h2>
-                    <p>Seeded instance endpoint and repository source.</p>
+                    <p class="eyebrow">Symphony</p>
+                    <h2>Repository instances</h2>
                 </div>
+                <StatusBadge Text="@($"{instances.Count} active")" Tone="@StatusBadgeTone.Info" />
             </div>
-            <dl class="detail-list">
-                <div>
-                    <dt>Repository URL</dt>
-                    <dd><a class="text-link" href="@Repository.WebUrl.ToString()">@Repository.WebUrl</a></dd>
+
+            @if (instances.Count == 0)
+            {
+                <EmptyState
+                    Title="No active instances are registered."
+                    Message="Create a Symphony instance shell during import or register an instance later." />
+            }
+            else
+            {
+                <div class="instances-table-wrap">
+                    <table class="instances-table">
+                        <thead>
+                            <tr>
+                                <th scope="col">Instance</th>
+                                <th scope="col">Health</th>
+                                <th scope="col">Runtime</th>
+                                <th scope="col">Release</th>
+                                <th scope="col">Last seen</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach (InstanceSummaryProjection instance in instances)
+                            {
+                                <tr>
+                                    <td>
+                                        <strong>@instance.DisplayName</strong>
+                                        <a href="@instance.BaseUrl.AbsoluteUri" target="_blank" rel="noreferrer">@instance.BaseUrl.Authority</a>
+                                    </td>
+                                    <td>
+                                        <StatusBadge
+                                            Text="@instance.HealthStatus.ToString()"
+                                            Tone="@MapHealthTone(instance.HealthStatus)" />
+                                    </td>
+                                    <td>
+                                        <span>@instance.LifecycleStatus</span>
+                                        <small>@(instance.SymphonyVersion ?? "Version unknown")</small>
+                                    </td>
+                                    <td>@(instance.SymphonyReleaseTag ?? "Not selected")</td>
+                                    <td>@FormatTimestamp(instance.LastSeenAtUtc, "Not seen")</td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
                 </div>
-                <div>
-                    <dt>Instance URL</dt>
-                    <dd>@(PrimaryInstance?.BaseUrl.ToString() ?? "No instance registered")</dd>
-                </div>
-                <div>
-                    <dt>Lifecycle</dt>
-                    <dd>@(PrimaryInstance?.LifecycleStatus.ToString() ?? "None")</dd>
-                </div>
-                <div>
-                    <dt>Execution mode</dt>
-                    <dd>@(PrimaryInstance?.ExecutionMode.ToString() ?? "None")</dd>
-                </div>
-            </dl>
+            }
         </section>
     }
 </section>
@@ -77,32 +183,74 @@
     [Parameter]
     public Guid RepositoryId { get; set; }
 
-    private RepositoryListItemProjection? Repository { get; set; }
-
-    private IReadOnlyList<InstanceSummaryProjection> Instances { get; set; } = [];
-
-    private InstanceSummaryProjection? PrimaryInstance => Instances.FirstOrDefault();
+    private RepositoryDetailProjection? repository;
+    private IReadOnlyList<InstanceSummaryProjection> instances = [];
+    private string? loadError;
+    private bool isLoading = true;
 
     protected override async Task OnParametersSetAsync()
     {
+        repository = null;
+        instances = [];
+        loadError = null;
+        isLoading = true;
         var repositoryId = new RepositoryId(RepositoryId);
-        IReadOnlyList<RepositoryListItemProjection> repositories =
-            await RepositoryQueries.ListRepositoriesAsync(new RepositoryListQuery(IncludeArchived: true));
 
-        Repository = repositories.SingleOrDefault(repository => repository.Id == repositoryId);
-        Instances = await InstanceQueries.ListInstanceSummariesAsync(
-            new InstanceSummaryQuery(RepositoryId: repositoryId, IncludeDestroyed: true));
+        try
+        {
+            repository = await RepositoryListQueryService.GetRepositoryAsync(repositoryId);
+            if (repository is not null)
+            {
+                instances = await InstanceSummaryQueryService.ListInstanceSummariesAsync(
+                    new InstanceSummaryQuery(RepositoryId: repositoryId));
+            }
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or IOException)
+        {
+            loadError = ex.Message;
+        }
+        finally
+        {
+            isLoading = false;
+        }
     }
 
-    private static string FormatLastSeen(DateTimeOffset? lastSeenAtUtc) =>
-        lastSeenAtUtc?.ToString("yyyy-MM-dd HH:mm 'UTC'", System.Globalization.CultureInfo.InvariantCulture) ?? "Never";
+    private string BuildPageTitle()
+    {
+        return repository is null
+            ? "Repository"
+            : repository.FullName;
+    }
 
-    private static string HealthStatusClass(InstanceHealthStatus status) =>
-        status switch
+    private string BuildHeaderSummary()
+    {
+        if (repository is null)
         {
-            InstanceHealthStatus.Healthy => "status-badge status-healthy",
-            InstanceHealthStatus.Warning => "status-badge status-warning",
-            InstanceHealthStatus.Critical or InstanceHealthStatus.Offline => "status-badge status-critical",
-            _ => "status-badge",
-        };
+            return "Review imported repository metadata and attached Symphony instances.";
+        }
+
+        string projectName = repository.ProjectName ?? "unassigned";
+
+        return $"{repository.Provider} repository in {projectName}, synced {FormatTimestamp(repository.LastSyncedAtUtc)}.";
+    }
+
+    private static StatusBadgeTone MapHealthTone(InstanceHealthStatus healthStatus) => healthStatus switch
+    {
+        InstanceHealthStatus.Healthy => StatusBadgeTone.Success,
+        InstanceHealthStatus.Warning => StatusBadgeTone.Warning,
+        InstanceHealthStatus.Critical or InstanceHealthStatus.Offline => StatusBadgeTone.Critical,
+        _ => StatusBadgeTone.Neutral,
+    };
+
+    private static StatusBadgeTone MapOrchestrationTone(RepositoryOrchestrationStatus orchestrationStatus) =>
+        orchestrationStatus == RepositoryOrchestrationStatus.Eligible
+            ? StatusBadgeTone.Success
+            : StatusBadgeTone.Warning;
+
+    private static string FormatTimestamp(DateTimeOffset? timestamp, string fallback = "Not synced")
+    {
+        return timestamp is null
+            ? fallback
+            : timestamp.Value.ToLocalTime().ToString("MMM d, yyyy HH:mm");
+    }
 }

--- a/src/Conductor.Host/wwwroot/app.css
+++ b/src/Conductor.Host/wwwroot/app.css
@@ -92,7 +92,8 @@ a {
 
 .dashboard,
 .instances-page,
-.repositories-page {
+.repositories-page,
+.repository-detail-page {
   display: grid;
   gap: 24px;
   max-width: 1220px;
@@ -1150,7 +1151,8 @@ h2 {
 .instance-registration,
 .instances-panel,
 .repository-import,
-.repositories-panel {
+.repositories-panel,
+.repository-detail-panel {
   display: grid;
   gap: 18px;
   padding: 24px;
@@ -1438,13 +1440,17 @@ h2 {
 
 .instances-table td:first-child,
 .repositories-table td:first-child,
-.repositories-table td:nth-child(5) {
+.repositories-table td:nth-child(3),
+.repositories-table td:nth-child(4),
+.repositories-table td:nth-child(5),
+.repositories-table td:nth-child(6) {
   display: grid;
   gap: 5px;
 }
 
 .instances-table td:first-child a,
 .repositories-table td:first-child a,
+.instances-table small,
 .repositories-table small {
   width: fit-content;
   max-width: 100%;
@@ -1530,6 +1536,65 @@ h2 {
 
 .repositories-table small {
   color: #aeb9c5;
+}
+
+.breadcrumb-link,
+.metadata-link {
+  width: fit-content;
+  max-width: 100%;
+  color: #9cc2ff;
+  font-weight: 700;
+  overflow-wrap: anywhere;
+}
+
+.breadcrumb-link {
+  display: inline-flex;
+  margin-bottom: 10px;
+  font-size: 0.9rem;
+}
+
+.repository-metadata-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  margin: 0;
+}
+
+.repository-metadata-grid div {
+  display: grid;
+  gap: 7px;
+  min-width: 0;
+  padding: 14px;
+  border: 1px solid #2b3138;
+  border-radius: 8px;
+  background: #191f25;
+}
+
+.repository-metadata-grid .metadata-wide {
+  grid-column: 1 / -1;
+}
+
+.repository-metadata-grid dt {
+  color: #aeb9c5;
+  font-size: 0.78rem;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.repository-metadata-grid dd {
+  margin: 0;
+  color: #ffffff;
+  overflow-wrap: anywhere;
+}
+
+.repository-metadata-grid code {
+  width: fit-content;
+  max-width: 100%;
+  padding: 4px 7px;
+  border-radius: 4px;
+  background: #232a31;
+  color: #f2c14e;
+  overflow-wrap: anywhere;
 }
 
 .ui-state {
@@ -1688,6 +1753,7 @@ h2 {
   .registration-form,
   .credential-form-row,
   .form-fields,
+  .repository-metadata-grid,
   .import-form-grid,
   .live-activity-header,
   .startup-panel dl {

--- a/src/Conductor.Infrastructure.Persistence.Sqlite/Queries/SqliteProjectionQueryService.cs
+++ b/src/Conductor.Infrastructure.Persistence.Sqlite/Queries/SqliteProjectionQueryService.cs
@@ -128,8 +128,13 @@ public sealed class SqliteProjectionQueryService :
                     repository.Name,
                     repository.FullName.Value,
                     repository.DefaultBranch,
+                    repository.CloneUrl,
                     repository.WebUrl,
+                    repository.Visibility,
                     repository.IsArchived,
+                    repository.LastSyncedAtUtc,
+                    repository.OrchestrationStatus,
+                    repository.OrchestrationStatusReason,
                     instances.Count,
                     instances.Count(instance => instance.LifecycleStatus == InstanceLifecycleStatus.Running),
                     worstHealthStatus,
@@ -139,6 +144,60 @@ public sealed class SqliteProjectionQueryService :
             .ThenBy(repository => repository.Owner)
             .ThenBy(repository => repository.Name)
             .ToArray();
+    }
+
+    public async Task<RepositoryDetailProjection?> GetRepositoryAsync(
+        RepositoryId repositoryId,
+        CancellationToken cancellationToken = default)
+    {
+        Repository? repository = await dbContext.Repositories
+            .AsNoTracking()
+            .FirstOrDefaultAsync(candidate => candidate.Id == repositoryId, cancellationToken);
+
+        if (repository is null)
+        {
+            return null;
+        }
+
+        Dictionary<ProjectId, Project> projectsById = await LoadProjectsAsync(
+            [repository.ProjectId],
+            cancellationToken);
+        Dictionary<RepositoryId, List<SymphonyInstance>> instancesByRepositoryId =
+            await LoadActiveInstancesByRepositoryAsync([repository.Id], cancellationToken);
+        List<SymphonyInstance> instances = instancesByRepositoryId.GetValueOrDefault(repository.Id) ?? [];
+        InstanceHealthStatus worstHealthStatus = instances.Count == 0
+            ? InstanceHealthStatus.Unknown
+            : instances
+                .Select(instance => instance.HealthStatus)
+                .OrderByDescending(MapHealthSeverity)
+                .First();
+
+        Project? project = null;
+        if (repository.ProjectId is { } projectId)
+        {
+            projectsById.TryGetValue(projectId, out project);
+        }
+
+        return new RepositoryDetailProjection(
+            repository.Id,
+            repository.ProjectId,
+            project?.Name,
+            repository.Provider,
+            repository.Owner,
+            repository.Name,
+            repository.FullName.Value,
+            repository.DefaultBranch,
+            repository.CloneUrl,
+            repository.WebUrl,
+            repository.Visibility,
+            repository.IsArchived,
+            repository.LastSyncedAtUtc,
+            repository.OrchestrationStatus,
+            repository.OrchestrationStatusReason,
+            instances.Count,
+            instances.Count(instance => instance.LifecycleStatus == InstanceLifecycleStatus.Running),
+            worstHealthStatus,
+            instances.Select(instance => instance.LastHealthCheckAtUtc).Max());
     }
 
     public async Task<IReadOnlyList<ProjectListItemProjection>> ListProjectsAsync(

--- a/tests/Conductor.Blazor.Tests/RepositoriesPageTests.cs
+++ b/tests/Conductor.Blazor.Tests/RepositoriesPageTests.cs
@@ -35,6 +35,27 @@ public sealed class RepositoriesPageTests
         Assert.Contains("Conductor local was created in NotProvisioned state.", page.Markup, StringComparison.Ordinal);
         Assert.Contains("Managed repositories", page.Markup, StringComparison.Ordinal);
         Assert.Contains("ReleasedGroup/ExistingService", page.Markup, StringComparison.Ordinal);
+        Assert.Contains("main branch", page.Markup, StringComparison.Ordinal);
+        Assert.Contains("Eligible", page.Markup, StringComparison.Ordinal);
+        Assert.Contains($"/repositories/{StaticRepositoryListQueryService.ExistingRepositoryId}", page.Markup, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RepositoryDetail_Shows_Metadata_And_Attached_Instances()
+    {
+        using BunitContext context = new();
+        context.Services.AddSingleton<IRepositoryListQueryService>(new StaticRepositoryListQueryService());
+        context.Services.AddSingleton<IInstanceSummaryQueryService>(new StaticInstanceSummaryQueryService());
+
+        IRenderedComponent<RepositoryDetail> page = context.Render<RepositoryDetail>(parameters => parameters
+            .Add(component => component.RepositoryId, StaticRepositoryListQueryService.ExistingRepositoryId.Value));
+
+        Assert.Contains("Imported repository", page.Markup, StringComparison.Ordinal);
+        Assert.Contains("ReleasedGroup/ExistingService", page.Markup, StringComparison.Ordinal);
+        Assert.Contains("https://github.com/ReleasedGroup/ExistingService.git", page.Markup, StringComparison.Ordinal);
+        Assert.Contains("Private", page.Markup, StringComparison.Ordinal);
+        Assert.Contains("Existing local", page.Markup, StringComparison.Ordinal);
+        Assert.Contains("3.1.4", page.Markup, StringComparison.Ordinal);
     }
 
     private sealed class FakeRepositoryImportService : IRepositoryImportService
@@ -60,6 +81,9 @@ public sealed class RepositoriesPageTests
 
     private sealed class StaticRepositoryListQueryService : IRepositoryListQueryService
     {
+        public static RepositoryId ExistingRepositoryId { get; } =
+            RepositoryId.Parse("11111111-1111-1111-1111-111111111111");
+
         public Task<IReadOnlyList<RepositoryListItemProjection>> ListRepositoriesAsync(
             RepositoryListQuery query,
             CancellationToken cancellationToken = default)
@@ -67,7 +91,7 @@ public sealed class RepositoriesPageTests
             IReadOnlyList<RepositoryListItemProjection> repositories =
             [
                 new RepositoryListItemProjection(
-                    RepositoryId.New(),
+                    ExistingRepositoryId,
                     null,
                     null,
                     RepositoryProvider.GitHub,
@@ -75,15 +99,81 @@ public sealed class RepositoriesPageTests
                     "ExistingService",
                     "ReleasedGroup/ExistingService",
                     "main",
+                    new Uri("https://github.com/ReleasedGroup/ExistingService.git"),
                     new Uri("https://github.com/ReleasedGroup/ExistingService"),
+                    RepositoryVisibility.Private,
                     IsArchived: false,
+                    LastSyncedAtUtc: DateTimeOffset.Parse("2026-04-29T02:00:00Z"),
+                    OrchestrationStatus: RepositoryOrchestrationStatus.Eligible,
+                    OrchestrationStatusReason: null,
                     InstanceCount: 1,
                     RunningInstanceCount: 0,
-                    InstanceHealthStatus.Unknown,
+                    WorstHealthStatus: InstanceHealthStatus.Unknown,
                     LastHealthCheckAtUtc: null),
             ];
 
             return Task.FromResult(repositories);
+        }
+
+        public Task<RepositoryDetailProjection?> GetRepositoryAsync(
+            RepositoryId repositoryId,
+            CancellationToken cancellationToken = default)
+        {
+            if (repositoryId != ExistingRepositoryId)
+            {
+                return Task.FromResult<RepositoryDetailProjection?>(null);
+            }
+
+            return Task.FromResult<RepositoryDetailProjection?>(new RepositoryDetailProjection(
+                ExistingRepositoryId,
+                null,
+                null,
+                RepositoryProvider.GitHub,
+                "ReleasedGroup",
+                "ExistingService",
+                "ReleasedGroup/ExistingService",
+                "main",
+                new Uri("https://github.com/ReleasedGroup/ExistingService.git"),
+                new Uri("https://github.com/ReleasedGroup/ExistingService"),
+                RepositoryVisibility.Private,
+                IsArchived: false,
+                LastSyncedAtUtc: DateTimeOffset.Parse("2026-04-29T02:00:00Z"),
+                OrchestrationStatus: RepositoryOrchestrationStatus.Eligible,
+                OrchestrationStatusReason: null,
+                InstanceCount: 1,
+                RunningInstanceCount: 1,
+                WorstHealthStatus: InstanceHealthStatus.Healthy,
+                LastHealthCheckAtUtc: DateTimeOffset.Parse("2026-04-29T02:10:00Z")));
+        }
+    }
+
+    private sealed class StaticInstanceSummaryQueryService : IInstanceSummaryQueryService
+    {
+        public Task<IReadOnlyList<InstanceSummaryProjection>> ListInstanceSummariesAsync(
+            InstanceSummaryQuery query,
+            CancellationToken cancellationToken = default)
+        {
+            IReadOnlyList<InstanceSummaryProjection> summaries =
+            [
+                new InstanceSummaryProjection(
+                    SymphonyInstanceId.Parse("22222222-2222-2222-2222-222222222222"),
+                    StaticRepositoryListQueryService.ExistingRepositoryId,
+                    "ReleasedGroup/ExistingService",
+                    null,
+                    null,
+                    "Existing local",
+                    ExecutionMode.LocalProcess,
+                    new Uri("http://localhost:8080/"),
+                    InstanceLifecycleStatus.Running,
+                    InstanceHealthStatus.Healthy,
+                    DateTimeOffset.Parse("2026-04-29T02:10:00Z"),
+                    DateTimeOffset.Parse("2026-04-29T02:10:00Z"),
+                    DateTimeOffset.Parse("2026-04-29T02:10:00Z"),
+                    SymphonyVersion: "3.1.4",
+                    SymphonyReleaseTag: "latest"),
+            ];
+
+            return Task.FromResult(summaries);
         }
     }
 

--- a/tests/Conductor.Persistence.Tests/SqliteProjectionQueryServiceTests.cs
+++ b/tests/Conductor.Persistence.Tests/SqliteProjectionQueryServiceTests.cs
@@ -32,6 +32,12 @@ public sealed class SqliteProjectionQueryServiceTests
         Assert.Equal(fixture.ApiRepositoryId, repository.Id);
         Assert.Equal("Alpha", repository.ProjectName);
         Assert.Equal("ReleasedGroup/api-service", repository.FullName);
+        Assert.Equal("https://github.com/ReleasedGroup/api-service.git", repository.CloneUrl.AbsoluteUri);
+        Assert.Equal(RepositoryVisibility.Public, repository.Visibility);
+        Assert.False(repository.IsArchived);
+        Assert.Equal(fixture.CreatedAtUtc, repository.LastSyncedAtUtc);
+        Assert.Equal(RepositoryOrchestrationStatus.Eligible, repository.OrchestrationStatus);
+        Assert.Null(repository.OrchestrationStatusReason);
         Assert.Equal(2, repository.InstanceCount);
         Assert.Equal(1, repository.RunningInstanceCount);
         Assert.Equal(InstanceHealthStatus.Warning, repository.WorstHealthStatus);
@@ -86,6 +92,33 @@ public sealed class SqliteProjectionQueryServiceTests
         Assert.Equal(0, repository.InstanceCount);
         Assert.Equal(InstanceHealthStatus.Unknown, repository.WorstHealthStatus);
         Assert.Null(repository.LastHealthCheckAtUtc);
+    }
+
+    [Fact]
+    public async Task GetRepositoryAsync_Returns_Metadata_And_Instance_Aggregates()
+    {
+        await using SqliteConnection connection = await OpenConnectionAsync();
+        await using ConductorDbContext dbContext = await CreateDbContextAsync(connection);
+        var fixture = await SeedPortfolioAsync(dbContext);
+        SqliteProjectionQueryService queryService = new(dbContext);
+
+        RepositoryDetailProjection? repository =
+            await queryService.GetRepositoryAsync(fixture.ApiRepositoryId);
+
+        Assert.NotNull(repository);
+        Assert.Equal(fixture.ApiRepositoryId, repository.Id);
+        Assert.Equal("Alpha", repository.ProjectName);
+        Assert.Equal("ReleasedGroup/api-service", repository.FullName);
+        Assert.Equal("main", repository.DefaultBranch);
+        Assert.Equal("https://github.com/ReleasedGroup/api-service.git", repository.CloneUrl.AbsoluteUri);
+        Assert.Equal("https://github.com/ReleasedGroup/api-service", repository.WebUrl.AbsoluteUri);
+        Assert.Equal(RepositoryVisibility.Public, repository.Visibility);
+        Assert.Equal(fixture.CreatedAtUtc, repository.LastSyncedAtUtc);
+        Assert.Equal(RepositoryOrchestrationStatus.Eligible, repository.OrchestrationStatus);
+        Assert.Equal(2, repository.InstanceCount);
+        Assert.Equal(1, repository.RunningInstanceCount);
+        Assert.Equal(InstanceHealthStatus.Warning, repository.WorstHealthStatus);
+        Assert.Equal(fixture.WarningObservedAtUtc, repository.LastHealthCheckAtUtc);
     }
 
     [Fact]
@@ -245,6 +278,7 @@ public sealed class SqliteProjectionQueryServiceTests
             betaRepositoryId,
             apiPrimaryInstanceId,
             destroyedInstanceId,
+            createdAtUtc,
             warningObservedAtUtc,
             latestSnapshotAtUtc);
     }
@@ -399,6 +433,7 @@ public sealed class SqliteProjectionQueryServiceTests
         RepositoryId BetaRepositoryId,
         SymphonyInstanceId ApiPrimaryInstanceId,
         SymphonyInstanceId DestroyedInstanceId,
+        DateTimeOffset CreatedAtUtc,
         DateTimeOffset WarningObservedAtUtc,
         DateTimeOffset LatestSnapshotAtUtc);
 }


### PR DESCRIPTION
## Summary
- expand repository query projections with imported metadata and a repository detail lookup
- update the repositories registry to show visibility, archive state, orchestration status, sync time, and detail links
- add a repository detail page for clone/web URLs, metadata, orchestration status, and active Symphony instances
- document the repository registry/detail workflow

Closes #51

## Validation
- dotnet restore Conductor.slnx
- dotnet build Conductor.slnx --no-restore --warnaserror
- dotnet test Conductor.slnx --no-build --collect:"XPlat Code Coverage"
- dotnet format Conductor.slnx --no-restore --verify-no-changes
- ./scripts/validate-docs.ps1