### PR TITLE
[codex] Add workflow profile editor

### DIFF
--- a/docs/feature_guides.md
+++ b/docs/feature_guides.md
@@ -33,3 +33,11 @@ When no repository projection data exists, the dashboard renders an empty state.
 The secret descriptor list supports GitHub PAT and OpenAI API key credentials as separate types. Descriptor rows show the credential name, scope, target environment variable, and a masked value only. OpenAI API key descriptors map to `OPENAI_API_KEY`; GitHub PAT descriptors map to `GITHUB_TOKEN`.
 
 Descriptors may include validation status, validation timestamp, a short validation message, and validation metadata JSON such as accepted token prefixes and the runtime environment variable used for injection. Plaintext token values are only accepted during create or rotate workflows and must not be returned in descriptor responses.
+
+## Workflow Profile Management
+
+Workflow profiles are managed from `/settings/workflows`. Operators can create a profile, edit an existing profile, mark one profile as the default, and preview the raw `WORKFLOW.md` source before saving.
+
+Each save increments the profile revision when profile content or default state changes. When a profile becomes the default, Conductor clears the default flag from any previous default profile in the same transaction.
+
+The Repositories page uses the saved profile list when creating a Symphony instance shell. Selecting a profile persists the `WorkflowProfileId` on the instance record for later workflow generation and validation.

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -28,4 +28,14 @@ When a project is selected during import, the repository is linked immediately a
 
 The page can also create a first Symphony instance shell in `NotProvisioned` state. The shell captures execution mode, instance URL, port, release selector, and credential inheritance choices so later provisioning work can start from a validated record.
 
+If workflow profiles exist, choose one while creating the instance shell. Conductor stores that profile reference on the instance so later workflow generation can render the correct `WORKFLOW.md` source.
+
 Imported repositories appear in the managed repository registry with project, visibility, default branch, archive state, orchestration eligibility, instance counts, last sync, and latest health metadata. Open a repository row to review its detail page, including clone and web URLs, sync metadata, orchestration status, and active Symphony instances attached to that repository.
+
+## Workflow Profiles
+
+Use the Workflows page to create and edit reusable `WORKFLOW.md` profiles. Each profile stores a name, optional description, raw Markdown source, default flag, revision number, and created/updated timestamps.
+
+Mark one profile as the default when it should be the standard choice for new Symphony instance shells. Setting a profile as default clears the previous default profile.
+
+The editor shows the current source beside the form before save. Saving a profile validates required fields and preserves an audit event for create and update operations.

--- a/src/Conductor.Core/Application/Workflows/IWorkflowProfileService.cs
+++ b/src/Conductor.Core/Application/Workflows/IWorkflowProfileService.cs
@@ -1,0 +1,81 @@
+using Conductor.Core.Domain.Ids;
+
+namespace Conductor.Core.Application.Workflows;
+
+public interface IWorkflowProfileService
+{
+    Task<IReadOnlyList<WorkflowProfileSummary>> ListAsync(
+        WorkflowProfileQuery query,
+        CancellationToken cancellationToken = default);
+
+    Task<WorkflowProfileDetail?> GetAsync(
+        WorkflowProfileId profileId,
+        CancellationToken cancellationToken = default);
+
+    Task<WorkflowProfileMutationResult> CreateAsync(
+        WorkflowProfileMutationRequest request,
+        CancellationToken cancellationToken = default);
+
+    Task<WorkflowProfileMutationResult> UpdateAsync(
+        WorkflowProfileId profileId,
+        WorkflowProfileMutationRequest request,
+        CancellationToken cancellationToken = default);
+}
+
+public sealed record WorkflowProfileQuery(
+    string? Search = null);
+
+public sealed record WorkflowProfileSummary(
+    WorkflowProfileId Id,
+    string Name,
+    string? Description,
+    bool IsDefault,
+    int Revision,
+    DateTimeOffset CreatedAtUtc,
+    DateTimeOffset UpdatedAtUtc);
+
+public sealed record WorkflowProfileDetail(
+    WorkflowProfileId Id,
+    string Name,
+    string? Description,
+    string WorkflowSource,
+    bool IsDefault,
+    int Revision,
+    DateTimeOffset CreatedAtUtc,
+    DateTimeOffset UpdatedAtUtc);
+
+public sealed record WorkflowProfileMutationRequest(
+    string Name,
+    string? Description,
+    string WorkflowSource,
+    bool IsDefault = false,
+    string? RequestedByUserId = null);
+
+public sealed record WorkflowProfileMutationResult(
+    WorkflowProfileId Id,
+    string Name,
+    bool IsDefault,
+    int Revision,
+    DateTimeOffset UpdatedAtUtc);
+
+public sealed class WorkflowProfileValidationException : Exception
+{
+    public WorkflowProfileValidationException(IReadOnlyDictionary<string, string[]> errors)
+        : base("Workflow profile failed validation.")
+    {
+        Errors = errors;
+    }
+
+    public IReadOnlyDictionary<string, string[]> Errors { get; }
+}
+
+public sealed class WorkflowProfileNotFoundException : Exception
+{
+    public WorkflowProfileNotFoundException(WorkflowProfileId profileId)
+        : base($"Workflow profile '{profileId}' was not found.")
+    {
+        ProfileId = profileId;
+    }
+
+    public WorkflowProfileId ProfileId { get; }
+}

--- a/src/Conductor.Core/Domain/Symphony/SymphonyInstance.cs
+++ b/src/Conductor.Core/Domain/Symphony/SymphonyInstance.cs
@@ -28,7 +28,8 @@ public sealed class SymphonyInstance
         string? workflowPath = null,
         string? dataPath = null,
         DateTimeOffset? lastStartedAtUtc = null,
-        DateTimeOffset? lastSeenAtUtc = null)
+        DateTimeOffset? lastSeenAtUtc = null,
+        WorkflowProfileId? workflowProfileId = null)
     {
         Id = new SymphonyInstanceId(Guard.NotEmpty(id.Value, nameof(id)));
         RepositoryId = new RepositoryId(Guard.NotEmpty(repositoryId.Value, nameof(repositoryId)));
@@ -57,6 +58,9 @@ public sealed class SymphonyInstance
         OpenAiCredentialInheritanceMode = openAiCredentialInheritanceMode;
         WorkflowPath = Guard.OptionalTrimmed(workflowPath);
         DataPath = Guard.OptionalTrimmed(dataPath);
+        WorkflowProfileId = workflowProfileId is null
+            ? null
+            : new WorkflowProfileId(Guard.NotEmpty(workflowProfileId.Value.Value, nameof(workflowProfileId)));
         LastStartedAtUtc = ValidateObservedAt(lastStartedAtUtc, nameof(lastStartedAtUtc));
         LastSeenAtUtc = ValidateObservedAt(lastSeenAtUtc, nameof(lastSeenAtUtc));
     }
@@ -100,6 +104,8 @@ public sealed class SymphonyInstance
     public string? WorkflowPath { get; private set; }
 
     public string? DataPath { get; private set; }
+
+    public WorkflowProfileId? WorkflowProfileId { get; private set; }
 
     public DateTimeOffset CreatedAtUtc { get; }
 
@@ -173,6 +179,13 @@ public sealed class SymphonyInstance
     {
         WorkflowPath = Guard.OptionalTrimmed(workflowPath);
         DataPath = Guard.OptionalTrimmed(dataPath);
+    }
+
+    public void AssignWorkflowProfile(WorkflowProfileId? workflowProfileId)
+    {
+        WorkflowProfileId = workflowProfileId is null
+            ? null
+            : new WorkflowProfileId(Guard.NotEmpty(workflowProfileId.Value.Value, nameof(workflowProfileId)));
     }
 
     public void MarkLifecycle(InstanceLifecycleStatus lifecycleStatus)

--- a/src/Conductor.Core/Domain/Workflows/WorkflowProfile.cs
+++ b/src/Conductor.Core/Domain/Workflows/WorkflowProfile.cs
@@ -10,18 +10,133 @@ public sealed class WorkflowProfile
         string name,
         string workflowSource,
         DateTimeOffset createdAtUtc)
+        : this(
+            id,
+            name,
+            description: null,
+            workflowSource,
+            isDefault: false,
+            createdAtUtc,
+            updatedAtUtc: createdAtUtc,
+            revision: 1)
     {
-        Id = id;
+    }
+
+    public WorkflowProfile(
+        WorkflowProfileId id,
+        string name,
+        string? description,
+        string workflowSource,
+        bool isDefault,
+        DateTimeOffset createdAtUtc,
+        DateTimeOffset updatedAtUtc,
+        int revision = 1)
+    {
+        if (revision < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(revision), revision, "Workflow profile revision must be at least 1.");
+        }
+
+        Id = new WorkflowProfileId(Guard.NotEmpty(id.Value, nameof(id)));
         Name = Guard.NotWhiteSpace(name, nameof(name));
+        Description = Guard.OptionalTrimmed(description);
         WorkflowSource = Guard.NotWhiteSpace(workflowSource, nameof(workflowSource));
-        CreatedAtUtc = createdAtUtc;
+        IsDefault = isDefault;
+        CreatedAtUtc = Guard.Utc(createdAtUtc, nameof(createdAtUtc));
+        UpdatedAtUtc = Guard.Utc(updatedAtUtc, nameof(updatedAtUtc));
+        Revision = revision;
+
+        if (UpdatedAtUtc < CreatedAtUtc)
+        {
+            throw new ArgumentException("Updated timestamp cannot be earlier than created timestamp.", nameof(updatedAtUtc));
+        }
     }
 
     public WorkflowProfileId Id { get; }
 
-    public string Name { get; }
+    public string Name { get; private set; }
 
-    public string WorkflowSource { get; }
+    public string? Description { get; private set; }
+
+    public string WorkflowSource { get; private set; }
+
+    public bool IsDefault { get; private set; }
+
+    public int Revision { get; private set; }
 
     public DateTimeOffset CreatedAtUtc { get; }
