### PR TITLE
[codex] Implement Symphony release resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ Data Source=./data/conductor.db;Cache=Shared
 
 The SQLite registration creates the database directory when a file-backed connection string is used and applies the required startup PRAGMAs for foreign keys, WAL journaling, and a 5 second busy timeout when EF Core opens a connection.
 
+## Symphony Release Resolution
+
+`Conductor.Infrastructure.GitHub` registers `ISymphonyReleaseResolver` for resolving Symphony releases from GitHub Releases. The resolver calls the latest release endpoint for the default `latest` selector, calls the tag-specific release endpoint for pinned selectors, and selects a release asset that matches the requested execution mode, operating system, and architecture.
+
+The resolver returns the resolved tag, release metadata, selected asset URL, size, content type, and checksum/digest when GitHub provides one. Later provisioning and runner services can persist that result through the existing `SymphonyReleaseArtifact` and `SymphonyInstance` provenance fields.
+
 ## Instance Collector
 
 The host registers an `InstanceCollector` background worker that polls non-destroyed Symphony instances from persistence. Defaults are configured in `src/Conductor.Host/appsettings.json`: health every 10 seconds, state every 30 seconds, runtime every 2 minutes, with a 1 second loop delay. Each collection writes an `InstanceSnapshots` row, updates the instance health timestamps, emits health transition events, and creates or resolves the built-in offline alert.

--- a/docs/writeup.md
+++ b/docs/writeup.md
@@ -16,7 +16,7 @@ house so buolt it in dotnet 10 with blazor webassembly front end.
 ## The Solution
 
 The final solution is a practical coordination tool for managing multiple professional software development engagements from a single control surface. It means
