### PR TITLE
Fix dashboard app shell styling

### DIFF
--- a/src/Conductor.Host/Components/Layout/MainLayout.razor
+++ b/src/Conductor.Host/Components/Layout/MainLayout.razor
@@ -1,23 +1,5 @@
 @inherits LayoutComponentBase
 
-<div class="app-shell">
-    <aside class="side-nav" aria-label="Primary">
-        <a class="brand" href="/">
-            <span class="brand-mark" aria-hidden="true">C</span>
-            <span>Conductor</span>
-        </a>
-        <nav>
-            <NavLink href="/" Match="NavLinkMatch.All">Dashboard</NavLink>
-            <NavLink href="/projects">Projects</NavLink>
-            <NavLink href="/repositories">Repositories</NavLink>
-            <NavLink href="/instances">Instances</NavLink>
-            <NavLink href="/settings/workflows">Workflows</NavLink>
-            <NavLink href="/settings/secrets">Secrets</NavLink>
-            <NavLink href="/reports">Reports</NavLink>
-        </nav>
-    </aside>
-
-    <main class="main-panel">
-        @Body
-    </main>
-</div>
+<AppShell>
+    @Body
+</AppShell>

--- a/src/Conductor.Host/wwwroot/app.css
+++ b/src/Conductor.Host/wwwroot/app.css
@@ -318,7 +318,6 @@ h1:focus-visible,
   margin: 0 auto;
 }
 
-.instances-page {
 .dashboard,
 .instances-page,
 .repositories-page,
@@ -357,12 +356,6 @@ h1:focus-visible,
 .page-heading p {
   margin-top: 8px;
   color: #c4d0df;
-.eyebrow {
-  margin: 0 0 8px;
-  color: #6fb7ff;
-  font-size: 0.78rem;
-  font-weight: 700;
-  text-transform: uppercase;
 }
 
 .dashboard-summary {
@@ -371,7 +364,7 @@ h1:focus-visible,
 }
 
 .eyebrow {
-  margin-bottom: 6px;
+  margin: 0 0 8px;
   color: #8fbaff;
   font-size: 12px;
   font-weight: 800;
@@ -1212,6 +1205,8 @@ td {
 .quick-action span span {
   margin-top: 4px;
   color: var(--muted);
+}
+
 .repository-table-wrap {
   overflow-x: auto;
 }

--- a/tests/Conductor.Blazor.Tests/LayoutShellTests.cs
+++ b/tests/Conductor.Blazor.Tests/LayoutShellTests.cs
@@ -1,0 +1,23 @@
+using Bunit;
+using Conductor.Host.Components.Layout;
+
+namespace Conductor.Blazor.Tests;
+
+public sealed class LayoutShellTests
+{
+    [Fact]
+    public void MainLayout_Renders_AppShell_Navigation_TopBar_And_Body()
+    {
+        using BunitContext context = new();
+
+        IRenderedComponent<MainLayout> layout = context.Render<MainLayout>(
+            parameters => parameters.Add(
+                component => component.Body,
+                builder => builder.AddMarkupContent(0, "<h1>Dashboard body</h1>")));
+
+        Assert.NotNull(layout.Find(".app-shell"));
+        Assert.Contains("Software Delivery Control Surface", layout.Markup, StringComparison.Ordinal);
+        Assert.Contains("Search repos, projects, issues", layout.Markup, StringComparison.Ordinal);
+        Assert.Contains("Dashboard body", layout.Markup, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## Summary
- Restore the dashboard route to the merged `AppShell` so the new side navigation and top bar wrap the UI.
- Repair malformed `app.css` blocks that swallowed dashboard, quick-action, and repository table styles.
- Add a Blazor layout regression test covering the app shell, navigation/top bar, and rendered body content.

## Validation
- `dotnet build Conductor.slnx --no-restore --warnaserror`: passed with no warnings
- `dotnet test Conductor.slnx --no-build`: passed, 218 tests
- `dotnet restore Conductor.slnx`: passed
- `dotnet format Conductor.slnx --no-restore --verify-no-changes`: passed with no formatting changes
- `git diff --check`: passed

## Notes
- Browser-checked the dashboard locally at `http://localhost:5230/`; shell, dashboard content, and active repository sections rendered without console errors.