+
+    public DateTimeOffset UpdatedAtUtc { get; private set; }
+
+    public void Update(
+        string name,
+        string? description,
+        string workflowSource,
+        bool isDefault,
+        DateTimeOffset updatedAtUtc)
+    {
+        var validatedName = Guard.NotWhiteSpace(name, nameof(name));
+        var validatedDescription = Guard.OptionalTrimmed(description);
+        var validatedWorkflowSource = Guard.NotWhiteSpace(workflowSource, nameof(workflowSource));
+        var validatedUpdatedAtUtc = ValidateUpdatedAt(updatedAtUtc);
+
+        if (Name == validatedName &&
+            Description == validatedDescription &&
+            WorkflowSource == validatedWorkflowSource &&
+            IsDefault == isDefault)
+        {
+            return;
+        }
+
+        Name = validatedName;
+        Description = validatedDescription;
+        WorkflowSource = validatedWorkflowSource;
+        IsDefault = isDefault;
+        RecordRevision(validatedUpdatedAtUtc);
+    }
+
+    public void MarkDefault(DateTimeOffset updatedAtUtc)
+    {
+        if (IsDefault)
+        {
+            return;
+        }
+
+        IsDefault = true;
+        RecordRevision(ValidateUpdatedAt(updatedAtUtc));
+    }
+
+    public void ClearDefault(DateTimeOffset updatedAtUtc)
+    {
+        if (!IsDefault)
+        {
+            return;
+        }
+
+        IsDefault = false;
+        RecordRevision(ValidateUpdatedAt(updatedAtUtc));
+    }
+
+    private void RecordRevision(DateTimeOffset updatedAtUtc)
+    {
+        UpdatedAtUtc = updatedAtUtc;
+        Revision++;
+    }
+
+    private DateTimeOffset ValidateUpdatedAt(DateTimeOffset updatedAtUtc)
+    {
+        var utcUpdatedAt = Guard.Utc(updatedAtUtc, nameof(updatedAtUtc));
+
+        if (utcUpdatedAt < CreatedAtUtc)
+        {
+            throw new ArgumentException("Updated timestamp cannot be earlier than created timestamp.", nameof(updatedAtUtc));
+        }
+
+        if (utcUpdatedAt < UpdatedAtUtc)
+        {
+            throw new ArgumentException("Updated timestamp cannot move backwards.", nameof(updatedAtUtc));
+        }
+
+        return utcUpdatedAt;
+    }
 }

--- a/src/Conductor.Host/Components/Layout/MainLayout.razor
+++ b/src/Conductor.Host/Components/Layout/MainLayout.razor
@@ -11,6 +11,7 @@
             <NavLink href="/projects">Projects</NavLink>
             <NavLink href="/repositories">Repositories</NavLink>
             <NavLink href="/instances">Instances</NavLink>
+            <NavLink href="/settings/workflows">Workflows</NavLink>
             <NavLink href="/settings/secrets">Secrets</NavLink>
             <NavLink href="/reports">Reports</NavLink>
         </nav>

--- a/src/Conductor.Host/Components/Pages/Repositories.razor
+++ b/src/Conductor.Host/Components/Pages/Repositories.razor
@@ -2,11 +2,13 @@
 @rendermode InteractiveServer
 @using Conductor.Core.Application.Queries
 @using Conductor.Core.Application.Repositories
+@using Conductor.Core.Application.Workflows
 @using Conductor.Core.Domain
 @using Conductor.Core.Domain.Ids
 @inject IRepositoryImportService RepositoryImportService
 @inject IRepositoryListQueryService RepositoryListQueryService
 @inject IProjectListQueryService ProjectListQueryService
+@inject IWorkflowProfileService WorkflowProfileService
 
 <PageTitle>Repositories - Conductor</PageTitle>
 
@@ -114,6 +116,16 @@
                                 @foreach (ExecutionMode executionMode in Enum.GetValues<ExecutionMode>())
                                 {
                                     <option value="@executionMode.ToString()">@executionMode</option>
+                                }
+                            </select>
+                        </label>
+                        <label>
+                            <span>Workflow profile</span>
+                            <select id="workflow-profile-id" @bind="importForm.WorkflowProfileId" disabled="@isSubmitting">
+                                <option value="">Unassigned</option>
+                                @foreach (WorkflowProfileSummary profile in workflowProfiles)
+                                {
+                                    <option value="@profile.Id.ToString()">@FormatWorkflowProfileOption(profile)</option>
                                 }
                             </select>
                         </label>
@@ -269,6 +281,7 @@
     private readonly RepositoryImportForm importForm = new();
     private IReadOnlyList<RepositoryListItemProjection> repositories = [];
     private IReadOnlyList<ProjectListItemProjection> projects = [];
+    private IReadOnlyList<WorkflowProfileSummary> workflowProfiles = [];
     private readonly List<string> validationMessages = [];
     private RepositoryImportResult? importResult;
     private string? importError;
@@ -316,6 +329,12 @@
             projectId = parsedProjectId;
         }
 
+        WorkflowProfileId? workflowProfileId = null;
+        if (WorkflowProfileId.TryParse(importForm.WorkflowProfileId, out WorkflowProfileId parsedWorkflowProfileId))
+        {
+            workflowProfileId = parsedWorkflowProfileId;
+        }
+
         return new RepositoryImportRequest(
             importForm.RepositoryFullName,
             importForm.DefaultBranch,
@@ -328,6 +347,7 @@
             InstanceBaseUrl: importForm.InstanceBaseUrl,
             Port: importForm.Port,
             ReleaseTag: importForm.ReleaseTag,
+            WorkflowProfileId: workflowProfileId,
             GitHubCredentialInheritanceMode: ParseEnum<CredentialInheritanceMode>(importForm.GitHubCredentialMode),
             OpenAiCredentialInheritanceMode: ParseEnum<CredentialInheritanceMode>(importForm.OpenAiCredentialMode),
             RequestedByUserId: "ui");
@@ -341,6 +361,7 @@
         try
         {
             projects = await ProjectListQueryService.ListProjectsAsync(new ProjectListQuery());
+            workflowProfiles = await WorkflowProfileService.ListAsync(new WorkflowProfileQuery());
             repositories = await RepositoryListQueryService.ListRepositoriesAsync(new RepositoryListQuery());
         }
         catch (Exception ex) when (ex is InvalidOperationException or IOException)
@@ -355,6 +376,11 @@
 
     private static string RepositoryHref(RepositoryListItemProjection repository) =>
         $"/repositories/{repository.Id.Value:D}";
+
+    private static string FormatWorkflowProfileOption(WorkflowProfileSummary profile) =>
+        profile.IsDefault
+            ? $"{profile.Name} (default)"
+            : profile.Name;
 
     private static TEnum ParseEnum<TEnum>(string value)
         where TEnum : struct, Enum
@@ -411,6 +437,8 @@
 
         public string ReleaseTag { get; set; } = "latest";
 
+        public string WorkflowProfileId { get; set; } = string.Empty;
+
         public string GitHubCredentialMode { get; set; } = CredentialInheritanceMode.InheritDefault.ToString();
 
         public string OpenAiCredentialMode { get; set; } = CredentialInheritanceMode.InheritDefault.ToString();
@@ -428,6 +456,7 @@
             InstanceBaseUrl = "http://localhost:8080/";
             Port = 8080;
             ReleaseTag = "latest";
+            WorkflowProfileId = string.Empty;
             GitHubCredentialMode = CredentialInheritanceMode.InheritDefault.ToString();
             OpenAiCredentialMode = CredentialInheritanceMode.InheritDefault.ToString();
         }