-we can democratise professional software development; give vibe coders somewhere to go and manage the non functional requirements which differentiate vibe apps 
+we can democratise professional software development; give vibe coders somewhere to go and manage the non functional requirements which differentiate vibe apps
 from real production ones. We're giving the world the ability to deliver commercial quality code at a fraction of the price and time of historical development.
 
 Small entrepreneurs now really have a chance to get out a working, reliable, secure and sclaable software solution without breaking the bank (and leaving money

--- a/src/Conductor.Core/Abstractions/Releases/SymphonyReleaseResolver.cs
+++ b/src/Conductor.Core/Abstractions/Releases/SymphonyReleaseResolver.cs
@@ -1,0 +1,232 @@
+using System.Runtime.InteropServices;
+using Conductor.Core.Common;
+using Conductor.Core.Domain;
+using Conductor.Core.Domain.Releases;
+using Conductor.Core.Domain.SymphonyReleases;
+
+namespace Conductor.Core.Abstractions.Releases;
+
+public interface ISymphonyReleaseResolver
+{
+    Task<ResolvedSymphonyRelease> ResolveAsync(
+        ReleaseSelector selector,
+        RuntimeTarget target,
+        CancellationToken cancellationToken);
+}
+
+public sealed record RuntimeTarget
+{
+    public RuntimeTarget(
+        ExecutionMode executionMode,
+        string operatingSystem,
+        string architecture,
+        RuntimeArtifactPreference artifactPreference = RuntimeArtifactPreference.Auto)
+    {
+        if (!Enum.IsDefined(executionMode))
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(executionMode),
+                executionMode,
+                "Execution mode is not supported.");
+        }
+
+        if (!Enum.IsDefined(artifactPreference))
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(artifactPreference),
+                artifactPreference,
+                "Runtime artifact preference is not supported.");
+        }
+
+        ExecutionMode = executionMode;
+        OperatingSystem = NormalizeToken(operatingSystem, nameof(operatingSystem));
+        Architecture = NormalizeToken(architecture, nameof(architecture));
+        ArtifactPreference = artifactPreference;
+    }
+
+    public ExecutionMode ExecutionMode { get; }
+
+    public string OperatingSystem { get; }
+
+    public string Architecture { get; }
+
+    public RuntimeArtifactPreference ArtifactPreference { get; }
+
+    public static RuntimeTarget Current(
+        ExecutionMode executionMode,
+        RuntimeArtifactPreference artifactPreference = RuntimeArtifactPreference.Auto) =>
+        new(
+            executionMode,
+            ResolveCurrentOperatingSystem(),
+            ResolveCurrentArchitecture(),
+            artifactPreference);
+
+    public override string ToString() =>
+        $"{ExecutionMode} {OperatingSystem}/{Architecture} ({ArtifactPreference})";
+
+    private static string ResolveCurrentOperatingSystem()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return "windows";
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            return "linux";
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            return "macos";
+        }
+
+        return "unknown";
+    }
+
+    private static string ResolveCurrentArchitecture() =>
+        RuntimeInformation.OSArchitecture switch
+        {
+            System.Runtime.InteropServices.Architecture.X64 => "x64",
+            System.Runtime.InteropServices.Architecture.X86 => "x86",
+            System.Runtime.InteropServices.Architecture.Arm64 => "arm64",
+            System.Runtime.InteropServices.Architecture.Arm => "arm",
+            System.Runtime.InteropServices.Architecture.S390x => "s390x",
+            System.Runtime.InteropServices.Architecture.Wasm => "wasm",
+            System.Runtime.InteropServices.Architecture.LoongArch64 => "loongarch64",
+            System.Runtime.InteropServices.Architecture.Armv6 => "armv6",
+            System.Runtime.InteropServices.Architecture.Ppc64le => "ppc64le",
+            _ => "unknown",
+        };
+
+    private static string NormalizeToken(string value, string parameterName) =>
+        Guard.NotWhiteSpace(value, parameterName).ToLowerInvariant();
+}
+
+public enum RuntimeArtifactPreference
+{
+    Auto,
+    ReleaseArchive,
+    ContainerImage,
+}
+
+public enum SymphonyReleaseAssetKind
+{
+    ReleaseArchive,
+    ContainerImageMetadata,
+    SourceArchive,
+}
+
+public sealed record ResolvedSymphonyReleaseAsset
+{
+    public ResolvedSymphonyReleaseAsset(
+        string name,
+        Uri sourceUrl,
+        long sizeBytes,
+        string? contentType,
+        string? checksum,
+        SymphonyReleaseAssetKind kind)
+    {
+        if (!Enum.IsDefined(kind))
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(kind),
+                kind,
+                "Symphony release asset kind is not supported.");
+        }
+
+        Name = Guard.NotWhiteSpace(name, nameof(name));
+        SourceUrl = Guard.AbsoluteUri(sourceUrl, nameof(sourceUrl));
+        SizeBytes = Guard.NonNegative(sizeBytes, nameof(sizeBytes));
+        ContentType = Guard.OptionalTrimmed(contentType);
+        Checksum = Guard.OptionalTrimmed(checksum);
+        Kind = kind;
+    }
+
+    public string Name { get; }
+
+    public Uri SourceUrl { get; }
+
+    public long SizeBytes { get; }
+
+    public string? ContentType { get; }
+
+    public string? Checksum { get; }
+
+    public SymphonyReleaseAssetKind Kind { get; }
+}
+
+public sealed record ResolvedSymphonyRelease
+{
+    public ResolvedSymphonyRelease(
+        ReleaseSelector requestedSelector,
+        ReleaseTag releaseTag,
+        Uri releaseUrl,
+        DateTimeOffset? publishedAtUtc,
+        bool isPrerelease,
+        ResolvedSymphonyReleaseAsset selectedAsset,
+        IReadOnlyList<ResolvedSymphonyReleaseAsset> assets)
+    {
+        ArgumentNullException.ThrowIfNull(requestedSelector);
+        ArgumentNullException.ThrowIfNull(releaseTag);
+        ArgumentNullException.ThrowIfNull(selectedAsset);
+        ArgumentNullException.ThrowIfNull(assets);
+
+        ResolvedSymphonyReleaseAsset[] copiedAssets = assets.ToArray();
+
+        if (copiedAssets.Length == 0)
+        {
+            throw new ArgumentException("At least one release asset is required.", nameof(assets));
+        }
+
+        if (!copiedAssets.Contains(selectedAsset))
+        {
+            throw new ArgumentException("The selected asset must be included in the asset list.", nameof(selectedAsset));
+        }
+
+        RequestedSelector = requestedSelector;
+        ReleaseTag = releaseTag;
+        ReleaseUrl = Guard.AbsoluteUri(releaseUrl, nameof(releaseUrl));
+        PublishedAtUtc = publishedAtUtc is null
+            ? null
+            : Guard.Utc(publishedAtUtc.Value, nameof(publishedAtUtc));
+        IsPrerelease = isPrerelease;
+        SelectedAsset = selectedAsset;
+        Assets = copiedAssets;
+    }
+
+    public ReleaseSelector RequestedSelector { get; }
+
+    public ReleaseTag ReleaseTag { get; }
+
+    public Uri ReleaseUrl { get; }
+
+    public DateTimeOffset? PublishedAtUtc { get; }
+
+    public bool IsPrerelease { get; }
+
+    public ResolvedSymphonyReleaseAsset SelectedAsset { get; }
+
+    public IReadOnlyList<ResolvedSymphonyReleaseAsset> Assets { get; }
+
+    public SymphonyReleaseArtifact ToArtifact(DateTimeOffset downloadedAtUtc) =>
+        new(
+            ReleaseTag,
+            SelectedAsset.Name,
+            SelectedAsset.SourceUrl,
+            Guard.Utc(downloadedAtUtc, nameof(downloadedAtUtc)),
+            SelectedAsset.Checksum);
+}
+
+public sealed class SymphonyReleaseResolutionException : Exception
+{
+    public SymphonyReleaseResolutionException(string message)
+        : base(message)
+    {
+    }
+
+    public SymphonyReleaseResolutionException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/src/Conductor.Infrastructure.GitHub/GitHubServiceCollectionExtensions.cs
+++ b/src/Conductor.Infrastructure.GitHub/GitHubServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using Conductor.Core.Abstractions.GitHub;
+using Conductor.Core.Abstractions.Releases;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Conductor.Infrastructure.GitHub;
@@ -11,6 +12,14 @@ public static class GitHubServiceCollectionExtensions
 
         services.AddHttpClient<IGitHubRepositoryClient, GitHubRepositoryClient>(
             GitHubRepositoryClient.HttpClientName,
+            client =>
+            {
+                client.BaseAddress = new Uri("https://api.github.com/");
+                client.Timeout = TimeSpan.FromSeconds(10);
+            });
+
+        services.AddHttpClient<ISymphonyReleaseResolver, GitHubSymphonyReleaseResolver>(
+            GitHubSymphonyReleaseResolver.HttpClientName,
             client =>
             {
                 client.BaseAddress = new Uri("https://api.github.com/");

--- a/src/Conductor.Infrastructure.GitHub/GitHubSymphonyReleaseResolver.cs
+++ b/src/Conductor.Infrastructure.GitHub/GitHubSymphonyReleaseResolver.cs
@@ -1,0 +1,371 @@
+using System.Globalization;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Conductor.Core.Abstractions.Releases;
+using Conductor.Core.Domain;
+using Conductor.Core.Domain.Releases;
+
+namespace Conductor.Infrastructure.GitHub;
+
+public sealed class GitHubSymphonyReleaseResolver(HttpClient httpClient) : ISymphonyReleaseResolver
+{
+    public const string HttpClientName = "GitHubSymphonyReleases";
+
+    private const string SymphonyRepositoryOwner = "releasedgroup";
+    private const string SymphonyRepositoryName = "symphony";
+
+    private static readonly Uri DefaultApiBaseUri = new("https://api.github.com/");
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+    private static readonly ProductInfoHeaderValue UserAgent = new("Conductor", "1.0");
+
+    public async Task<ResolvedSymphonyRelease> ResolveAsync(
+        ReleaseSelector selector,
+        RuntimeTarget target,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(selector);
+        ArgumentNullException.ThrowIfNull(target);
+
+        string endpoint = selector.IsLatest
+            ? $"repos/{SymphonyRepositoryOwner}/{SymphonyRepositoryName}/releases/latest"
+            : $"repos/{SymphonyRepositoryOwner}/{SymphonyRepositoryName}/releases/tags/{Uri.EscapeDataString(selector.Tag!.Value)}";
+
+        using HttpRequestMessage request = CreateRequest(endpoint);
+        using HttpResponseMessage response = await SendAsync(request, selector, cancellationToken);
+        string body = await ReadBodyAsync(response, cancellationToken);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            throw CreateHttpFailure(selector, response);
+        }
+
+        GitHubReleaseResponse release = Deserialize(body);
+        ReleaseTag releaseTag = new(RequireNonEmpty(release.TagName, "GitHub release tag name"));
+        Uri releaseUrl = CreateAbsoluteUri(release.HtmlUrl, "GitHub release URL");
+        ResolvedSymphonyReleaseAsset[] assets = release.Assets
+            .Select(ToResolvedAsset)
+            .ToArray();
+
+        if (assets.Length == 0)
+        {
+            throw new SymphonyReleaseResolutionException(
+                $"Symphony release '{releaseTag}' does not publish any downloadable assets.");
+        }
+
+        ResolvedSymphonyReleaseAsset selectedAsset = SelectAsset(selector, target, releaseTag, assets);
+
+        return new ResolvedSymphonyRelease(
+            selector,
+            releaseTag,
+            releaseUrl,
+            release.PublishedAtUtc,
+            release.Prerelease,
+            selectedAsset,
+            assets);
+    }
+
+    private async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        ReleaseSelector selector,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await httpClient.SendAsync(
+                request,
+                HttpCompletionOption.ResponseContentRead,
+                cancellationToken);
+        }
+        catch (HttpRequestException ex)
+        {
+            throw new SymphonyReleaseResolutionException(
+                $"GitHub Releases request failed while resolving Symphony release selector '{selector}'.",
+                ex);
+        }
+    }
+
+    private HttpRequestMessage CreateRequest(string endpoint)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get, BuildEndpointUri(endpoint));
+        request.Headers.UserAgent.Add(UserAgent);
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.github+json"));
+        request.Headers.TryAddWithoutValidation("X-GitHub-Api-Version", "2022-11-28");
+
+        return request;
+    }
+
+    private Uri BuildEndpointUri(string endpoint)
+    {
+        Uri baseUri = httpClient.BaseAddress ?? DefaultApiBaseUri;
+        return new Uri(baseUri, endpoint);
+    }
+
+    private static SymphonyReleaseResolutionException CreateHttpFailure(
+        ReleaseSelector selector,
+        HttpResponseMessage response)
+    {
+        if (response.StatusCode == HttpStatusCode.NotFound)
+        {
+            return selector.IsLatest
+                ? new SymphonyReleaseResolutionException(
+                    $"GitHub did not return a latest Symphony release from {SymphonyRepositoryOwner}/{SymphonyRepositoryName}.")
+                : new SymphonyReleaseResolutionException(
+                    $"Symphony release tag '{selector.Tag}' was not found in {SymphonyRepositoryOwner}/{SymphonyRepositoryName}.");
+        }
+
+        return new SymphonyReleaseResolutionException(
+            string.Create(
+                CultureInfo.InvariantCulture,
+                $"GitHub Releases returned HTTP {(int)response.StatusCode} ({response.ReasonPhrase}) while resolving Symphony release selector '{selector}'."));
+    }
+
+    private static ResolvedSymphonyReleaseAsset SelectAsset(
+        ReleaseSelector selector,
+        RuntimeTarget target,
+        ReleaseTag releaseTag,
+        IReadOnlyList<ResolvedSymphonyReleaseAsset> assets)
+    {
+        SymphonyReleaseAssetKind[] preferredKinds = GetPreferredKinds(target);
+        string[] operatingSystemAliases = GetOperatingSystemAliases(target.OperatingSystem);
+        string[] architectureAliases = GetArchitectureAliases(target.Architecture);
+
+        var selected = assets
+            .Select((asset, index) => new AssetCandidate(
+                asset,
+                index,
+                Array.IndexOf(preferredKinds, asset.Kind),
+                GetAssetScore(asset)))
+            .Where(candidate => candidate.KindPreferenceIndex >= 0)
+            .Where(candidate => ContainsAnyToken(candidate.Asset.Name, operatingSystemAliases))
+            .Where(candidate => ContainsAnyToken(candidate.Asset.Name, architectureAliases))
+            .OrderBy(candidate => candidate.KindPreferenceIndex)
+            .ThenByDescending(candidate => candidate.Score)
+            .ThenBy(candidate => candidate.OriginalIndex)
+            .FirstOrDefault();
+
+        if (selected is not null)
+        {
+            return selected.Asset;
+        }
+
+        throw new SymphonyReleaseResolutionException(
+            $"No Symphony release asset compatible with {target.ExecutionMode} {target.OperatingSystem}/{target.Architecture} " +
+            $"was found for selector '{selector}' resolved to '{releaseTag}'. Available assets: {FormatAssetList(assets)}.");
+    }
+
+    private static SymphonyReleaseAssetKind[] GetPreferredKinds(RuntimeTarget target)
+    {
+        return target.ArtifactPreference switch
+        {
+            RuntimeArtifactPreference.ReleaseArchive => [SymphonyReleaseAssetKind.ReleaseArchive],
+            RuntimeArtifactPreference.ContainerImage => [SymphonyReleaseAssetKind.ContainerImageMetadata],
+            _ when target.ExecutionMode is ExecutionMode.Docker or ExecutionMode.AzureContainer =>
+                [SymphonyReleaseAssetKind.ContainerImageMetadata, SymphonyReleaseAssetKind.ReleaseArchive],
+            _ => [SymphonyReleaseAssetKind.ReleaseArchive],
+        };
+    }
+
+    private static string[] GetOperatingSystemAliases(string operatingSystem)
+    {
+        return operatingSystem switch
+        {
+            "windows" or "win" or "win32" => ["windows", "win", "win32"],
+            "linux" => ["linux"],
+            "macos" or "osx" or "darwin" or "mac" => ["macos", "osx", "darwin", "mac"],
+            _ => [operatingSystem],
+        };
+    }
+
+    private static string[] GetArchitectureAliases(string architecture)
+    {
+        return architecture switch
+        {
+            "x64" or "amd64" or "x86_64" or "x86-64" => ["x64", "amd64", "x86_64", "x86-64"],
+            "arm64" or "aarch64" => ["arm64", "aarch64"],
+            "x86" or "i386" or "i686" => ["x86", "i386", "i686"],
+            _ => [architecture],
+        };
+    }
+
+    private static int GetAssetScore(ResolvedSymphonyReleaseAsset asset)
+    {
+        int score = 0;
+
+        if (asset.Name.StartsWith("symphony", StringComparison.OrdinalIgnoreCase))
+        {
+            score += 2;
+        }
+
+        if (asset.Name.EndsWith(".zip", StringComparison.OrdinalIgnoreCase) ||
+            asset.Name.EndsWith(".tar.gz", StringComparison.OrdinalIgnoreCase) ||
+            asset.Name.EndsWith(".tgz", StringComparison.OrdinalIgnoreCase))
+        {
+            score += 2;
+        }
+
+        if (asset.ContentType?.Contains("zip", StringComparison.OrdinalIgnoreCase) == true ||
+            asset.ContentType?.Contains("gzip", StringComparison.OrdinalIgnoreCase) == true ||
+            asset.ContentType?.Contains("json", StringComparison.OrdinalIgnoreCase) == true)
+        {
+            score++;
+        }
+
+        return score;
+    }
+
+    private static bool ContainsAnyToken(string value, IReadOnlyList<string> tokens)
+    {
+        string searchable = ToTokenSearchString(value);
+
+        return tokens
+            .Select(ToTokenSearchString)
+            .Any(token => searchable.Contains(token, StringComparison.Ordinal));
+    }
+
+    private static string ToTokenSearchString(string value)
+    {
+        var builder = new StringBuilder(value.Length + 2);
+        builder.Append('-');
+        bool previousWasSeparator = true;
+
+        foreach (char c in value.ToLowerInvariant())
+        {
+            if (char.IsLetterOrDigit(c))
+            {
+                builder.Append(c);
+                previousWasSeparator = false;
+            }
+            else if (!previousWasSeparator)
+            {
+                builder.Append('-');
+                previousWasSeparator = true;
+            }
+        }
+
+        if (!previousWasSeparator)
+        {
+            builder.Append('-');
+        }
+
+        return builder.ToString();
+    }
+
+    private static string FormatAssetList(IReadOnlyList<ResolvedSymphonyReleaseAsset> assets)
+    {
+        string[] assetNames = assets
+            .Take(10)
+            .Select(asset => asset.Name)
+            .ToArray();
+        string suffix = assets.Count > assetNames.Length ? ", ..." : string.Empty;
+
+        return assetNames.Length == 0
+            ? "none"
+            : string.Join(", ", assetNames) + suffix;
+    }
+
+    private static ResolvedSymphonyReleaseAsset ToResolvedAsset(GitHubReleaseAsset asset)
+    {
+        string name = RequireNonEmpty(asset.Name, "GitHub release asset name");
+
+        return new ResolvedSymphonyReleaseAsset(
+            name,
+            CreateAbsoluteUri(asset.BrowserDownloadUrl, $"GitHub release asset '{name}' download URL"),
+            asset.Size,
+            asset.ContentType,
+            asset.Digest,
+            ClassifyAsset(name));
+    }
+
+    private static SymphonyReleaseAssetKind ClassifyAsset(string name)
+    {
+        if (ContainsAnyToken(name, ["docker", "container", "image", "oci"]))
+        {
+            return SymphonyReleaseAssetKind.ContainerImageMetadata;
+        }
+
+        if (ContainsAnyToken(name, ["source", "src"]))
+        {
+            return SymphonyReleaseAssetKind.SourceArchive;
+        }
+
+        return SymphonyReleaseAssetKind.ReleaseArchive;
+    }
+
+    private static Uri CreateAbsoluteUri(string value, string fieldName)
+    {
+        if (!Uri.TryCreate(RequireNonEmpty(value, fieldName), UriKind.Absolute, out Uri? uri))
+        {
+            throw new JsonException($"{fieldName} was not an absolute URL.");
+        }
+
+        return uri;
+    }
+
+    private static async Task<string> ReadBodyAsync(
+        HttpResponseMessage response,
+        CancellationToken cancellationToken) =>
+        response.Content is null
+            ? string.Empty
+            : await response.Content.ReadAsStringAsync(cancellationToken);
+
+    private static GitHubReleaseResponse Deserialize(string json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            throw new JsonException("GitHub returned an empty release JSON response.");
+        }
+
+        return JsonSerializer.Deserialize<GitHubReleaseResponse>(json, JsonOptions)
+            ?? throw new JsonException("GitHub returned an unexpected release JSON response.");
+    }
+
+    private static string RequireNonEmpty(string value, string fieldName)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new JsonException($"{fieldName} is required.");
+        }
+
+        return value.Trim();
+    }
+
+    private sealed record AssetCandidate(
+        ResolvedSymphonyReleaseAsset Asset,
+        int OriginalIndex,
+        int KindPreferenceIndex,
+        int Score);
+
+    private sealed record GitHubReleaseResponse
+    {
+        [JsonPropertyName("tag_name")]
+        public string TagName { get; init; } = string.Empty;
+
+        [JsonPropertyName("html_url")]
+        public string HtmlUrl { get; init; } = string.Empty;
+
+        [JsonPropertyName("published_at")]
+        public DateTimeOffset? PublishedAtUtc { get; init; }
+
+        public bool Prerelease { get; init; }
+
+        public IReadOnlyList<GitHubReleaseAsset> Assets { get; init; } = [];
+    }
+
+    private sealed record GitHubReleaseAsset
+    {
+        public string Name { get; init; } = string.Empty;
+
+        [JsonPropertyName("browser_download_url")]
+        public string BrowserDownloadUrl { get; init; } = string.Empty;
+
+        [JsonPropertyName("content_type")]
+        public string? ContentType { get; init; }
+
+        public long Size { get; init; }
+
+        public string? Digest { get; init; }
+    }
+}

