### PR TITLE
Select compatible Symphony release assets

### DIFF
--- a/docs/technical.md
+++ b/docs/technical.md
@@ -1030,6 +1030,13 @@ Behaviors:
 - Persist provenance.
 - Surface failure if release assets do not match target runtime.
 
+Compatible asset selection:
+
+- Match release assets by target execution mode, operating system, and architecture before download or cache lookup.
+- Ignore checksum/signature companion files as primary assets, but retain the matching checksum asset when one exists.
+- Local process mode selects the runtime archive for the host OS and architecture, preferring Windows `.zip` bundles and Linux/macOS `.tar.gz` bundles.
+- Docker and Azure container modes select Linux-compatible assets for the requested architecture, preferring container/image metadata assets when published and otherwise falling back to the Linux runtime archive used to build or prepare the container runtime.
+
 ## 16. Symphony API Integration
 
 ### 16.1 HTTP Client

--- a/docs/writeup.md
+++ b/docs/writeup.md
@@ -16,7 +16,7 @@ house so buolt it in dotnet 10 with blazor webassembly front end.
 ## The Solution
 
 The final solution is a practical coordination tool for managing multiple professional software development engagements from a single control surface. It means
-we can democratise professional software development; give vibe coders somewhere to go and manage the non functional requirements which differentiate vibe apps 
+we can democratise professional software development; give vibe coders somewhere to go and manage the non functional requirements which differentiate vibe apps
 from real production ones. We're giving the world the ability to deliver commercial quality code at a fraction of the price and time of historical development.
 
 Small entrepreneurs now really have a chance to get out a working, reliable, secure and sclaable software solution without breaking the bank (and leaving money

--- a/src/Conductor.Core/Domain/SymphonyReleases/SymphonyReleaseAsset.cs
+++ b/src/Conductor.Core/Domain/SymphonyReleases/SymphonyReleaseAsset.cs
@@ -1,0 +1,30 @@
+using Conductor.Core.Common;
+
+namespace Conductor.Core.Domain.SymphonyReleases;
+
+public sealed record SymphonyReleaseAsset
+{
+    public SymphonyReleaseAsset(
+        string name,
+        Uri downloadUrl,
+        long sizeBytes,
+        string? contentType = null,
+        string? digest = null)
+    {
+        Name = Guard.NotWhiteSpace(name, nameof(name));
+        DownloadUrl = Guard.AbsoluteUri(downloadUrl, nameof(downloadUrl));
+        SizeBytes = Guard.NonNegative(sizeBytes, nameof(sizeBytes));
+        ContentType = Guard.OptionalTrimmed(contentType);
+        Digest = Guard.OptionalTrimmed(digest);
+    }
+
+    public string Name { get; }
+
+    public Uri DownloadUrl { get; }
+
+    public long SizeBytes { get; }
+
+    public string? ContentType { get; }
+
+    public string? Digest { get; }
+}

--- a/src/Conductor.Core/Domain/SymphonyReleases/SymphonyReleaseAssetSelector.cs
+++ b/src/Conductor.Core/Domain/SymphonyReleases/SymphonyReleaseAssetSelector.cs
@@ -1,0 +1,275 @@
+using Conductor.Core.Domain;
+
+namespace Conductor.Core.Domain.SymphonyReleases;
+
+public enum ReleaseAssetOperatingSystem
+{
+    Windows,
+    Linux,
+    MacOS,
+}
+
+public enum ReleaseAssetArchitecture
+{
+    X64,
+    Arm64,
+}
+
+public sealed record SymphonyReleaseAssetSelectionTarget
+{
+    public SymphonyReleaseAssetSelectionTarget(
+        ExecutionMode executionMode,
+        ReleaseAssetOperatingSystem operatingSystem,
+        ReleaseAssetArchitecture architecture)
+    {
+        ValidateEnum(executionMode, nameof(executionMode));
+        ValidateEnum(operatingSystem, nameof(operatingSystem));
+        ValidateEnum(architecture, nameof(architecture));
+
+        ExecutionMode = executionMode;
+        OperatingSystem = operatingSystem;
+        Architecture = architecture;
+    }
+
+    public ExecutionMode ExecutionMode { get; }
+
+    public ReleaseAssetOperatingSystem OperatingSystem { get; }
+
+    public ReleaseAssetArchitecture Architecture { get; }
+
+    public override string ToString() => $"{ExecutionMode}/{OperatingSystem}/{Architecture}";
+
+    private static void ValidateEnum<TEnum>(TEnum value, string parameterName)
+        where TEnum : struct, Enum
+    {
+        if (!Enum.IsDefined(value))
+        {
+            throw new ArgumentOutOfRangeException(parameterName, value, "Unsupported release asset target value.");
+        }
+    }
+}
+
+public sealed record SymphonyReleaseAssetSelection(
+    SymphonyReleaseAsset Asset,
+    SymphonyReleaseAsset? ChecksumAsset,
+    SymphonyReleaseAssetSelectionTarget Target);
+
+public sealed record SymphonyReleaseAssetSelectionResult
+{
+    private SymphonyReleaseAssetSelectionResult(
+        SymphonyReleaseAssetSelection? selection,
+        string? failureReason)
+    {
+        Selection = selection;
+        FailureReason = failureReason;
+    }
+
+    public bool Succeeded => Selection is not null;
+
+    public SymphonyReleaseAssetSelection? Selection { get; }
+
+    public string? FailureReason { get; }
+
+    public static SymphonyReleaseAssetSelectionResult Success(SymphonyReleaseAssetSelection selection)
+    {
+        ArgumentNullException.ThrowIfNull(selection);
+
+        return new SymphonyReleaseAssetSelectionResult(selection, failureReason: null);
+    }
+
+    public static SymphonyReleaseAssetSelectionResult Failure(string failureReason) =>
+        new(selection: null, failureReason);
+}
+
+public static class SymphonyReleaseAssetSelector
+{
+    public static SymphonyReleaseAssetSelectionResult SelectCompatibleAsset(
+        IEnumerable<SymphonyReleaseAsset> assets,
+        SymphonyReleaseAssetSelectionTarget target)
+    {
+        ArgumentNullException.ThrowIfNull(assets);
+        ArgumentNullException.ThrowIfNull(target);
+
+        List<SymphonyReleaseAsset> allAssets = assets.ToList();
+
+        if (allAssets.Count == 0)
+        {
+            return SymphonyReleaseAssetSelectionResult.Failure(
+                $"No Symphony release assets were available for {target}.");
+        }
+
+        SymphonyReleaseAsset? selectedAsset = allAssets
+            .Where(asset => !IsChecksumAsset(asset.Name))
+            .Select(asset => new ScoredAsset(asset, ScoreAsset(asset.Name, target)))
+            .Where(candidate => candidate.Score > 0)
+            .OrderByDescending(candidate => candidate.Score)
+            .ThenBy(candidate => candidate.Asset.Name, StringComparer.OrdinalIgnoreCase)
+            .Select(candidate => candidate.Asset)
+            .FirstOrDefault();
+
+        if (selectedAsset is null)
+        {
+            return SymphonyReleaseAssetSelectionResult.Failure(
+                $"No compatible Symphony release asset was found for {target}.");
+        }
+
+        SymphonyReleaseAsset? checksumAsset = FindChecksumAsset(allAssets, selectedAsset);
+        return SymphonyReleaseAssetSelectionResult.Success(
+            new SymphonyReleaseAssetSelection(selectedAsset, checksumAsset, target));
+    }
+
+    private static int ScoreAsset(string assetName, SymphonyReleaseAssetSelectionTarget target)
+    {
+        AssetNameTokens tokens = AssetNameTokens.Parse(assetName);
+
+        if (!tokens.Matches(target.OperatingSystem) || !tokens.Matches(target.Architecture))
+        {
+            return 0;
+        }
+
+        return target.ExecutionMode switch
+        {
+            ExecutionMode.LocalProcess => ScoreLocalProcessAsset(assetName, tokens, target),
+            ExecutionMode.Docker => ScoreContainerAsset(assetName, tokens, target),
+            ExecutionMode.AzureContainer => ScoreContainerAsset(assetName, tokens, target),
+            _ => 0,
+        };
+    }
+
+    private static int ScoreLocalProcessAsset(
+        string assetName,
+        AssetNameTokens tokens,
+        SymphonyReleaseAssetSelectionTarget target)
+    {
+        if (tokens.HasContainerMarker || !LooksLikeRuntimeArchive(assetName))
+        {
+            return 0;
+        }
+
+        return 100 + ArchivePreferenceScore(assetName, target.OperatingSystem);
+    }
+
+    private static int ScoreContainerAsset(
+        string assetName,
+        AssetNameTokens tokens,
+        SymphonyReleaseAssetSelectionTarget target)
+    {
+        if (target.OperatingSystem is not ReleaseAssetOperatingSystem.Linux)
+        {
+            return 0;
+        }
+
+        if (tokens.HasContainerMarker)
+        {
+            return 200 + ArchivePreferenceScore(assetName, target.OperatingSystem);
+        }
+
+        return LooksLikeRuntimeArchive(assetName)
+            ? 100 + ArchivePreferenceScore(assetName, target.OperatingSystem)
+            : 0;
+    }
+
+    private static int ArchivePreferenceScore(string assetName, ReleaseAssetOperatingSystem operatingSystem)
+    {
+        string normalized = assetName.ToLowerInvariant();
+
+        if (operatingSystem is ReleaseAssetOperatingSystem.Windows && normalized.EndsWith(".zip", StringComparison.Ordinal))
+        {
+            return 4;
+        }
+
+        if (normalized.EndsWith(".tar.gz", StringComparison.Ordinal))
+        {
+            return 3;
+        }
+
+        if (normalized.EndsWith(".tgz", StringComparison.Ordinal))
+        {
+            return 2;
+        }
+
+        return normalized.EndsWith(".zip", StringComparison.Ordinal) ? 1 : 0;
+    }
+
+    private static bool LooksLikeRuntimeArchive(string assetName)
+    {
+        string normalized = assetName.ToLowerInvariant();
+
+        return normalized.EndsWith(".zip", StringComparison.Ordinal) ||
+            normalized.EndsWith(".tar.gz", StringComparison.Ordinal) ||
+            normalized.EndsWith(".tgz", StringComparison.Ordinal);
+    }
+
+    private static bool IsChecksumAsset(string assetName)
+    {
+        string normalized = assetName.ToLowerInvariant();
+
+        return normalized.EndsWith(".sha256", StringComparison.Ordinal) ||
+            normalized.EndsWith(".sha512", StringComparison.Ordinal) ||
+            normalized.EndsWith(".md5", StringComparison.Ordinal) ||
+            normalized.EndsWith(".sig", StringComparison.Ordinal) ||
+            normalized.EndsWith(".asc", StringComparison.Ordinal);
+    }
+
+    private static SymphonyReleaseAsset? FindChecksumAsset(
+        IEnumerable<SymphonyReleaseAsset> assets,
+        SymphonyReleaseAsset selectedAsset) =>
+        assets.FirstOrDefault(asset =>
+            string.Equals(asset.Name, $"{selectedAsset.Name}.sha256", StringComparison.OrdinalIgnoreCase)) ??
+        assets.FirstOrDefault(asset =>
+            string.Equals(asset.Name, $"{selectedAsset.Name}.sha512", StringComparison.OrdinalIgnoreCase));
+
+    private sealed record ScoredAsset(SymphonyReleaseAsset Asset, int Score);
+
+    private sealed class AssetNameTokens
+    {
+        private static readonly char[] TokenSeparators =
+        [
+            ' ',
+            '.',
+            '-',
+            '_',
+            '/',
+            '\\',
+            ':',
+            '+',
+            '(',
+            ')',
+            '[',
+            ']',
+        ];
+
+        private readonly HashSet<string> tokens;
+
+        private AssetNameTokens(IEnumerable<string> tokens)
+        {
+            this.tokens = tokens.ToHashSet(StringComparer.OrdinalIgnoreCase);
+        }
+
+        public bool HasContainerMarker =>
+            tokens.Contains("container") ||
+            tokens.Contains("docker") ||
+            tokens.Contains("image") ||
+            tokens.Contains("oci");
+
+        public static AssetNameTokens Parse(string assetName) =>
+            new(assetName.Split(TokenSeparators, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries));
+
+        public bool Matches(ReleaseAssetOperatingSystem operatingSystem) =>
+            operatingSystem switch
+            {
+                ReleaseAssetOperatingSystem.Windows => tokens.Contains("win") || tokens.Contains("windows"),
+                ReleaseAssetOperatingSystem.Linux => tokens.Contains("linux"),
+                ReleaseAssetOperatingSystem.MacOS => tokens.Contains("osx") || tokens.Contains("macos") || tokens.Contains("mac") || tokens.Contains("darwin"),
+                _ => false,
+            };
+
+        public bool Matches(ReleaseAssetArchitecture architecture) =>
+            architecture switch
+            {
+                ReleaseAssetArchitecture.X64 => tokens.Contains("x64") || tokens.Contains("x86") && tokens.Contains("64") || tokens.Contains("x86_64") || tokens.Contains("amd64"),
+                ReleaseAssetArchitecture.Arm64 => tokens.Contains("arm64") || tokens.Contains("aarch64"),
+                _ => false,
+            };
+    }
+}

--- a/tests/Conductor.Core.Tests/SymphonyReleaseAssetSelectorTests.cs
+++ b/tests/Conductor.Core.Tests/SymphonyReleaseAssetSelectorTests.cs
@@ -1,0 +1,129 @@
+using Conductor.Core.Domain;
+using Conductor.Core.Domain.SymphonyReleases;
+
+namespace Conductor.Core.Tests;
+
+public sealed class SymphonyReleaseAssetSelectorTests
+{
+    [Fact]
+    public void SelectCompatibleAsset_Selects_Windows_X64_Zip_For_Local_Process()
+    {
+        SymphonyReleaseAssetSelectionResult result = SymphonyReleaseAssetSelector.SelectCompatibleAsset(
+            CreateSymphonyReleaseAssets(),
+            new SymphonyReleaseAssetSelectionTarget(
+                ExecutionMode.LocalProcess,
+                ReleaseAssetOperatingSystem.Windows,
+                ReleaseAssetArchitecture.X64));
+
+        Assert.True(result.Succeeded);
+        Assert.NotNull(result.Selection);
+        Assert.Equal("Symphony-0.0.7-alpha-win-x64.zip", result.Selection.Asset.Name);
+        Assert.Equal("Symphony-0.0.7-alpha-win-x64.zip.sha256", result.Selection.ChecksumAsset?.Name);
+        Assert.Equal("sha256:win-x64-digest", result.Selection.Asset.Digest);
+    }
+
+    [Fact]
+    public void SelectCompatibleAsset_Selects_MacOS_Arm64_Tarball_For_Local_Process()
+    {
+        SymphonyReleaseAssetSelectionResult result = SymphonyReleaseAssetSelector.SelectCompatibleAsset(
+            CreateSymphonyReleaseAssets(),
+            new SymphonyReleaseAssetSelectionTarget(
+                ExecutionMode.LocalProcess,
+                ReleaseAssetOperatingSystem.MacOS,
+                ReleaseAssetArchitecture.Arm64));
+
+        Assert.True(result.Succeeded);
+        Assert.NotNull(result.Selection);
+        Assert.Equal("Symphony-0.0.7-alpha-osx-arm64.tar.gz", result.Selection.Asset.Name);
+    }
+
+    [Fact]
+    public void SelectCompatibleAsset_Prefers_Container_Metadata_For_Docker()
+    {
+        SymphonyReleaseAssetSelectionResult result = SymphonyReleaseAssetSelector.SelectCompatibleAsset(
+            [
+                Asset("Symphony-0.0.7-alpha-linux-x64.tar.gz"),
+                Asset("Symphony-0.0.7-alpha-linux-x64-docker-image.json"),
+            ],
+            new SymphonyReleaseAssetSelectionTarget(
+                ExecutionMode.Docker,
+                ReleaseAssetOperatingSystem.Linux,
+                ReleaseAssetArchitecture.X64));
+
+        Assert.True(result.Succeeded);
+        Assert.NotNull(result.Selection);
+        Assert.Equal("Symphony-0.0.7-alpha-linux-x64-docker-image.json", result.Selection.Asset.Name);
+    }
+
+    [Fact]
+    public void SelectCompatibleAsset_Falls_Back_To_Linux_Archive_For_Docker()
+    {
+        SymphonyReleaseAssetSelectionResult result = SymphonyReleaseAssetSelector.SelectCompatibleAsset(
+            CreateSymphonyReleaseAssets(),
+            new SymphonyReleaseAssetSelectionTarget(
+                ExecutionMode.Docker,
+                ReleaseAssetOperatingSystem.Linux,
+                ReleaseAssetArchitecture.Arm64));
+
+        Assert.True(result.Succeeded);
+        Assert.NotNull(result.Selection);
+        Assert.Equal("Symphony-0.0.7-alpha-linux-arm64.tar.gz", result.Selection.Asset.Name);
+    }
+
+    [Fact]
+    public void SelectCompatibleAsset_Does_Not_Select_Checksum_As_Primary_Asset()
+    {
+        SymphonyReleaseAssetSelectionResult result = SymphonyReleaseAssetSelector.SelectCompatibleAsset(
+            [
+                Asset("Symphony-0.0.7-alpha-linux-x64.tar.gz.sha256"),
+                Asset("Symphony-0.0.7-alpha-linux-x64.tar.gz"),
+            ],
+            new SymphonyReleaseAssetSelectionTarget(
+                ExecutionMode.LocalProcess,
+                ReleaseAssetOperatingSystem.Linux,
+                ReleaseAssetArchitecture.X64));
+
+        Assert.True(result.Succeeded);
+        Assert.NotNull(result.Selection);
+        Assert.Equal("Symphony-0.0.7-alpha-linux-x64.tar.gz", result.Selection.Asset.Name);
+    }
+
+    [Fact]
+    public void SelectCompatibleAsset_Returns_Failure_When_No_Target_Matches()
+    {
+        SymphonyReleaseAssetSelectionResult result = SymphonyReleaseAssetSelector.SelectCompatibleAsset(
+            [Asset("Symphony-0.0.7-alpha-win-x64.zip")],
+            new SymphonyReleaseAssetSelectionTarget(
+                ExecutionMode.LocalProcess,
+                ReleaseAssetOperatingSystem.Linux,
+                ReleaseAssetArchitecture.Arm64));
+
+        Assert.False(result.Succeeded);
+        Assert.Null(result.Selection);
+        Assert.Contains("LocalProcess/Linux/Arm64", result.FailureReason, StringComparison.Ordinal);
+    }
+
+    private static IReadOnlyList<SymphonyReleaseAsset> CreateSymphonyReleaseAssets() =>
+    [
+        Asset("Symphony-0.0.7-alpha-linux-arm64.tar.gz"),
+        Asset("Symphony-0.0.7-alpha-linux-arm64.tar.gz.sha256"),
+        Asset("Symphony-0.0.7-alpha-linux-x64.tar.gz"),
+        Asset("Symphony-0.0.7-alpha-linux-x64.tar.gz.sha256"),
+        Asset("Symphony-0.0.7-alpha-osx-arm64.tar.gz"),
+        Asset("Symphony-0.0.7-alpha-osx-arm64.tar.gz.sha256"),
+        Asset("Symphony-0.0.7-alpha-osx-x64.tar.gz"),
+        Asset("Symphony-0.0.7-alpha-osx-x64.tar.gz.sha256"),
+        Asset("Symphony-0.0.7-alpha-win-arm64.zip"),
+        Asset("Symphony-0.0.7-alpha-win-arm64.zip.sha256"),
+        Asset("Symphony-0.0.7-alpha-win-x64.zip", digest: "sha256:win-x64-digest"),
+        Asset("Symphony-0.0.7-alpha-win-x64.zip.sha256"),
+    ];
+
+    private static SymphonyReleaseAsset Asset(string name, string? digest = null) =>
+        new(
+            name,
+            new Uri($"https://github.com/ReleasedGroup/Symphony/releases/download/v0.0.7-alpha/{name}"),
+            sizeBytes: 1024,
+            contentType: null,
+            digest);
+}


### PR DESCRIPTION
## Summary
- Add Core-domain release asset metadata and a compatible asset selector for execution mode, OS, and architecture.
- Ignore checksum/signature companion files as primary assets while returning the matching checksum asset when present.
- Document the selector contract and remove a tracked trailing whitespace issue so docs validation passes.

Closes #56

## Validation
- `dotnet restore Conductor.slnx`: passed
- `dotnet build Conductor.slnx --no-restore --warnaserror`: passed with 0 warnings
- `dotnet test Conductor.slnx --no-build`: passed
- `dotnet format Conductor.slnx --no-restore --verify-no-changes`: passed
- `./scripts/validate-docs.ps1`: passed
- `git diff --check`: passed