--- a/src/Conductor.Host/Components/Pages/WorkflowProfiles.razor
+++ b/src/Conductor.Host/Components/Pages/WorkflowProfiles.razor
@@ -1,0 +1,365 @@
+@page "/settings/workflows"
+@rendermode InteractiveServer
+@using System.Data.Common
+@using Conductor.Core.Application.Workflows
+@using Conductor.Core.Domain.Ids
+@inject IWorkflowProfileService WorkflowProfileService
+
+<PageTitle>Workflow profiles - Conductor</PageTitle>
+
+<section class="workflow-profiles-page">
+    <header class="workflow-profiles-header">
+        <div>
+            <p class="eyebrow">Workflow registry</p>
+            <h1>Workflow profiles</h1>
+            <p class="workflow-profiles-summary">Reusable WORKFLOW.md templates for Symphony instance provisioning.</p>
+        </div>
+        <div class="dashboard-meta">
+            <StatusBadge Text="@($"{profiles.Count} profiles")" Tone="@StatusBadgeTone.Info" />
+            @if (profiles.Any(profile => profile.IsDefault))
+            {
+                <StatusBadge Text="Default selected" Tone="@StatusBadgeTone.Success" />
+            }
+        </div>
+    </header>
+
+    <section class="workflow-profile-editor" aria-label="Workflow profile editor">
+        <form class="workflow-profile-form" @onsubmit="SaveProfileAsync" @onsubmit:preventDefault>
+            <div class="workflow-profile-editor-heading">
+                <div>
+                    <p class="eyebrow">@EditorModeLabel</p>
+                    <h2>@EditorTitle</h2>
+                </div>
+                @if (editingProfileId is not null)
+                {
+                    <StatusBadge Text="@($"Revision {form.Revision}")" Tone="@StatusBadgeTone.Neutral" />
+                }
+            </div>
+
+            <div class="workflow-profile-form-grid">
+                <label>
+                    <span>Name</span>
+                    <input
+                        id="workflow-profile-name"
+                        type="text"
+                        required
+                        maxlength="200"
+                        autocomplete="off"
+                        @bind="form.Name"
+                        disabled="@isSaving" />
+                </label>
+                <label class="workflow-profile-default-row">
+                    <input
+                        id="workflow-profile-default"
+                        type="checkbox"
+                        @bind="form.IsDefault"
+                        disabled="@isSaving" />
+                    <span>Default profile</span>
+                </label>
+            </div>
+
+            <label>
+                <span>Description</span>
+                <textarea
+                    id="workflow-profile-description"
+                    maxlength="500"
+                    rows="3"
+                    @bind="form.Description"
+                    disabled="@isSaving"></textarea>
+            </label>
+
+            <label>
+                <span>WORKFLOW.md source</span>
+                <textarea
+                    id="workflow-profile-source"
+                    required
+                    rows="16"
+                    spellcheck="false"
+                    @bind="form.WorkflowSource"
+                    disabled="@isSaving"></textarea>
+            </label>
+
+            <div class="form-actions">
+                <button type="submit" disabled="@isSaving">
+                    @(isSaving ? "Saving" : SubmitLabel)
+                </button>
+                @if (editingProfileId is not null)
+                {
+                    <button type="button" class="secondary-action" @onclick="ResetEditor" disabled="@isSaving">
+                        Cancel
+                    </button>
+                }
+            </div>
+        </form>
+
+        <aside class="workflow-profile-preview" aria-label="Workflow profile preview">
+            <div class="workflow-profile-editor-heading">
+                <div>
+                    <p class="eyebrow">Preview</p>
+                    <h2>Rendered source</h2>
+                </div>
+            </div>
+            <pre>@PreviewSource</pre>
+        </aside>
+    </section>
+
+    @if (validationMessages.Count > 0)
+    {
+        <ErrorState
+            Title="Workflow profile was not saved."
+            Message="Review the validation result and retry."
+            Detail="@string.Join(" ", validationMessages)" />
+    }
+    else if (operationError is not null)
+    {
+        <ErrorState
+            Title="Workflow profile was not saved."
+            Message="The profile request did not complete."
+            Detail="@operationError" />
+    }
+    else if (successMessage is not null)
+    {
+        <SuccessState
+            Title="Workflow profile saved"
+            Message="@successMessage" />
+    }
+
+    <section class="workflow-profiles-panel" aria-label="Saved workflow profiles">
+        <div class="instances-panel-header">
+            <div>
+                <p class="eyebrow">Registry</p>
+                <h2>Saved profiles</h2>
+            </div>
+        </div>
+
+        @if (loadError is not null)
+        {
+            <ErrorState
+                Title="Workflow profiles could not be loaded."
+                Message="Check the persistence store and retry."
+                Detail="@loadError" />
+        }
+        else if (isLoading)
+        {
+            <LoadingState
+                Title="Loading workflow profiles"
+                Message="Reading persisted WORKFLOW.md templates." />
+        }
+        else if (profiles.Count == 0)
+        {
+            <EmptyState
+                Title="No workflow profiles yet."
+                Message="Create a reusable WORKFLOW.md profile before provisioning Symphony instances." />
+        }
+        else
+        {
+            <div class="workflow-profiles-table-wrap">
+                <table class="workflow-profiles-table">
+                    <thead>
+                        <tr>
+                            <th scope="col">Profile</th>
+                            <th scope="col">State</th>
+                            <th scope="col">Updated</th>
+                            <th scope="col">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (WorkflowProfileSummary profile in profiles)
+                        {
+                            <tr data-workflow-profile-id="@profile.Id.ToString()">
+                                <th scope="row">
+                                    <span class="workflow-profile-name">@profile.Name</span>
+                                    @if (!string.IsNullOrWhiteSpace(profile.Description))
+                                    {
+                                        <span class="workflow-profile-muted">@profile.Description</span>
+                                    }
+                                </th>
+                                <td>
+                                    <StatusBadge
+                                        Text="@GetProfileStateText(profile)"
+                                        Tone="@GetProfileStateTone(profile)" />
+                                    <small>Revision @profile.Revision</small>
+                                </td>
+                                <td>
+                                    <time datetime="@profile.UpdatedAtUtc.ToString("O")">
+                                        @profile.UpdatedAtUtc.ToLocalTime().ToString("MMM d, yyyy HH:mm")
+                                    </time>
+                                    <small>Created @profile.CreatedAtUtc.ToLocalTime().ToString("MMM d, yyyy")</small>
+                                </td>
+                                <td>
+                                    <button
+                                        type="button"
+                                        class="table-action"
+                                        @onclick="() => EditProfileAsync(profile.Id)"
+                                        disabled="@isSaving">
+                                        Edit
+                                    </button>
+                                </td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+        }
+    </section>
+</section>
+
+@code {
+    private readonly WorkflowProfileForm form = new();
+    private IReadOnlyList<WorkflowProfileSummary> profiles = [];
+    private readonly List<string> validationMessages = [];
+    private WorkflowProfileId? editingProfileId;
+    private string? loadError;
+    private string? operationError;
+    private string? successMessage;
+    private bool isLoading = true;
+    private bool isSaving;
+
+    private string EditorModeLabel => editingProfileId is null ? "Create" : "Edit";
+
+    private string EditorTitle => editingProfileId is null ? "New workflow profile" : "Edit workflow profile";
+
+    private string SubmitLabel => editingProfileId is null ? "Create profile" : "Save profile";
+
+    private string PreviewSource => string.IsNullOrWhiteSpace(form.WorkflowSource)
+        ? "WORKFLOW.md source will appear here."
+        : form.WorkflowSource;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadProfilesAsync();
+    }
+
+    private async Task SaveProfileAsync()
+    {
+        validationMessages.Clear();
+        operationError = null;
+        successMessage = null;
+        isSaving = true;
+
+        try
+        {
+            WorkflowProfileMutationRequest request = new(
+                form.Name,
+                form.Description,
+                form.WorkflowSource,
+                form.IsDefault,
+                RequestedByUserId: "ui");
+
+            WorkflowProfileMutationResult result = editingProfileId is { } profileId
+                ? await WorkflowProfileService.UpdateAsync(profileId, request)
+                : await WorkflowProfileService.CreateAsync(request);
+
+            successMessage = $"{result.Name} is revision {result.Revision}.";
+            await LoadProfilesAsync();
+
+            if (editingProfileId is null)
+            {
+                ResetEditor();
+            }
+            else
+            {
+                form.Revision = result.Revision;
+            }
+        }
+        catch (WorkflowProfileValidationException ex)
+        {
+            validationMessages.AddRange(ex.Errors.SelectMany(error => error.Value));
+        }
+        catch (WorkflowProfileNotFoundException ex)
+        {
+            operationError = ex.Message;
+            ResetEditor();
+            await LoadProfilesAsync();
+        }
+        catch (Exception ex) when (ex is DbException or InvalidOperationException or IOException or UnauthorizedAccessException)
+        {
+            operationError = ex.Message;
+        }
+        finally
+        {
+            isSaving = false;
+        }
+    }
+
+    private async Task EditProfileAsync(WorkflowProfileId profileId)
+    {
+        validationMessages.Clear();
+        operationError = null;
+        successMessage = null;
+
+        try
+        {
+            WorkflowProfileDetail? profile = await WorkflowProfileService.GetAsync(profileId);
+            if (profile is null)
+            {
+                throw new WorkflowProfileNotFoundException(profileId);
+            }
+
+            editingProfileId = profile.Id;
+            form.Name = profile.Name;
+            form.Description = profile.Description;
+            form.WorkflowSource = profile.WorkflowSource;
+            form.IsDefault = profile.IsDefault;
+            form.Revision = profile.Revision;
+        }
+        catch (WorkflowProfileNotFoundException ex)
+        {
+            operationError = ex.Message;
+            await LoadProfilesAsync();
+        }
+    }
+
+    private async Task LoadProfilesAsync()
+    {
+        isLoading = true;
+        loadError = null;
+
+        try
+        {
+            profiles = await WorkflowProfileService.ListAsync(new WorkflowProfileQuery());
+        }
+        catch (Exception ex) when (ex is DbException or InvalidOperationException or IOException or UnauthorizedAccessException)
+        {
+            loadError = ex.Message;
+        }
+        finally
+        {
+            isLoading = false;
+        }
+    }
+
+    private void ResetEditor()
+    {
+        editingProfileId = null;
+        form.Reset();
+    }
+
+    private static string GetProfileStateText(WorkflowProfileSummary profile) =>
+        profile.IsDefault ? "Default" : "Available";
+
+    private static StatusBadgeTone GetProfileStateTone(WorkflowProfileSummary profile) =>
+        profile.IsDefault ? StatusBadgeTone.Success : StatusBadgeTone.Neutral;
+
+    private sealed class WorkflowProfileForm
+    {
+        public string Name { get; set; } = string.Empty;
+
+        public string? Description { get; set; }
+
+        public string WorkflowSource { get; set; } = string.Empty;
+
+        public bool IsDefault { get; set; }
+
+        public int Revision { get; set; } = 1;
+
+        public void Reset()
+        {
+            Name = string.Empty;
+            Description = null;
+            WorkflowSource = string.Empty;
+            IsDefault = false;
+            Revision = 1;
+        }
+    }
+}

--- a/src/Conductor.Host/wwwroot/app.css
+++ b/src/Conductor.Host/wwwroot/app.css
@@ -1096,14 +1096,22 @@ h2 {
   max-width: 1180px;
 }
 