--- a/tests/Conductor.Core.Tests/SymphonyReleaseResolverModelTests.cs
+++ b/tests/Conductor.Core.Tests/SymphonyReleaseResolverModelTests.cs
@@ -1,0 +1,51 @@
+using Conductor.Core.Abstractions.Releases;
+using Conductor.Core.Domain;
+using Conductor.Core.Domain.Releases;
+
+namespace Conductor.Core.Tests;
+
+public sealed class SymphonyReleaseResolverModelTests
+{
+    [Fact]
+    public void RuntimeTarget_Normalizes_Platform_Tokens()
+    {
+        var target = new RuntimeTarget(
+            ExecutionMode.LocalProcess,
+            " Windows ",
+            " X64 ",
+            RuntimeArtifactPreference.ReleaseArchive);
+
+        Assert.Equal(ExecutionMode.LocalProcess, target.ExecutionMode);
+        Assert.Equal("windows", target.OperatingSystem);
+        Assert.Equal("x64", target.Architecture);
+        Assert.Equal(RuntimeArtifactPreference.ReleaseArchive, target.ArtifactPreference);
+        Assert.Equal("LocalProcess windows/x64 (ReleaseArchive)", target.ToString());
+    }
+
+    [Fact]
+    public void ResolvedSymphonyRelease_Creates_Persistable_Artifact_Provenance()
+    {
+        var selectedAsset = new ResolvedSymphonyReleaseAsset(
+            "symphony-linux-x64.tar.gz",
+            new Uri("https://github.com/releasedgroup/symphony/releases/download/v0.0.7-alpha/symphony-linux-x64.tar.gz"),
+            42_000,
+            "application/gzip",
+            "sha256:abc123",
+            SymphonyReleaseAssetKind.ReleaseArchive);
+        var release = new ResolvedSymphonyRelease(
+            ReleaseSelector.Latest,
+            new ReleaseTag("v0.0.7-alpha"),
+            new Uri("https://github.com/releasedgroup/symphony/releases/tag/v0.0.7-alpha"),
+            DateTimeOffset.Parse("2026-04-29T00:00:00Z"),
+            isPrerelease: true,
+            selectedAsset,
+            [selectedAsset]);
+
+        var artifact = release.ToArtifact(DateTimeOffset.Parse("2026-04-29T01:00:00Z"));
+
+        Assert.Equal("v0.0.7-alpha", artifact.ReleaseTag.Value);
+        Assert.Equal("symphony-linux-x64.tar.gz", artifact.AssetName);
+        Assert.Equal(selectedAsset.SourceUrl, artifact.SourceUrl);
+        Assert.Equal("sha256:abc123", artifact.Checksum);
+    }
+}