-.secrets-header {
+.workflow-profiles-page {
+  display: grid;
+  gap: 24px;
+  max-width: 1220px;
+}
+
+.secrets-header,
+.workflow-profiles-header {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
   gap: 16px;
 }
 
-.secrets-summary {
+.secrets-summary,
+.workflow-profiles-summary {
   margin: 8px 0 0;
   color: #aeb9c5;
 }
@@ -1152,13 +1160,20 @@ h2 {
 .instances-panel,
 .repository-import,
 .repositories-panel,
-.repository-detail-panel {
+.repository-detail-panel,
+.workflow-profile-editor,
+.workflow-profiles-panel {
   display: grid;
   gap: 18px;
   padding: 24px;
   border: 1px solid #2b3138;
   border-radius: 8px;
   background: #151a1f;
+}
+
+.workflow-profile-editor {
+  grid-template-columns: minmax(0, 1fr) minmax(320px, 0.8fr);
+  align-items: start;
 }
 
 .secret-table {
@@ -1188,13 +1203,27 @@ h2 {
   gap: 18px;
 }
 
+.workflow-profile-form,
+.workflow-profile-preview {
+  display: grid;
+  gap: 18px;
+}
+
 .import-form-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(240px, 1fr));
   gap: 12px;
 }
 
-.repository-import-form label {
+.workflow-profile-form-grid {
+  display: grid;
+  grid-template-columns: minmax(240px, 1fr) auto;
+  gap: 12px;
+  align-items: end;
+}
+
+.repository-import-form label,
+.workflow-profile-form label {
   display: grid;
   gap: 8px;
   color: #dbe6ee;
@@ -1203,7 +1232,9 @@ h2 {
 }
 
 .repository-import-form input,
-.repository-import-form select {
+.repository-import-form select,
+.workflow-profile-form input,
+.workflow-profile-form textarea {
   width: 100%;
   min-height: 42px;
   padding: 9px 11px;
@@ -1214,22 +1245,32 @@ h2 {
   font: inherit;
 }
 
-.repository-import-form input[type="checkbox"] {
+.repository-import-form input[type="checkbox"],
+.workflow-profile-form input[type="checkbox"] {
   width: 18px;
   height: 18px;
   min-height: 18px;
   padding: 0;
 }
 
+.workflow-profile-form textarea {
+  resize: vertical;
+  line-height: 1.45;
+}
+
 .repository-import-form input:focus,
-.repository-import-form select:focus {
+.repository-import-form select:focus,
+.workflow-profile-form input:focus,
+.workflow-profile-form textarea:focus {
   border-color: #9ee7d7;
   outline: 2px solid rgba(158, 231, 215, 0.18);
   outline-offset: 1px;
 }
 
 .repository-import-form input:disabled,
-.repository-import-form select:disabled {
+.repository-import-form select:disabled,
+.workflow-profile-form input:disabled,
+.workflow-profile-form textarea:disabled {
   cursor: not-allowed;
   opacity: 0.66;
 }
@@ -1248,6 +1289,45 @@ h2 {
   align-items: center;
   min-height: 34px;
   gap: 8px;
+}
+
+.workflow-profile-default-row {
+  display: inline-flex;
+  grid-template-columns: none;
+  align-items: center;
+  min-height: 42px;
+  gap: 8px;
+  padding-bottom: 1px;
+}
+
+.workflow-profile-editor-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 14px;
+}
+
+.workflow-profile-editor-heading h2 {
+  margin-bottom: 0;
+}
+
+.workflow-profile-preview {
+  min-width: 0;
+}
+
+.workflow-profile-preview pre {
+  min-height: 470px;
+  max-height: 760px;
+  margin: 0;
+  padding: 16px;
+  overflow: auto;
+  border: 1px solid #2b3138;
+  border-radius: 8px;
+  background: #111417;
+  color: #dbe6ee;
+  font: 0.86rem/1.45 Consolas, "Cascadia Mono", "Courier New", monospace;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
 }
 
 .orchestration-shell {
@@ -1280,9 +1360,20 @@ h2 {
   cursor: pointer;
 }
 
+.form-actions .secondary-action {
+  border-color: #3b4652;
+  background: #232a31;
+  color: #dbe6ee;
+}
+
 .form-actions button:hover:not(:disabled),
 .form-actions button:focus-visible {
   background: #259078;
+}
+
+.form-actions .secondary-action:hover:not(:disabled),
+.form-actions .secondary-action:focus-visible {
+  background: #2d3640;
 }
 
 .form-actions button:disabled {
@@ -1362,12 +1453,14 @@ h2 {
 }
 
 .instances-table-wrap,
-.repositories-table-wrap {
+.repositories-table-wrap,
+.workflow-profiles-table-wrap {
   overflow-x: auto;
 }
 
 .instances-table,
-.repositories-table {
+.repositories-table,
+.workflow-profiles-table {
   width: 100%;
   min-width: 1120px;
   border-collapse: collapse;
@@ -1376,7 +1469,9 @@ h2 {
 .instances-table th,
 .instances-table td,
 .repositories-table th,
-.repositories-table td {
+.repositories-table td,
+.workflow-profiles-table th,
+.workflow-profiles-table td {
   padding: 14px 12px;
   border-top: 1px solid #2b3138;
   text-align: left;
@@ -1384,7 +1479,8 @@ h2 {
 }
 
 .instances-table th,
-.repositories-table th {
+.repositories-table th,
+.workflow-profiles-table th {
   color: #aeb9c5;
   font-size: 0.78rem;
   font-weight: 800;
@@ -1392,17 +1488,21 @@ h2 {
 }
 
 .secret-name,
-.secret-muted {
+.secret-muted,
+.workflow-profile-name,
+.workflow-profile-muted {
   display: block;
   overflow-wrap: anywhere;
 }
 
-.secret-name {
+.secret-name,
+.workflow-profile-name {
   color: #ffffff;
   font-weight: 800;
 }
 
-.secret-muted {
+.secret-muted,
+.workflow-profile-muted {
   margin-top: 5px;
   color: #aeb9c5;
   font-size: 0.84rem;
@@ -1434,7 +1534,8 @@ h2 {
 }
 
 .instances-table td,
-.repositories-table td {
+.repositories-table td,
+.workflow-profiles-table td {
   color: #dbe6ee;
 }
 
@@ -1443,7 +1544,9 @@ h2 {
 .repositories-table td:nth-child(3),
 .repositories-table td:nth-child(4),
 .repositories-table td:nth-child(5),
-.repositories-table td:nth-child(6) {
+.repositories-table td:nth-child(6),
+.workflow-profiles-table td:nth-child(2),
+.workflow-profiles-table td:nth-child(3) {
   display: grid;
   gap: 5px;
 }
@@ -1536,6 +1639,36 @@ h2 {
 
 .repositories-table small {
   color: #aeb9c5;
+}
+
+.workflow-profiles-table small {
+  display: block;
+  margin-top: 5px;
+  color: #aeb9c5;
+  font-size: 0.84rem;
+}
+
+.table-action {
+  min-height: 34px;
+  padding: 0 12px;
+  border: 1px solid #3b4652;
+  border-radius: 6px;
+  background: #232a31;
+  color: #ffffff;
+  font: inherit;
+  font-size: 0.84rem;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.table-action:hover:not(:disabled),
+.table-action:focus-visible {
+  background: #2d3640;
+}
+
+.table-action:disabled {
+  cursor: not-allowed;
+  opacity: 0.66;
 }
 
 .breadcrumb-link,
@@ -1753,10 +1886,12 @@ h2 {
   .registration-form,
   .credential-form-row,
   .form-fields,
-  .repository-metadata-grid,
-  .import-form-grid,
-  .live-activity-header,
-  .startup-panel dl {
+    .repository-metadata-grid,
+    .import-form-grid,
+    .workflow-profile-editor,
+    .workflow-profile-form-grid,
+    .live-activity-header,
+    .startup-panel dl {
     grid-template-columns: 1fr;
   }
 
@@ -1789,6 +1924,7 @@ h2 {
   }
 
   .secrets-header,
+  .workflow-profiles-header,
   .secret-type-grid {
     display: grid;
     grid-template-columns: 1fr;

--- a/src/Conductor.Infrastructure.Persistence.Sqlite/Configurations/StronglyTypedIdValueConverters.cs
+++ b/src/Conductor.Infrastructure.Persistence.Sqlite/Configurations/StronglyTypedIdValueConverters.cs
@@ -82,6 +82,10 @@ internal static class StronglyTypedIdValueConverters
         id => id.Value,
         value => new WorkflowProfileId(value));
 
+    public static readonly ValueConverter<WorkflowProfileId?, Guid?> NullableWorkflowProfileId = new(
+        id => id.HasValue ? id.Value.Value : null,
+        value => value.HasValue ? new WorkflowProfileId(value.Value) : null);
+
     public static readonly ValueConverter<Uri, string> AbsoluteUri = new(
         uri => uri.ToString(),
         value => new Uri(value, UriKind.Absolute));

--- a/src/Conductor.Infrastructure.Persistence.Sqlite/Configurations/SymphonyInstanceConfiguration.cs
+++ b/src/Conductor.Infrastructure.Persistence.Sqlite/Configurations/SymphonyInstanceConfiguration.cs
@@ -1,6 +1,7 @@
 using Conductor.Core.Domain.Repositories;
 using Conductor.Core.Domain.Secrets;
 using Conductor.Core.Domain.Symphony;
+using Conductor.Core.Domain.Workflows;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
@@ -90,6 +91,9 @@ internal sealed class SymphonyInstanceConfiguration : IEntityTypeConfiguration<S
         builder.Property(instance => instance.DataPath)
             .HasMaxLength(1024);
 
+        builder.Property(instance => instance.WorkflowProfileId)
+            .HasConversion(StronglyTypedIdValueConverters.NullableWorkflowProfileId);
+
         builder.Property(instance => instance.CreatedAtUtc)
             .IsRequired();
 
@@ -102,6 +106,7 @@ internal sealed class SymphonyInstanceConfiguration : IEntityTypeConfiguration<S
         builder.HasIndex(instance => instance.RepositoryId);
         builder.HasIndex(instance => new { instance.LifecycleStatus, instance.HealthStatus });
         builder.HasIndex(instance => instance.ExecutionMode);
+        builder.HasIndex(instance => instance.WorkflowProfileId);
 
         builder.HasOne<Repository>()
             .WithMany()
@@ -116,6 +121,11 @@ internal sealed class SymphonyInstanceConfiguration : IEntityTypeConfiguration<S
         builder.HasOne<SecretDescriptor>()
             .WithMany()
             .HasForeignKey(instance => instance.OpenAiCredentialSecretId)
+            .OnDelete(DeleteBehavior.SetNull);
+
+        builder.HasOne<WorkflowProfile>()
+            .WithMany()
+            .HasForeignKey(instance => instance.WorkflowProfileId)
             .OnDelete(DeleteBehavior.SetNull);
     }
 }

--- a/src/Conductor.Infrastructure.Persistence.Sqlite/Configurations/WorkflowProfileConfiguration.cs
+++ b/src/Conductor.Infrastructure.Persistence.Sqlite/Configurations/WorkflowProfileConfiguration.cs
@@ -20,11 +20,25 @@ internal sealed class WorkflowProfileConfiguration : IEntityTypeConfiguration<Wo
             .HasMaxLength(200)
             .IsRequired();
 
+        builder.Property(profile => profile.Description)
+            .HasMaxLength(500);
+
         builder.Property(profile => profile.WorkflowSource)
             .HasColumnType("TEXT")
             .IsRequired();
 
+        builder.Property(profile => profile.IsDefault)
+            .IsRequired();
+
+        builder.Property(profile => profile.Revision)
+            .IsRequired();
+
         builder.Property(profile => profile.CreatedAtUtc)
             .IsRequired();
+
+        builder.Property(profile => profile.UpdatedAtUtc)
+            .IsRequired();
+
+        builder.HasIndex(profile => profile.IsDefault);
     }
 }

--- a/src/Conductor.Infrastructure.Persistence.Sqlite/Migrations/20260429051111_AddWorkflowProfileEditing.Designer.cs
+++ b/src/Conductor.Infrastructure.Persistence.Sqlite/Migrations/20260429051111_AddWorkflowProfileEditing.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Conductor.Infrastructure.Persistence.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Conductor.Infrastructure.Persistence.Sqlite.Migrations
 {
     [DbContext(typeof(ConductorDbContext))]
-    partial class ConductorDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260429051111_AddWorkflowProfileEditing")]
+    partial class AddWorkflowProfileEditing
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Conductor.Infrastructure.Persistence.Sqlite/Migrations/20260429051111_AddWorkflowProfileEditing.cs
+++ b/src/Conductor.Infrastructure.Persistence.Sqlite/Migrations/20260429051111_AddWorkflowProfileEditing.cs
@@ -1,0 +1,110 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Conductor.Infrastructure.Persistence.Sqlite.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddWorkflowProfileEditing : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Description",
+                table: "WorkflowProfiles",
+                type: "TEXT",
+                maxLength: 500,
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsDefault",
+                table: "WorkflowProfiles",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<int>(
+                name: "Revision",
+                table: "WorkflowProfiles",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 1);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "UpdatedAtUtc",
+                table: "WorkflowProfiles",
+                type: "TEXT",
+                nullable: false,
+                defaultValue: new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)));
+
+            migrationBuilder.Sql(
+                """
+                UPDATE WorkflowProfiles
+                SET Revision = 1,
+                    UpdatedAtUtc = CreatedAtUtc;
+                """);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "WorkflowProfileId",
+                table: "SymphonyInstances",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_WorkflowProfiles_IsDefault",
+                table: "WorkflowProfiles",
+                column: "IsDefault");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SymphonyInstances_WorkflowProfileId",
+                table: "SymphonyInstances",
+                column: "WorkflowProfileId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_SymphonyInstances_WorkflowProfiles_WorkflowProfileId",
+                table: "SymphonyInstances",
+                column: "WorkflowProfileId",
+                principalTable: "WorkflowProfiles",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_SymphonyInstances_WorkflowProfiles_WorkflowProfileId",
+                table: "SymphonyInstances");
+
+            migrationBuilder.DropIndex(
+                name: "IX_WorkflowProfiles_IsDefault",
+                table: "WorkflowProfiles");
+
+            migrationBuilder.DropIndex(
+                name: "IX_SymphonyInstances_WorkflowProfileId",
+                table: "SymphonyInstances");
+
+            migrationBuilder.DropColumn(
+                name: "Description",
+                table: "WorkflowProfiles");
+
+            migrationBuilder.DropColumn(
+                name: "IsDefault",
+                table: "WorkflowProfiles");
+
+            migrationBuilder.DropColumn(
+                name: "Revision",
+                table: "WorkflowProfiles");
+
+            migrationBuilder.DropColumn(
+                name: "UpdatedAtUtc",
+                table: "WorkflowProfiles");
+
+            migrationBuilder.DropColumn(
+                name: "WorkflowProfileId",
+                table: "SymphonyInstances");
+        }
+    }
+}

--- a/src/Conductor.Infrastructure.Persistence.Sqlite/Repositories/SqliteRepositoryImportService.cs
+++ b/src/Conductor.Infrastructure.Persistence.Sqlite/Repositories/SqliteRepositoryImportService.cs
@@ -256,7 +256,8 @@ internal sealed class SqliteRepositoryImportService : IRepositoryImportService
             openAiCredentialSecretId: instancePlan.OpenAiCredential.SecretId,
             openAiCredentialInheritanceMode: instancePlan.OpenAiCredential.InheritanceMode,
             workflowPath: instancePlan.WorkflowPath,
-            dataPath: instancePlan.DataPath);
+            dataPath: instancePlan.DataPath,
+            workflowProfileId: instancePlan.WorkflowProfileId);
 
         dbContext.SymphonyInstances.Add(instance);
 

--- a/src/Conductor.Infrastructure.Persistence.Sqlite/SqlitePersistenceServiceCollectionExtensions.cs
+++ b/src/Conductor.Infrastructure.Persistence.Sqlite/SqlitePersistenceServiceCollectionExtensions.cs
@@ -5,11 +5,13 @@ using Conductor.Core.Application.Queries;
 using Conductor.Core.Application.Repositories;
 using Conductor.Core.Application.Secrets;
 using Conductor.Core.Application.Snapshots;
+using Conductor.Core.Application.Workflows;
 using Conductor.Infrastructure.Persistence.Sqlite.Dashboard;
 using Conductor.Infrastructure.Persistence.Sqlite.Instances;
 using Conductor.Infrastructure.Persistence.Sqlite.Queries;
 using Conductor.Infrastructure.Persistence.Sqlite.Repositories;
 using Conductor.Infrastructure.Persistence.Sqlite.Snapshots;
+using Conductor.Infrastructure.Persistence.Sqlite.Workflows;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -54,6 +56,7 @@ public static class SqlitePersistenceServiceCollectionExtensions
         services.AddScoped<IInstanceCredentialAssignmentService, SqliteInstanceCredentialAssignmentService>();
         services.AddScoped<IInstanceCollectionStore, SqliteInstanceCollectionStore>();
         services.AddScoped<IInstanceSnapshotStore, SqliteInstanceSnapshotStore>();
+        services.AddScoped<IWorkflowProfileService, SqliteWorkflowProfileService>();
         services.TryAddSingleton(TimeProvider.System);
 
         return services;

--- a/src/Conductor.Infrastructure.Persistence.Sqlite/Workflows/SqliteWorkflowProfileService.cs
+++ b/src/Conductor.Infrastructure.Persistence.Sqlite/Workflows/SqliteWorkflowProfileService.cs
@@ -1,0 +1,334 @@
+using System.Text.Json;
+using Conductor.Core.Application.Workflows;
+using Conductor.Core.Domain;
+using Conductor.Core.Domain.Auditing;
+using Conductor.Core.Domain.Ids;
+using Conductor.Core.Domain.Workflows;
+using Microsoft.EntityFrameworkCore;
+
+namespace Conductor.Infrastructure.Persistence.Sqlite.Workflows;
+
+internal sealed class SqliteWorkflowProfileService : IWorkflowProfileService
+{
+    private const int MaxNameLength = 200;
+    private const int MaxDescriptionLength = 500;
+
+    private readonly ConductorDbContext dbContext;
+    private readonly TimeProvider timeProvider;
+
+    public SqliteWorkflowProfileService(
+        ConductorDbContext dbContext,
+        TimeProvider timeProvider)
+    {
+        this.dbContext = dbContext;
+        this.timeProvider = timeProvider;
+    }
+
+    public async Task<IReadOnlyList<WorkflowProfileSummary>> ListAsync(
+        WorkflowProfileQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        IQueryable<WorkflowProfile> profiles = dbContext.WorkflowProfiles.AsNoTracking();
+
+        if (!string.IsNullOrWhiteSpace(query.Search))
+        {
+            string search = query.Search.Trim();
+            profiles = profiles.Where(profile =>
+                profile.Name.Contains(search) ||
+                (profile.Description != null && profile.Description.Contains(search)));
+        }
+
+        return await profiles
+            .OrderByDescending(profile => profile.IsDefault)
+            .ThenBy(profile => profile.Name)
+            .Select(profile => new WorkflowProfileSummary(
+                profile.Id,
+                profile.Name,
+                profile.Description,
+                profile.IsDefault,
+                profile.Revision,
+                profile.CreatedAtUtc,
+                profile.UpdatedAtUtc))
+            .ToArrayAsync(cancellationToken);
+    }
+
+    public async Task<WorkflowProfileDetail?> GetAsync(
+        WorkflowProfileId profileId,
+        CancellationToken cancellationToken = default)
+    {
+        return await dbContext.WorkflowProfiles
+            .AsNoTracking()
+            .Where(profile => profile.Id == profileId)
+            .Select(profile => new WorkflowProfileDetail(
+                profile.Id,
+                profile.Name,
+                profile.Description,
+                profile.WorkflowSource,
+                profile.IsDefault,
+                profile.Revision,
+                profile.CreatedAtUtc,
+                profile.UpdatedAtUtc))
+            .FirstOrDefaultAsync(cancellationToken);
+    }
+
+    public async Task<WorkflowProfileMutationResult> CreateAsync(
+        WorkflowProfileMutationRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ValidatedWorkflowProfileRequest validated = await ValidateRequestAsync(
+            request,
+            excludedProfileId: null,
+            cancellationToken);
+        DateTimeOffset now = timeProvider.GetUtcNow();
+
+        await using Microsoft.EntityFrameworkCore.Storage.IDbContextTransaction transaction =
+            await dbContext.Database.BeginTransactionAsync(cancellationToken);
+
+        if (validated.IsDefault)
+        {
+            await ClearDefaultProfilesAsync(excludedProfileId: null, now, cancellationToken);
+        }
+
+        WorkflowProfile profile = new(
+            WorkflowProfileId.New(),
+            validated.Name,
+            validated.Description,
+            validated.WorkflowSource,
+            validated.IsDefault,
+            now,
+            now);
+
+        dbContext.WorkflowProfiles.Add(profile);
+        RecordAuditEvent(
+            request.RequestedByUserId,
+            "CreateWorkflowProfile",
+            profile,
+            now);
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+        await transaction.CommitAsync(cancellationToken);
+
+        return MapMutationResult(profile);
+    }
+
+    public async Task<WorkflowProfileMutationResult> UpdateAsync(
+        WorkflowProfileId profileId,
+        WorkflowProfileMutationRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ValidatedWorkflowProfileRequest validated = await ValidateRequestAsync(
+            request,
+            profileId,
+            cancellationToken);
+        DateTimeOffset now = timeProvider.GetUtcNow();
+        WorkflowProfile profile = await dbContext.WorkflowProfiles
+            .FirstOrDefaultAsync(candidate => candidate.Id == profileId, cancellationToken)
+            ?? throw new WorkflowProfileNotFoundException(profileId);
+
+        await using Microsoft.EntityFrameworkCore.Storage.IDbContextTransaction transaction =
+            await dbContext.Database.BeginTransactionAsync(cancellationToken);
+
+        if (validated.IsDefault)
+        {
+            await ClearDefaultProfilesAsync(profileId, now, cancellationToken);
+        }
+
+        profile.Update(
+            validated.Name,
+            validated.Description,
+            validated.WorkflowSource,
+            validated.IsDefault,
+            now);
+
+        RecordAuditEvent(
+            request.RequestedByUserId,
+            "UpdateWorkflowProfile",
+            profile,
+            now);
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+        await transaction.CommitAsync(cancellationToken);
+
+        return MapMutationResult(profile);
+    }
+
+    private async Task<ValidatedWorkflowProfileRequest> ValidateRequestAsync(
+        WorkflowProfileMutationRequest request,
+        WorkflowProfileId? excludedProfileId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        Dictionary<string, List<string>> errors = new(StringComparer.Ordinal);
+        string name = ValidateRequiredText(
+            request.Name,
+            nameof(request.Name),
+            MaxNameLength,
+            "A workflow profile name is required.",
+            errors);
+        string? description = ValidateOptionalText(
+            request.Description,
+            nameof(request.Description),
+            MaxDescriptionLength,
+            errors);
+        string workflowSource = ValidateRequiredText(
+            request.WorkflowSource,
+            nameof(request.WorkflowSource),
+            maxLength: null,
+            "Workflow source Markdown is required.",
+            errors);
+
+        if (errors.Count == 0)
+        {
+            IReadOnlyList<WorkflowProfileSummary> existingProfiles = await ListAsync(
+                new WorkflowProfileQuery(),
+                cancellationToken);
+
+            if (existingProfiles.Any(profile =>
+                    (!excludedProfileId.HasValue || profile.Id != excludedProfileId.Value) &&
+                    string.Equals(profile.Name, name, StringComparison.OrdinalIgnoreCase)))
+            {
+                AddError(errors, nameof(request.Name), "A workflow profile with this name already exists.");
+            }
+        }
+
+        if (errors.Count > 0)
+        {
+            throw new WorkflowProfileValidationException(ToErrorDictionary(errors));
+        }
+
+        return new ValidatedWorkflowProfileRequest(
+            name,
+            description,
+            workflowSource,
+            request.IsDefault);
+    }
+
+    private static string ValidateRequiredText(
+        string value,
+        string fieldName,
+        int? maxLength,
+        string requiredMessage,
+        Dictionary<string, List<string>> errors)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            AddError(errors, fieldName, requiredMessage);
+            return string.Empty;
+        }
+
+        string trimmed = value.Trim();
+        if (maxLength is { } length && trimmed.Length > length)
+        {
+            AddError(errors, fieldName, $"Enter {length} characters or fewer.");
+        }
+
+        return trimmed;
+    }
+
+    private static string? ValidateOptionalText(
+        string? value,
+        string fieldName,
+        int maxLength,
+        Dictionary<string, List<string>> errors)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        string trimmed = value.Trim();
+        if (trimmed.Length > maxLength)
+        {
+            AddError(errors, fieldName, $"Enter {maxLength} characters or fewer.");
+        }
+
+        return trimmed;
+    }
+
+    private async Task ClearDefaultProfilesAsync(
+        WorkflowProfileId? excludedProfileId,
+        DateTimeOffset updatedAtUtc,
+        CancellationToken cancellationToken)
+    {
+        IQueryable<WorkflowProfile> defaultProfileQuery = dbContext.WorkflowProfiles
+            .Where(profile => profile.IsDefault);
+
+        if (excludedProfileId.HasValue)
+        {
+            WorkflowProfileId profileId = excludedProfileId.Value;
+            defaultProfileQuery = defaultProfileQuery.Where(profile => profile.Id != profileId);
+        }
+
+        WorkflowProfile[] defaultProfiles = await defaultProfileQuery.ToArrayAsync(cancellationToken);
+
+        foreach (WorkflowProfile defaultProfile in defaultProfiles)
+        {
+            defaultProfile.ClearDefault(updatedAtUtc);
+        }
+    }
+
+    private void RecordAuditEvent(
+        string? requestedByUserId,
+        string action,
+        WorkflowProfile profile,
+        DateTimeOffset occurredAtUtc)
+    {
+        string metadataJson = JsonSerializer.Serialize(new
+        {
+            workflowProfileId = profile.Id.ToString(),
+            profile.Name,
+            profile.IsDefault,
+            profile.Revision,
+        });
+
+        dbContext.AuditEvents.Add(new AuditEvent(
+            AuditEventId.New(),
+            string.IsNullOrWhiteSpace(requestedByUserId) ? "system" : requestedByUserId.Trim(),
+            action,
+            "WorkflowProfile",
+            profile.Id.ToString(),
+            occurredAtUtc,
+            AuditEventOutcome.Succeeded,
+            correlationId: null,
+            message: $"{action} {profile.Name}.",
+            metadataJson: metadataJson));
+    }
+
+    private static WorkflowProfileMutationResult MapMutationResult(WorkflowProfile profile) =>
+        new(
+            profile.Id,
+            profile.Name,
+            profile.IsDefault,
+            profile.Revision,
+            profile.UpdatedAtUtc);
+
+    private static void AddError(
+        Dictionary<string, List<string>> errors,
+        string fieldName,
+        string message)
+    {
+        if (!errors.TryGetValue(fieldName, out List<string>? messages))
+        {
+            messages = [];
+            errors[fieldName] = messages;
+        }
+
+        messages.Add(message);
+    }
+
+    private static IReadOnlyDictionary<string, string[]> ToErrorDictionary(
+        Dictionary<string, List<string>> errors)
+    {
+        return errors.ToDictionary(
+            item => item.Key,
+            item => item.Value.ToArray(),
+            StringComparer.Ordinal);
+    }
+
+    private sealed record ValidatedWorkflowProfileRequest(
+        string Name,
+        string? Description,
+        string WorkflowSource,
+        bool IsDefault);
+}

--- a/tests/Conductor.Blazor.Tests/RepositoriesPageTests.cs
+++ b/tests/Conductor.Blazor.Tests/RepositoriesPageTests.cs
@@ -1,6 +1,7 @@
 using Bunit;
 using Conductor.Core.Application.Queries;
 using Conductor.Core.Application.Repositories;
+using Conductor.Core.Application.Workflows;
 using Conductor.Core.Domain;
 using Conductor.Core.Domain.Ids;
 using Conductor.Host.Components.Pages;
@@ -18,12 +19,14 @@ public sealed class RepositoriesPageTests
         context.Services.AddSingleton<IRepositoryImportService>(importService);
         context.Services.AddSingleton<IRepositoryListQueryService>(new StaticRepositoryListQueryService());
         context.Services.AddSingleton<IProjectListQueryService>(new StaticProjectListQueryService());
+        context.Services.AddSingleton<IWorkflowProfileService>(new StaticWorkflowProfileService());
 
         IRenderedComponent<Repositories> page = context.Render<Repositories>();
         page.Find("#repository-full-name").Change("ReleasedGroup/TheConductor");
         page.Find("#project-id").Change(StaticProjectListQueryService.PlatformProjectId.ToString());
         page.Find("#create-instance-shell").Change(true);
         page.Find("#instance-base-url").Change("http://localhost:8080/");
+        page.Find("#workflow-profile-id").Change(StaticWorkflowProfileService.DefaultWorkflowProfileId.ToString());
 
         await page.Find("form").SubmitAsync();
 
@@ -32,6 +35,7 @@ public sealed class RepositoriesPageTests
         Assert.Equal(StaticProjectListQueryService.PlatformProjectId, importService.LastRequest.ProjectId);
         Assert.True(importService.LastRequest.CreateSymphonyInstance);
         Assert.Equal("http://localhost:8080/", importService.LastRequest.InstanceBaseUrl);
+        Assert.Equal(StaticWorkflowProfileService.DefaultWorkflowProfileId, importService.LastRequest.WorkflowProfileId);
         Assert.Equal(CredentialInheritanceMode.InheritDefault, importService.LastRequest.GitHubCredentialInheritanceMode);
         Assert.Contains("ReleasedGroup/TheConductor imported", page.Markup, StringComparison.Ordinal);
         Assert.Contains("Linked to Platform.", page.Markup, StringComparison.Ordinal);
@@ -202,5 +206,46 @@ public sealed class RepositoriesPageTests
 
             return Task.FromResult(projects);
         }
+    }
+
+    private sealed class StaticWorkflowProfileService : IWorkflowProfileService
+    {
+        public static readonly WorkflowProfileId DefaultWorkflowProfileId =
+            WorkflowProfileId.Parse("33333333-3333-3333-3333-333333333333");
+
+        public Task<IReadOnlyList<WorkflowProfileSummary>> ListAsync(
+            WorkflowProfileQuery query,
+            CancellationToken cancellationToken = default)
+        {
+            IReadOnlyList<WorkflowProfileSummary> profiles =
+            [
+                new WorkflowProfileSummary(
+                    DefaultWorkflowProfileId,
+                    "Default Docker",
+                    "Docker profile",
+                    IsDefault: true,
+                    Revision: 1,
+                    CreatedAtUtc: DateTimeOffset.Parse("2026-04-29T02:00:00Z"),
+                    UpdatedAtUtc: DateTimeOffset.Parse("2026-04-29T02:00:00Z")),
+            ];
+
+            return Task.FromResult(profiles);
+        }
+
+        public Task<WorkflowProfileDetail?> GetAsync(
+            WorkflowProfileId profileId,
+            CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<WorkflowProfileMutationResult> CreateAsync(
+            WorkflowProfileMutationRequest request,
+            CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<WorkflowProfileMutationResult> UpdateAsync(
+            WorkflowProfileId profileId,
+            WorkflowProfileMutationRequest request,
+            CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
     }
 }

--- a/tests/Conductor.Blazor.Tests/WorkflowProfilesPageTests.cs
+++ b/tests/Conductor.Blazor.Tests/WorkflowProfilesPageTests.cs
@@ -1,0 +1,184 @@
+using Bunit;
+using Conductor.Core.Application.Workflows;
+using Conductor.Core.Domain.Ids;
+using Conductor.Host.Components.Pages;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Conductor.Blazor.Tests;
+
+public sealed class WorkflowProfilesPageTests
+{
+    [Fact]
+    public async Task WorkflowProfiles_Creates_Profile_From_Editor_Form()
+    {
+        using BunitContext context = new();
+        FakeWorkflowProfileService workflowProfileService = new();
+        context.Services.AddSingleton<IWorkflowProfileService>(workflowProfileService);
+
+        IRenderedComponent<WorkflowProfiles> page = context.Render<WorkflowProfiles>();
+        page.Find("#workflow-profile-name").Change("Default Docker");
+        page.Find("#workflow-profile-description").Change("Docker provisioning profile");
+        page.Find("#workflow-profile-source").Change("# WORKFLOW\ntracker:\n  api_key: $GITHUB_TOKEN");
+        page.Find("#workflow-profile-default").Change(true);
+
+        await page.Find("form").SubmitAsync();
+
+        Assert.NotNull(workflowProfileService.LastCreateRequest);
+        Assert.Equal("Default Docker", workflowProfileService.LastCreateRequest.Name);
+        Assert.Equal("Docker provisioning profile", workflowProfileService.LastCreateRequest.Description);
+        Assert.Equal("# WORKFLOW\ntracker:\n  api_key: $GITHUB_TOKEN", workflowProfileService.LastCreateRequest.WorkflowSource);
+        Assert.True(workflowProfileService.LastCreateRequest.IsDefault);
+        Assert.Contains("Workflow profile saved", page.Markup, StringComparison.Ordinal);
+        Assert.Contains("Default Docker is revision 1.", page.Markup, StringComparison.Ordinal);
+        Assert.Contains("Default Docker", page.Markup, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task WorkflowProfiles_Edits_Selected_Profile()
+    {
+        using BunitContext context = new();
+        FakeWorkflowProfileService workflowProfileService = new();
+        workflowProfileService.SeedProfile(
+            FakeWorkflowProfileService.ExistingProfileId,
+            "Local",
+            "Local runner profile",
+            "# WORKFLOW local",
+            isDefault: false,
+            revision: 2);
+        context.Services.AddSingleton<IWorkflowProfileService>(workflowProfileService);
+
+        IRenderedComponent<WorkflowProfiles> page = context.Render<WorkflowProfiles>();
+        page.Find("button.table-action").Click();
+        page.Find("#workflow-profile-name").Change("Company Standard");
+        page.Find("#workflow-profile-description").Change("Shared local runner profile");
+        page.Find("#workflow-profile-source").Change("# WORKFLOW local\ntracker:\n  api_key: $GITHUB_TOKEN");
+        page.Find("#workflow-profile-default").Change(true);
+
+        await page.Find("form").SubmitAsync();
+
+        Assert.Equal(FakeWorkflowProfileService.ExistingProfileId, workflowProfileService.LastUpdateProfileId);
+        Assert.NotNull(workflowProfileService.LastUpdateRequest);
+        Assert.Equal("Company Standard", workflowProfileService.LastUpdateRequest.Name);
+        Assert.Equal("Shared local runner profile", workflowProfileService.LastUpdateRequest.Description);
+        Assert.True(workflowProfileService.LastUpdateRequest.IsDefault);
+        Assert.Contains("Company Standard is revision 3.", page.Markup, StringComparison.Ordinal);
+    }
+
+    private sealed class FakeWorkflowProfileService : IWorkflowProfileService
+    {
+        public static readonly WorkflowProfileId ExistingProfileId =
+            WorkflowProfileId.Parse("44444444-4444-4444-4444-444444444444");
+
+        private readonly Dictionary<WorkflowProfileId, WorkflowProfileDetail> details = [];
+
+        public WorkflowProfileMutationRequest? LastCreateRequest { get; private set; }
+
+        public WorkflowProfileMutationRequest? LastUpdateRequest { get; private set; }
+
+        public WorkflowProfileId? LastUpdateProfileId { get; private set; }
+
+        public Task<IReadOnlyList<WorkflowProfileSummary>> ListAsync(
+            WorkflowProfileQuery query,
+            CancellationToken cancellationToken = default)
+        {
+            IReadOnlyList<WorkflowProfileSummary> profiles = details.Values
+                .OrderByDescending(profile => profile.IsDefault)
+                .ThenBy(profile => profile.Name)
+                .Select(profile => new WorkflowProfileSummary(
+                    profile.Id,
+                    profile.Name,
+                    profile.Description,
+                    profile.IsDefault,
+                    profile.Revision,
+                    profile.CreatedAtUtc,
+                    profile.UpdatedAtUtc))
+                .ToArray();
+
+            return Task.FromResult(profiles);
+        }
+
+        public Task<WorkflowProfileDetail?> GetAsync(
+            WorkflowProfileId profileId,
+            CancellationToken cancellationToken = default)
+        {
+            details.TryGetValue(profileId, out WorkflowProfileDetail? profile);
+
+            return Task.FromResult(profile);
+        }
+
+        public Task<WorkflowProfileMutationResult> CreateAsync(
+            WorkflowProfileMutationRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            LastCreateRequest = request;
+            WorkflowProfileId profileId = WorkflowProfileId.New();
+            DateTimeOffset now = DateTimeOffset.Parse("2026-04-29T06:00:00Z");
+
+            details[profileId] = new WorkflowProfileDetail(
+                profileId,
+                request.Name,
+                request.Description,
+                request.WorkflowSource,
+                request.IsDefault,
+                Revision: 1,
+                now,
+                now);
+
+            return Task.FromResult(new WorkflowProfileMutationResult(
+                profileId,
+                request.Name,
+                request.IsDefault,
+                Revision: 1,
+                now));
+        }
+
+        public Task<WorkflowProfileMutationResult> UpdateAsync(
+            WorkflowProfileId profileId,
+            WorkflowProfileMutationRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            LastUpdateProfileId = profileId;
+            LastUpdateRequest = request;
+            WorkflowProfileDetail existing = details[profileId];
+            DateTimeOffset updatedAt = existing.UpdatedAtUtc.AddMinutes(15);
+            int revision = existing.Revision + 1;
+
+            details[profileId] = existing with
+            {
+                Name = request.Name,
+                Description = request.Description,
+                WorkflowSource = request.WorkflowSource,
+                IsDefault = request.IsDefault,
+                Revision = revision,
+                UpdatedAtUtc = updatedAt,
+            };
+
+            return Task.FromResult(new WorkflowProfileMutationResult(
+                profileId,
+                request.Name,
+                request.IsDefault,
+                revision,
+                updatedAt));
+        }
+
+        public void SeedProfile(
+            WorkflowProfileId profileId,
+            string name,
+            string? description,
+            string workflowSource,
+            bool isDefault,
+            int revision)
+        {
+            DateTimeOffset createdAt = DateTimeOffset.Parse("2026-04-29T06:00:00Z");
+            details[profileId] = new WorkflowProfileDetail(
+                profileId,
+                name,
+                description,
+                workflowSource,
+                isDefault,
+                revision,
+                createdAt,
+                createdAt);
+        }
+    }
+}

--- a/tests/Conductor.Core.Tests/Issue13DomainEntityTests.cs
+++ b/tests/Conductor.Core.Tests/Issue13DomainEntityTests.cs
@@ -20,6 +20,39 @@ public sealed class Issue13DomainEntityTests
         Assert.Equal("Default Docker", profile.Name);
         Assert.Equal("# WORKFLOW\nrun: symphony", profile.WorkflowSource);
         Assert.Equal(createdAt, profile.CreatedAtUtc);
+        Assert.Equal(createdAt, profile.UpdatedAtUtc);
+        Assert.Equal(1, profile.Revision);
+        Assert.False(profile.IsDefault);
+        Assert.Null(profile.Description);
+    }
+
+    [Fact]
+    public void WorkflowProfile_Update_Records_Revision_Metadata()
+    {
+        var createdAt = DateTimeOffset.Parse("2026-04-29T00:00:00Z");
+        var updatedAt = DateTimeOffset.Parse("2026-04-29T00:15:00Z");
+        var profile = new WorkflowProfile(
+            WorkflowProfileId.New(),
+            "Default Docker",
+            "Docker profile",
+            "# WORKFLOW",
+            isDefault: false,
+            createdAt,
+            createdAt);
+
+        profile.Update(
+            "  Local Runner  ",
+            "  Local process profile  ",
+            "  # WORKFLOW\nmode: local  ",
+            isDefault: true,
+            updatedAt);
+
+        Assert.Equal("Local Runner", profile.Name);
+        Assert.Equal("Local process profile", profile.Description);
+        Assert.Equal("# WORKFLOW\nmode: local", profile.WorkflowSource);
+        Assert.True(profile.IsDefault);
+        Assert.Equal(2, profile.Revision);
+        Assert.Equal(updatedAt, profile.UpdatedAtUtc);
     }
 
     [Fact]

--- a/tests/Conductor.Persistence.Tests/SqliteRepositoryImportServiceTests.cs
+++ b/tests/Conductor.Persistence.Tests/SqliteRepositoryImportServiceTests.cs
@@ -8,6 +8,7 @@ using Conductor.Core.Domain.Ids;
 using Conductor.Core.Domain.Projects;
 using Conductor.Core.Domain.Repositories;
 using Conductor.Core.Domain.Symphony;
+using Conductor.Core.Domain.Workflows;
 using Conductor.Infrastructure.Persistence.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
@@ -25,6 +26,16 @@ public sealed class SqliteRepositoryImportServiceTests
         await using AsyncServiceScope scope = provider.CreateAsyncScope();
         ConductorDbContext dbContext = scope.ServiceProvider.GetRequiredService<ConductorDbContext>();
         await dbContext.Database.MigrateAsync();
+        WorkflowProfileId workflowProfileId = WorkflowProfileId.New();
+        dbContext.WorkflowProfiles.Add(new WorkflowProfile(
+            workflowProfileId,
+            "Default Docker",
+            "Default orchestration profile",
+            "# WORKFLOW",
+            isDefault: true,
+            importedAtUtc,
+            importedAtUtc));
+        await dbContext.SaveChangesAsync();
         IRepositoryImportService importService = scope.ServiceProvider.GetRequiredService<IRepositoryImportService>();
 
         RepositoryImportResult result = await importService.ImportAsync(new RepositoryImportRequest(
@@ -36,6 +47,7 @@ public sealed class SqliteRepositoryImportServiceTests
             ExecutionMode: ExecutionMode.LocalProcess,
             InstanceBaseUrl: "http://localhost:8080/",
             ReleaseTag: "latest",
+            WorkflowProfileId: workflowProfileId,
             GitHubCredentialInheritanceMode: CredentialInheritanceMode.None,
             OpenAiCredentialInheritanceMode: CredentialInheritanceMode.InheritDefault,
             RequestedByUserId: "nick"));
@@ -55,6 +67,7 @@ public sealed class SqliteRepositoryImportServiceTests
         Assert.Equal(InstanceLifecycleStatus.NotProvisioned, instance.LifecycleStatus);
         Assert.Equal(InstanceHealthStatus.Unknown, instance.HealthStatus);
         Assert.Equal("latest", instance.SymphonyReleaseTag);
+        Assert.Equal(workflowProfileId, instance.WorkflowProfileId);
         Assert.Equal(CredentialInheritanceMode.None, instance.GitHubCredentialInheritanceMode);
         Assert.Equal("ImportRepository", auditEvent.Action);
         Assert.Equal("nick", auditEvent.ActorUserId);
@@ -72,6 +85,7 @@ public sealed class SqliteRepositoryImportServiceTests
         Assert.True(metadata.GetProperty("createSymphonyInstance").GetBoolean());
         Assert.True(metadata.GetProperty("createdSymphonyInstance").GetBoolean());
         Assert.Equal(instance.Id.ToString(), metadata.GetProperty("symphonyInstanceId").GetString());
+        Assert.Equal(workflowProfileId.ToString(), metadata.GetProperty("workflowProfileId").GetString());
     }
 
     [Fact]

--- a/tests/Conductor.Persistence.Tests/SqliteWorkflowProfileServiceTests.cs
+++ b/tests/Conductor.Persistence.Tests/SqliteWorkflowProfileServiceTests.cs
@@ -1,0 +1,163 @@
+using System.Globalization;
+using System.Text.Json;
+using Conductor.Core.Application.Workflows;
+using Conductor.Core.Domain.Auditing;
+using Conductor.Core.Domain.Workflows;
+using Conductor.Infrastructure.Persistence.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Conductor.Persistence.Tests;
+
+public sealed class SqliteWorkflowProfileServiceTests
+{
+    [Fact]
+    public async Task CreateAsync_Persists_Profile_Metadata_And_Audit_Event()
+    {
+        DateTimeOffset now = DateTimeOffset.Parse("2026-04-29T05:00:00Z");
+        ManualTimeProvider timeProvider = new(now);
+        await using ServiceProvider provider = BuildProvider(timeProvider);
+        await using AsyncServiceScope scope = provider.CreateAsyncScope();
+        ConductorDbContext dbContext = scope.ServiceProvider.GetRequiredService<ConductorDbContext>();
+        await dbContext.Database.MigrateAsync();
+        IWorkflowProfileService workflowProfiles =
+            scope.ServiceProvider.GetRequiredService<IWorkflowProfileService>();
+
+        WorkflowProfileMutationResult result = await workflowProfiles.CreateAsync(new WorkflowProfileMutationRequest(
+            "  Default Docker  ",
+            "  Docker provisioning profile  ",
+            "  # WORKFLOW\ntracker:\n  api_key: $GITHUB_TOKEN  ",
+            IsDefault: true,
+            RequestedByUserId: "nick"));
+
+        dbContext.ChangeTracker.Clear();
+        WorkflowProfile profile = await dbContext.WorkflowProfiles.SingleAsync();
+        AuditEvent auditEvent = await dbContext.AuditEvents.SingleAsync();
+        WorkflowProfileDetail detail = (await workflowProfiles.GetAsync(result.Id))!;
+        IReadOnlyList<WorkflowProfileSummary> summaries = await workflowProfiles.ListAsync(new WorkflowProfileQuery());
+
+        Assert.Equal(profile.Id, result.Id);
+        Assert.Equal("Default Docker", profile.Name);
+        Assert.Equal("Docker provisioning profile", profile.Description);
+        Assert.Equal("# WORKFLOW\ntracker:\n  api_key: $GITHUB_TOKEN", profile.WorkflowSource);
+        Assert.True(profile.IsDefault);
+        Assert.Equal(1, profile.Revision);
+        Assert.Equal(now, profile.CreatedAtUtc);
+        Assert.Equal(now, profile.UpdatedAtUtc);
+        Assert.Equal(profile.WorkflowSource, detail.WorkflowSource);
+        Assert.Single(summaries);
+        Assert.Equal("CreateWorkflowProfile", auditEvent.Action);
+        Assert.Equal("WorkflowProfile", auditEvent.TargetResourceType);
+        Assert.Equal(profile.Id.ToString(), auditEvent.TargetResourceId);
+        Assert.Equal("nick", auditEvent.ActorUserId);
+
+        using JsonDocument metadata = JsonDocument.Parse(auditEvent.MetadataJson!);
+        Assert.Equal(profile.Id.ToString(), metadata.RootElement.GetProperty("workflowProfileId").GetString());
+        Assert.True(metadata.RootElement.GetProperty("IsDefault").GetBoolean());
+        Assert.Equal(1, metadata.RootElement.GetProperty("Revision").GetInt32());
+    }
+
+    [Fact]
+    public async Task UpdateAsync_Advances_Revision_And_Moves_Default_Flag()
+    {
+        DateTimeOffset createdAt = DateTimeOffset.Parse("2026-04-29T05:00:00Z");
+        ManualTimeProvider timeProvider = new(createdAt);
+        await using ServiceProvider provider = BuildProvider(timeProvider);
+        await using AsyncServiceScope scope = provider.CreateAsyncScope();
+        ConductorDbContext dbContext = scope.ServiceProvider.GetRequiredService<ConductorDbContext>();
+        await dbContext.Database.MigrateAsync();
+        IWorkflowProfileService workflowProfiles =
+            scope.ServiceProvider.GetRequiredService<IWorkflowProfileService>();
+        WorkflowProfileMutationResult first = await workflowProfiles.CreateAsync(new WorkflowProfileMutationRequest(
+            "Docker",
+            "Docker profile",
+            "# WORKFLOW docker",
+            IsDefault: true));
+        WorkflowProfileMutationResult second = await workflowProfiles.CreateAsync(new WorkflowProfileMutationRequest(
+            "Local",
+            "Local profile",
+            "# WORKFLOW local"));
+
+        DateTimeOffset updatedAt = createdAt.AddMinutes(20);
+        timeProvider.UtcNow = updatedAt;
+        WorkflowProfileMutationResult updated = await workflowProfiles.UpdateAsync(
+            second.Id,
+            new WorkflowProfileMutationRequest(
+                "Local runner",
+                "Local process profile",
+                "# WORKFLOW local\ntracker:\n  api_key: $GITHUB_TOKEN",
+                IsDefault: true));
+
+        dbContext.ChangeTracker.Clear();
+        WorkflowProfile firstProfile = await dbContext.WorkflowProfiles.SingleAsync(profile => profile.Id == first.Id);
+        WorkflowProfile secondProfile = await dbContext.WorkflowProfiles.SingleAsync(profile => profile.Id == second.Id);
+        IReadOnlyList<WorkflowProfileSummary> summaries = await workflowProfiles.ListAsync(new WorkflowProfileQuery());
+
+        Assert.False(firstProfile.IsDefault);
+        Assert.Equal(2, firstProfile.Revision);
+        Assert.Equal(updatedAt, firstProfile.UpdatedAtUtc);
+        Assert.True(secondProfile.IsDefault);
+        Assert.Equal("Local runner", secondProfile.Name);
+        Assert.Equal(2, secondProfile.Revision);
+        Assert.Equal(updatedAt, secondProfile.UpdatedAtUtc);
+        Assert.Equal(2, updated.Revision);
+        Assert.Equal(second.Id, summaries[0].Id);
+        Assert.Equal(3, await dbContext.AuditEvents.CountAsync());
+    }
+
+    [Fact]
+    public async Task SaveAsync_Rejects_Duplicate_Profile_Names()
+    {
+        DateTimeOffset now = DateTimeOffset.Parse("2026-04-29T05:00:00Z");
+        ManualTimeProvider timeProvider = new(now);
+        await using ServiceProvider provider = BuildProvider(timeProvider);
+        await using AsyncServiceScope scope = provider.CreateAsyncScope();
+        ConductorDbContext dbContext = scope.ServiceProvider.GetRequiredService<ConductorDbContext>();
+        await dbContext.Database.MigrateAsync();
+        IWorkflowProfileService workflowProfiles =
+            scope.ServiceProvider.GetRequiredService<IWorkflowProfileService>();
+
+        await workflowProfiles.CreateAsync(new WorkflowProfileMutationRequest(
+            "Default",
+            null,
+            "# WORKFLOW"));
+
+        WorkflowProfileValidationException exception =
+            await Assert.ThrowsAsync<WorkflowProfileValidationException>(() =>
+                workflowProfiles.CreateAsync(new WorkflowProfileMutationRequest(
+                    " default ",
+                    null,
+                    "# WORKFLOW duplicate")));
+
+        Assert.Contains(nameof(WorkflowProfileMutationRequest.Name), exception.Errors.Keys);
+        Assert.Equal(1, await dbContext.WorkflowProfiles.CountAsync());
+    }
+
+    private static ServiceProvider BuildProvider(TimeProvider timeProvider)
+    {
+        string databasePath = Path.Combine(
+            Path.GetTempPath(),
+            "conductor-workflow-profile-tests",
+            Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture),
+            "conductor.db");
+        IConfiguration configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                [$"ConnectionStrings:{SqlitePersistenceOptions.ConnectionStringName}"] = $"Data Source={databasePath};Cache=Shared",
+            })
+            .Build();
+        ServiceCollection services = new();
+        services.AddSingleton<TimeProvider>(timeProvider);
+        services.AddConductorPersistence(configuration);
+
+        return services.BuildServiceProvider(validateScopes: true);
+    }
+
+    private sealed class ManualTimeProvider(DateTimeOffset utcNow) : TimeProvider
+    {
+        public DateTimeOffset UtcNow { get; set; } = utcNow;
+
+        public override DateTimeOffset GetUtcNow() => UtcNow;
+    }
+}


### PR DESCRIPTION
Closes #57.

## Summary
- Adds workflow profile mutation contracts, domain revision/default metadata, and SQLite persistence with migration support.
- Adds the Workflow Profiles editor page and repository import profile selection.
- Documents workflow profile management and covers the new behavior with domain, persistence, and Blazor tests.

## Validation
- dotnet build Conductor.slnx --no-restore
- dotnet test Conductor.slnx --no-build