--- a/tests/Conductor.Integration.Tests/GitHubSymphonyReleaseResolverTests.cs
+++ b/tests/Conductor.Integration.Tests/GitHubSymphonyReleaseResolverTests.cs
@@ -1,0 +1,250 @@
+using System.Net;
+using System.Net.Http.Headers;
+using Conductor.Core.Abstractions.Releases;
+using Conductor.Core.Domain;
+using Conductor.Core.Domain.Releases;
+using Conductor.Infrastructure.GitHub;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Conductor.Integration.Tests;
+
+public sealed class GitHubSymphonyReleaseResolverTests
+{
+    [Fact]
+    public async Task ResolveAsync_Uses_Latest_Endpoint_And_Selects_Local_Target_Asset()
+    {
+        var handler = new QueueHandler(_ => JsonResponse(
+            HttpStatusCode.OK,
+            """
+            {
+              "tag_name": "v0.0.7-alpha",
+              "html_url": "https://github.com/releasedgroup/symphony/releases/tag/v0.0.7-alpha",
+              "published_at": "2026-04-29T00:10:00Z",
+              "prerelease": true,
+              "assets": [
+                {
+                  "name": "symphony-linux-x64.tar.gz",
+                  "browser_download_url": "https://github.com/releasedgroup/symphony/releases/download/v0.0.7-alpha/symphony-linux-x64.tar.gz",
+                  "content_type": "application/gzip",
+                  "size": 1200,
+                  "digest": "sha256:linux"
+                },
+                {
+                  "name": "symphony-win-x64.zip",
+                  "browser_download_url": "https://github.com/releasedgroup/symphony/releases/download/v0.0.7-alpha/symphony-win-x64.zip",
+                  "content_type": "application/zip",
+                  "size": 1250,
+                  "digest": "sha256:windows"
+                }
+              ]
+            }
+            """));
+        GitHubSymphonyReleaseResolver resolver = CreateResolver(handler);
+
+        ResolvedSymphonyRelease release = await resolver.ResolveAsync(
+            ReleaseSelector.Latest,
+            new RuntimeTarget(ExecutionMode.LocalProcess, "windows", "x64"),
+            CancellationToken.None);
+
+        Assert.Equal("v0.0.7-alpha", release.ReleaseTag.Value);
+        Assert.Equal(ReleaseSelector.Latest, release.RequestedSelector);
+        Assert.True(release.IsPrerelease);
+        Assert.Equal(DateTimeOffset.Parse("2026-04-29T00:10:00Z"), release.PublishedAtUtc);
+        Assert.Equal("symphony-win-x64.zip", release.SelectedAsset.Name);
+        Assert.Equal(SymphonyReleaseAssetKind.ReleaseArchive, release.SelectedAsset.Kind);
+        Assert.Equal("sha256:windows", release.SelectedAsset.Checksum);
+        Assert.Equal(2, release.Assets.Count);
+
+        RecordedRequest request = Assert.Single(handler.Requests);
+        Assert.Equal("GET /repos/releasedgroup/symphony/releases/latest", $"{request.Method} {request.Uri.AbsolutePath}");
+        Assert.Contains("application/vnd.github+json", request.Accept);
+        Assert.Contains("Conductor/1.0", request.UserAgent);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_Uses_Tag_Endpoint_For_Pinned_Releases()
+    {
+        var handler = new QueueHandler(_ => JsonResponse(
+            HttpStatusCode.OK,
+            """
+            {
+              "tag_name": "v0.0.6-alpha",
+              "html_url": "https://github.com/releasedgroup/symphony/releases/tag/v0.0.6-alpha",
+              "published_at": "2026-04-28T03:00:00Z",
+              "prerelease": true,
+              "assets": [
+                {
+                  "name": "symphony-linux-x64.tar.gz",
+                  "browser_download_url": "https://github.com/releasedgroup/symphony/releases/download/v0.0.6-alpha/symphony-linux-x64.tar.gz",
+                  "content_type": "application/gzip",
+                  "size": 1000,
+                  "digest": "sha256:pinned"
+                }
+              ]
+            }
+            """));
+        GitHubSymphonyReleaseResolver resolver = CreateResolver(handler);
+
+        ResolvedSymphonyRelease release = await resolver.ResolveAsync(
+            ReleaseSelector.PinnedTag("v0.0.6-alpha"),
+            new RuntimeTarget(ExecutionMode.LocalProcess, "linux", "x64"),
+            CancellationToken.None);
+
+        Assert.Equal("v0.0.6-alpha", release.ReleaseTag.Value);
+        Assert.Equal("symphony-linux-x64.tar.gz", release.SelectedAsset.Name);
+
+        RecordedRequest request = Assert.Single(handler.Requests);
+        Assert.Equal("GET /repos/releasedgroup/symphony/releases/tags/v0.0.6-alpha", $"{request.Method} {request.Uri.AbsolutePath}");
+    }
+
+    [Fact]
+    public async Task ResolveAsync_Prefers_Container_Image_Metadata_For_Docker_Target()
+    {
+        var handler = new QueueHandler(_ => JsonResponse(
+            HttpStatusCode.OK,
+            """
+            {
+              "tag_name": "v0.0.7-alpha",
+              "html_url": "https://github.com/releasedgroup/symphony/releases/tag/v0.0.7-alpha",
+              "published_at": "2026-04-29T00:10:00Z",
+              "prerelease": true,
+              "assets": [
+                {
+                  "name": "symphony-linux-x64.tar.gz",
+                  "browser_download_url": "https://github.com/releasedgroup/symphony/releases/download/v0.0.7-alpha/symphony-linux-x64.tar.gz",
+                  "content_type": "application/gzip",
+                  "size": 1200,
+                  "digest": "sha256:linux"
+                },
+                {
+                  "name": "symphony-container-linux-x64.json",
+                  "browser_download_url": "https://github.com/releasedgroup/symphony/releases/download/v0.0.7-alpha/symphony-container-linux-x64.json",
+                  "content_type": "application/json",
+                  "size": 500,
+                  "digest": "sha256:image"
+                }
+              ]
+            }
+            """));
+        GitHubSymphonyReleaseResolver resolver = CreateResolver(handler);
+
+        ResolvedSymphonyRelease release = await resolver.ResolveAsync(
+            ReleaseSelector.Latest,
+            new RuntimeTarget(ExecutionMode.Docker, "linux", "x64"),
+            CancellationToken.None);
+
+        Assert.Equal("symphony-container-linux-x64.json", release.SelectedAsset.Name);
+        Assert.Equal(SymphonyReleaseAssetKind.ContainerImageMetadata, release.SelectedAsset.Kind);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_Fails_When_No_Compatible_Asset_Is_Published()
+    {
+        var handler = new QueueHandler(_ => JsonResponse(
+            HttpStatusCode.OK,
+            """
+            {
+              "tag_name": "v0.0.7-alpha",
+              "html_url": "https://github.com/releasedgroup/symphony/releases/tag/v0.0.7-alpha",
+              "published_at": "2026-04-29T00:10:00Z",
+              "prerelease": true,
+              "assets": [
+                {
+                  "name": "symphony-linux-x64.tar.gz",
+                  "browser_download_url": "https://github.com/releasedgroup/symphony/releases/download/v0.0.7-alpha/symphony-linux-x64.tar.gz",
+                  "content_type": "application/gzip",
+                  "size": 1200,
+                  "digest": "sha256:linux"
+                }
+              ]
+            }
+            """));
+        GitHubSymphonyReleaseResolver resolver = CreateResolver(handler);
+
+        SymphonyReleaseResolutionException exception = await Assert.ThrowsAsync<SymphonyReleaseResolutionException>(() =>
+            resolver.ResolveAsync(
+                ReleaseSelector.Latest,
+                new RuntimeTarget(ExecutionMode.LocalProcess, "windows", "arm64"),
+                CancellationToken.None));
+
+        Assert.Contains("No Symphony release asset compatible with LocalProcess windows/arm64", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("symphony-linux-x64.tar.gz", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ResolveAsync_Reports_Missing_Pinned_Tag()
+    {
+        var handler = new QueueHandler(_ => JsonResponse(
+            HttpStatusCode.NotFound,
+            """{"message":"Not Found"}"""));
+        GitHubSymphonyReleaseResolver resolver = CreateResolver(handler);
+
+        SymphonyReleaseResolutionException exception = await Assert.ThrowsAsync<SymphonyReleaseResolutionException>(() =>
+            resolver.ResolveAsync(
+                ReleaseSelector.PinnedTag("v9.9.9"),
+                new RuntimeTarget(ExecutionMode.LocalProcess, "linux", "x64"),
+                CancellationToken.None));
+
+        Assert.Contains("v9.9.9", exception.Message, StringComparison.Ordinal);
+        Assert.Contains("not found", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void AddConductorGitHub_Registers_Symphony_Release_Resolver()
+    {
+        ServiceCollection services = [];
+
+        services.AddConductorGitHub();
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        Assert.IsType<GitHubSymphonyReleaseResolver>(provider.GetRequiredService<ISymphonyReleaseResolver>());
+    }
+
+    private static GitHubSymphonyReleaseResolver CreateResolver(QueueHandler handler)
+    {
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://api.github.test/"),
+        };
+
+        return new GitHubSymphonyReleaseResolver(httpClient);
+    }
+
+    private static HttpResponseMessage JsonResponse(HttpStatusCode statusCode, string json)
+    {
+        var response = new HttpResponseMessage(statusCode)
+        {
+            Content = new StringContent(json),
+        };
+        response.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+        return response;
+    }
+
+    private sealed class QueueHandler(
+        params Func<RecordedRequest, HttpResponseMessage>[] responses) : HttpMessageHandler
+    {
+        private readonly Queue<Func<RecordedRequest, HttpResponseMessage>> responses = new(responses);
+
+        public List<RecordedRequest> Requests { get; } = [];
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            var recordedRequest = new RecordedRequest(
+                request.Method.Method,
+                request.RequestUri ?? throw new InvalidOperationException("Request URI was not set."),
+                string.Join(" ", request.Headers.UserAgent.Select(value => value.ToString())),
+                string.Join(", ", request.Headers.Accept.Select(value => value.MediaType)));
+
+            Requests.Add(recordedRequest);
+            return Task.FromResult(responses.Dequeue()(recordedRequest));
+        }
+    }
+
+    private sealed record RecordedRequest(
+        string Method,
+        Uri Uri,
+        string UserAgent,
+        string Accept);
+}


### PR DESCRIPTION
## Summary

- Add the core `ISymphonyReleaseResolver` contract, runtime target model, resolved release metadata, and artifact provenance projection.
- Implement the GitHub Releases-backed Symphony resolver for dynamic `latest` resolution, pinned tag resolution, and execution-mode/OS/architecture asset selection.
- Register the resolver in `Conductor.Infrastructure.GitHub`, add focused unit and integration coverage, and document the resolver behavior in the README.

Closes #54

## Validation

- `dotnet restore Conductor.slnx`
- `dotnet build Conductor.slnx --no-restore --warnaserror`
- `dotnet test Conductor.slnx --no-build`
- `dotnet format Conductor.slnx --no-restore --verify-no-changes`

## Notes

The resolver keeps `latest` dynamic and does not hard-code the current Symphony tag. It currently resolves metadata and selects the compatible published asset; download/extract/cache orchestration remains a separate provisioning/cache layer.